### PR TITLE
Feat(user): 사용자 로그인 API 구현

### DIFF
--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/AuthService.java
@@ -1,10 +1,13 @@
 package com.rushcrew.auth_service.auth.application;
 
 import com.rushcrew.auth_service.auth.application.client.UserClient;
+import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.port.TokenProvider;
+import com.rushcrew.auth_service.auth.application.result.LoginResult;
 import com.rushcrew.auth_service.auth.application.result.SignUpResult;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,23 @@ public class AuthService {
         );
 
         return new SignUpResult(
+            result.userId(),
+            result.email(),
+            result.name(),
+            accessToken
+        );
+    }
+
+    public LoginResult login(LoginCommand command) {
+        VerifyPasswordResult result = userClient.verifyPassword(command);
+
+        String accessToken = accessTokenProvider.generateToken(
+            result.userId(),
+            result.email(),
+            result.role()
+        );
+
+        return new LoginResult(
             result.userId(),
             result.email(),
             result.name(),

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/client/UserClient.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/client/UserClient.java
@@ -1,8 +1,12 @@
 package com.rushcrew.auth_service.auth.application.client;
 
+import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 
 public interface UserClient {
     UserCreateResult createUser(SignUpCommand command);
+
+    VerifyPasswordResult verifyPassword(LoginCommand command);
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/LoginCommand.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/LoginCommand.java
@@ -1,0 +1,6 @@
+package com.rushcrew.auth_service.auth.application.command;
+
+public record LoginCommand(
+    String email,
+    String password
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/LoginResult.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/LoginResult.java
@@ -1,0 +1,8 @@
+package com.rushcrew.auth_service.auth.application.result;
+
+public record LoginResult(
+    Long userId,
+    String email,
+    String name,
+    String accessToken
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/VerifyPasswordResult.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/VerifyPasswordResult.java
@@ -1,0 +1,8 @@
+package com.rushcrew.auth_service.auth.application.result;
+
+public record VerifyPasswordResult(
+    Long userId,
+    String email,
+    String name,
+    String role
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserClientImpl.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserClientImpl.java
@@ -1,10 +1,14 @@
 package com.rushcrew.auth_service.auth.infrastructure.external;
 
 import com.rushcrew.auth_service.auth.application.client.UserClient;
+import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateRequest;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateResponse;
+import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordRequest;
+import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,14 +20,19 @@ public class UserClientImpl implements UserClient {
 
     @Override
     public UserCreateResult createUser(SignUpCommand command) {
-        UserCreateRequest request = UserCreateRequest.from(command);
+        UserCreateRequest request = UserCreateRequest.fromCommand(command);
+
         UserCreateResponse response = userFeignClient.createUser(request);
 
-        return new UserCreateResult(
-            response.userId(),
-            response.email(),
-            response.name(),
-            response.role()
-        );
+        return response.toResult();
+    }
+
+    @Override
+    public VerifyPasswordResult verifyPassword(LoginCommand command) {
+        VerifyPasswordRequest request = VerifyPasswordRequest.fromCommand(command);
+
+        VerifyPasswordResponse response = userFeignClient.verifyPassword(request);
+
+        return response.toResult();
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserFeignClient.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserFeignClient.java
@@ -2,6 +2,8 @@ package com.rushcrew.auth_service.auth.infrastructure.external;
 
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateRequest;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateResponse;
+import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordRequest;
+import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,5 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 @FeignClient(name = "user-service")
 public interface UserFeignClient {
     @PostMapping("/api/v1/users")
-    UserCreateResponse createUser(@RequestBody UserCreateRequest UserCreateRequest);
+    UserCreateResponse createUser(@RequestBody UserCreateRequest request);
+
+    @PostMapping("/api/v1/users/verify-password")
+    VerifyPasswordResponse verifyPassword(@RequestBody VerifyPasswordRequest request);
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/UserCreateRequest.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/UserCreateRequest.java
@@ -8,7 +8,7 @@ public record UserCreateRequest(
     String name,
     String role
 ) {
-    public static UserCreateRequest from(SignUpCommand command) {
+    public static UserCreateRequest fromCommand(SignUpCommand command) {
         return new UserCreateRequest(
             command.email(),
             command.password(),

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/UserCreateResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/UserCreateResponse.java
@@ -1,9 +1,14 @@
 package com.rushcrew.auth_service.auth.infrastructure.external.dto;
 
+import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+
 public record UserCreateResponse(
     Long userId,
     String email,
     String name,
     String role
 ) {
+    public UserCreateResult toResult() {
+        return new UserCreateResult(userId, email, name, role);
+    }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/VerifyPasswordRequest.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/VerifyPasswordRequest.java
@@ -1,0 +1,16 @@
+package com.rushcrew.auth_service.auth.infrastructure.external.dto;
+
+import com.rushcrew.auth_service.auth.application.command.LoginCommand;
+
+public record VerifyPasswordRequest(
+    String email,
+    String password
+) {
+
+    public static VerifyPasswordRequest fromCommand(LoginCommand command) {
+        return new VerifyPasswordRequest(
+            command.email(),
+            command.password()
+        );
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/VerifyPasswordResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/VerifyPasswordResponse.java
@@ -1,0 +1,15 @@
+package com.rushcrew.auth_service.auth.infrastructure.external.dto;
+
+import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
+
+public record VerifyPasswordResponse(
+    Long userId,
+    String email,
+    String name,
+    String role
+) {
+
+    public VerifyPasswordResult toResult() {
+        return new VerifyPasswordResult(userId, email, name, role);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/AuthController.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/AuthController.java
@@ -1,9 +1,13 @@
 package com.rushcrew.auth_service.auth.presentation;
 
 import com.rushcrew.auth_service.auth.application.AuthService;
+import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
+import com.rushcrew.auth_service.auth.application.result.LoginResult;
 import com.rushcrew.auth_service.auth.application.result.SignUpResult;
+import com.rushcrew.auth_service.auth.presentation.dto.request.LoginRequest;
 import com.rushcrew.auth_service.auth.presentation.dto.request.SignUpRequest;
+import com.rushcrew.auth_service.auth.presentation.dto.response.LoginResponse;
 import com.rushcrew.auth_service.auth.presentation.dto.response.SignUpResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -31,6 +35,17 @@ public class AuthController {
 
         URI location = URI.create("/api/v1/users/" + result.userId());
 
-        return ResponseEntity.created(location).body(SignUpResponse.from(result));
+        return ResponseEntity.created(location).body(SignUpResponse.fromResult(result));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(
+        @Valid @RequestBody LoginRequest request
+    ) {
+        LoginCommand command = request.toCommand();
+
+        LoginResult result = authService.login(command);
+
+        return ResponseEntity.ok(LoginResponse.fromResult(result));
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/request/LoginRequest.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/request/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.rushcrew.auth_service.auth.presentation.dto.request;
+
+import com.rushcrew.auth_service.auth.application.command.LoginCommand;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    String email,
+
+    @NotBlank(message = "비밀번호는 필수입니다.") String password
+) {
+    public LoginCommand toCommand() {
+        return new LoginCommand(email, password);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/LoginResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/LoginResponse.java
@@ -1,15 +1,15 @@
 package com.rushcrew.auth_service.auth.presentation.dto.response;
 
-import com.rushcrew.auth_service.auth.application.result.SignUpResult;
+import com.rushcrew.auth_service.auth.application.result.LoginResult;
 
-public record SignUpResponse(
+public record LoginResponse(
     Long userId,
     String email,
     String name,
     String accessToken
 ) {
-    public static SignUpResponse fromResult(SignUpResult result) {
-        return new SignUpResponse(
+    public static LoginResponse fromResult(LoginResult result) {
+        return new LoginResponse(
             result.userId(),
             result.email(),
             result.name(),


### PR DESCRIPTION
## 🧾 Summary
- Access Token 발급 후 로그인 처리
- Auth Service에 로그인 API 구현 및 User Service 연동 완료


## 🔧 구현 내용
### 1. 비즈니스 로직
- 로그인: 비밀번호 검증 후 AccessToken 발급

### 2. 마이크로서비스 통신
- `POST /api/users/verify-password`: Feign Client를 통한 User Service 호출


### 3. API 엔드포인트
- **POST `/api/v1/auth/login`**: 로그인 및 토큰 발급
  - **Request**: email, password
  - **Response**: userId, email, name, accessToken

### 4. DTO 구조
- **Command**: `SignUpCommand`, `LoginCommand`
- **Result**: `SignUpResult`, `LoginResult`, `UserCreateResult`, `VerifyPasswordResult`
- **Request/Response**: 각 API별 Presentation 계층 DTO
- **External DTO**: User Service 연동용 DTO

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #38 
