### PR TITLE
Feat(queue): 타임딜 정책 CRUD Presentation 레이어, 도메인 구성

### DIFF
--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/CreatePolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/CreatePolicyCommand.java
@@ -1,7 +1,8 @@
 package com.rushcrew.queue.application.command;
 
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
-import java.time.LocalDateTime;
+import com.rushcrew.queue.domain.vo.TimePeriod;
+import com.rushcrew.queue.domain.vo.TrafficSetting;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -10,11 +11,8 @@ public record CreatePolicyCommand(
     UUID productId,
     String dealName,
     QueuePolicyStatus status,
-    LocalDateTime startTime,
-    LocalDateTime endTime,
-    Integer limitSize,
-    Integer queueGap,
-    Integer ttl
+    TimePeriod timePeriod,
+    TrafficSetting trafficSetting
 ) {
 
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/CreatePolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/CreatePolicyCommand.java
@@ -1,0 +1,20 @@
+package com.rushcrew.queue.application.command;
+
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CreatePolicyCommand(
+    UUID productId,
+    String dealName,
+    QueuePolicyStatus status,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    Integer limitSize,
+    Integer queueGap,
+    Integer ttl
+) {
+
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/SearchPolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/SearchPolicyCommand.java
@@ -1,0 +1,19 @@
+package com.rushcrew.queue.application.command;
+
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import java.util.UUID;
+
+public record SearchPolicyCommand(
+    UUID productId,
+    QueuePolicyStatus status
+) {
+    public static SearchPolicyCommand of(UUID productId, QueuePolicyStatus status) {
+        if (status == null) {
+            return new SearchPolicyCommand(productId, null);
+        }
+        if (productId == null) {
+            return new SearchPolicyCommand(null, status);
+        }
+        return new SearchPolicyCommand(productId, status);
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/UpdatePolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/UpdatePolicyCommand.java
@@ -1,7 +1,8 @@
 package com.rushcrew.queue.application.command;
 
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
-import java.time.LocalDateTime;
+import com.rushcrew.queue.domain.vo.TimePeriod;
+import com.rushcrew.queue.domain.vo.TrafficSetting;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -10,11 +11,8 @@ public record UpdatePolicyCommand(
     UUID productId,
     String timeDealName,
     QueuePolicyStatus status,
-    LocalDateTime startTime,
-    LocalDateTime endTime,
-    Integer limitSize,
-    Integer queueGap,
-    Integer ttl
+    TimePeriod timePeriod,
+    TrafficSetting trafficSetting
 ) {
 
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/UpdatePolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/UpdatePolicyCommand.java
@@ -1,4 +1,4 @@
-package com.rushcrew.queue.application.dto;
+package com.rushcrew.queue.application.command;
 
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import java.time.LocalDateTime;
@@ -6,8 +6,7 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record PolicyQueryResponse(
-    UUID policyId,
+public record UpdatePolicyCommand(
     UUID productId,
     String timeDealName,
     QueuePolicyStatus status,

--- a/queue-service/src/main/java/com/rushcrew/queue/application/dto/PageQuery.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/dto/PageQuery.java
@@ -1,0 +1,17 @@
+package com.rushcrew.queue.application.dto;
+
+import lombok.Builder;
+import org.springframework.data.domain.Sort;
+
+@Builder
+public record PageQuery(
+    Integer page,
+    Integer size,
+    String sortBy, // 정렬 기준 필드 (예: "createdAt")
+    Sort.Direction direction
+) {
+
+    public static PageQuery of(Integer page, Integer size, String sortBy, Sort.Direction direction) {
+        return new PageQuery(page, size, sortBy, direction);
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/application/dto/PolicyQueryResponse.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/dto/PolicyQueryResponse.java
@@ -1,0 +1,21 @@
+package com.rushcrew.queue.application.dto;
+
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record PolicyQueryResponse(
+    UUID policyId,
+    UUID productId,
+    String timeDealName,
+    QueuePolicyStatus status,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    Integer limitSize,
+    Integer queueGap,
+    Integer ttl
+) {
+
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/application/dto/QueuePolicyResponse.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/dto/QueuePolicyResponse.java
@@ -1,0 +1,21 @@
+package com.rushcrew.queue.application.dto;
+
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record QueuePolicyResponse(
+    UUID policyId,
+    UUID productId,
+    String timeDealName,
+    QueuePolicyStatus status,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    Integer limitSize,
+    Integer queueGap,
+    Integer ttl
+) {
+
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/entity/QueuePolicy.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/entity/QueuePolicy.java
@@ -2,8 +2,10 @@ package com.rushcrew.queue.domain.entity;
 
 import com.rushcrew.common.entity.BaseEntity;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
-import com.rushcrew.queue.domain.enums.QueueStatus;
+import com.rushcrew.queue.domain.vo.TimePeriod;
+import com.rushcrew.queue.domain.vo.TrafficSetting;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -44,36 +46,22 @@ public class QueuePolicy extends BaseEntity {
     @Column(name = "status", nullable = false)
     private QueuePolicyStatus status;
 
-    @Column(name = "start_time", nullable = false)
-    private LocalDateTime startTime;
+    // vo 적용
+    @Embedded
+    private TimePeriod timePeriod;
 
-    @Column(name = "end_time", nullable = false)
-    private LocalDateTime endTime;
+    @Embedded
+    private TrafficSetting trafficSetting;
 
-    // 활성 허용 인원
-    @Column(name = "limit_size", nullable = false)
-    private Integer limitSize;
-
-    // 활성 체크 주기 (몇 초 마다 확인해서 들여보낼 지 주기)
-    @Column(name = "queue_gap", nullable = false)
-    private Integer queueGap;
-
-    // 토큰 유효 시 (Active 토큰의 만료 시간 (예: 300초))
-    @Column(name = "ttl", nullable = false)
-    private Integer ttl;
-
-    public static QueuePolicy create(UUID productId, String timeDealName, QueueStatus status,
+    public static QueuePolicy create(UUID productId, String timeDealName, QueuePolicyStatus status,
         LocalDateTime startTime, LocalDateTime endTime, Integer limitSize, Integer queueGap,
         Integer ttl) {
         return QueuePolicy.builder()
             .productId(productId)
             .timeDealName(timeDealName)
             .status(status)
-            .startTime(startTime)
-            .endTime(endTime)
-            .limitSize(limitSize)
-            .queueGap(queueGap)
-            .ttl(ttl)
+            .timePeriod(new TimePeriod(startTime, endTime))
+            .trafficSetting(new TrafficSetting(limitSize, queueGap, ttl))
             .build();
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/entity/QueuePolicy.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/entity/QueuePolicy.java
@@ -46,10 +46,11 @@ public class QueuePolicy extends BaseEntity {
     @Column(name = "status", nullable = false)
     private QueuePolicyStatus status;
 
-    // vo 적용
+    // vo 적용 (운영시간)
     @Embedded
     private TimePeriod timePeriod;
 
+    // vo 적용 (활성 허용 인원, 활성 체크 주기, ttl)
     @Embedded
     private TrafficSetting trafficSetting;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueuePolicyRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueuePolicyRepository.java
@@ -1,0 +1,29 @@
+package com.rushcrew.queue.domain.repository;
+
+import com.rushcrew.queue.domain.entity.QueuePolicy;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface QueuePolicyRepository {
+
+    /**
+     * 타임딜 정책 등록
+     * @param queuePolicy
+     * @return
+     */
+    QueuePolicy save(QueuePolicy queuePolicy);
+
+    /**
+     * 정책 ID로 조회
+     * @param policyId
+     * @return
+     */
+    Optional<QueuePolicy> findById(UUID policyId);
+
+    /**
+     * 상품 ID로 타임딜 정책 조회
+     * @param productId
+     * @return
+     */
+    Optional<QueuePolicy> findByProductId(UUID productId);
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TimePeriod.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TimePeriod.java
@@ -1,0 +1,35 @@
+package com.rushcrew.queue.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 시작시간, 종료시간 관리
+ */
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TimePeriod {
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
+
+    public TimePeriod(LocalDateTime startTime, LocalDateTime endTime) {
+        if (startTime == null || endTime == null) {
+            throw new IllegalArgumentException("시작 시간과 종료 시간은 필수입니다.");
+        }
+
+        if (endTime.isBefore(startTime)) {
+            throw new IllegalArgumentException("종료 시간은 시작 시간보다 빠를 수 없습니다.");
+        }
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
@@ -1,0 +1,37 @@
+package com.rushcrew.queue.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrafficSetting {
+    // 활성 허용 인원
+    @Column(name = "limit_size", nullable = false)
+    private Integer limitSize;
+
+    // 활성 체크 주기 (몇 초 마다 확인해서 들여보낼 지 주기)
+    @Column(name = "queue_gap", nullable = false)
+    private Integer queueGap;
+
+    // 토큰 유효 시 (Active 토큰의 만료 시간 (예: 300초))
+    @Column(name = "ttl", nullable = false)
+    private Integer ttl;
+
+    public TrafficSetting(Integer limitSize, Integer queueGap, Integer ttl) {
+        if (limitSize == null || limitSize <= 0) {
+            throw new IllegalArgumentException("진입 허용 인원은 1명 이상이어야 합니다.");
+        }
+
+        if (ttl == null || ttl < 10) {
+            throw new IllegalArgumentException("TTL은 최소 10초 이상이어야 합니다.");
+        }
+        this.limitSize = limitSize;
+        this.queueGap = queueGap;
+        this.ttl = ttl;
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
@@ -27,6 +27,10 @@ public class TrafficSetting {
             throw new IllegalArgumentException("진입 허용 인원은 1명 이상이어야 합니다.");
         }
 
+        if (queueGap == null || queueGap <= 0) {
+            throw new IllegalArgumentException("활성 체크 주기는 1초 이상이어야 합니다.");
+        }
+
         if (ttl == null || ttl < 10) {
             throw new IllegalArgumentException("TTL은 최소 10초 이상이어야 합니다.");
         }

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
@@ -31,8 +31,8 @@ public class TrafficSetting {
             throw new IllegalArgumentException("활성 체크 주기는 1초 이상이어야 합니다.");
         }
 
-        if (ttl == null || ttl < 10) {
-            throw new IllegalArgumentException("TTL은 최소 10초 이상이어야 합니다.");
+        if (ttl == null || ttl <= 60) {
+            throw new IllegalArgumentException("TTL은 최소 60초 이상이어야 합니다.");
         }
         this.limitSize = limitSize;
         this.queueGap = queueGap;

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/QueuePolicyRepositoryImpl.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/QueuePolicyRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.rushcrew.queue.infrastructure.repository;
+
+import com.rushcrew.queue.domain.entity.QueuePolicy;
+import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
+import com.rushcrew.queue.infrastructure.repository.jpa.JpaQueuePolicyRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueuePolicyRepositoryImpl implements QueuePolicyRepository {
+
+    private final JpaQueuePolicyRepository jpaQueuePolicyRepository;
+
+    public QueuePolicyRepositoryImpl(JpaQueuePolicyRepository jpaQueuePolicyRepository) {
+        this.jpaQueuePolicyRepository = jpaQueuePolicyRepository;
+    }
+
+    @Override
+    public QueuePolicy save(QueuePolicy queuePolicy) {
+        return jpaQueuePolicyRepository.save(queuePolicy);
+    }
+
+    @Override
+    public Optional<QueuePolicy> findById(UUID policyId) {
+        return jpaQueuePolicyRepository.findByPolicyIdAndDeletedAtIsNull(policyId);
+    }
+
+    @Override
+    public Optional<QueuePolicy> findByProductId(UUID productId) {
+        return jpaQueuePolicyRepository.findByProductIdAndDeletedAtIsNull(productId);
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/jpa/JpaQueuePolicyRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/jpa/JpaQueuePolicyRepository.java
@@ -1,0 +1,12 @@
+package com.rushcrew.queue.infrastructure.repository.jpa;
+
+import com.rushcrew.queue.domain.entity.QueuePolicy;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaQueuePolicyRepository extends JpaRepository<QueuePolicy, UUID> {
+    Optional<QueuePolicy> findByPolicyIdAndDeletedAtIsNull(UUID policyId);
+
+    Optional<QueuePolicy> findByProductIdAndDeletedAtIsNull(UUID productId);
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
@@ -1,0 +1,39 @@
+package com.rushcrew.queue.presentation;
+
+import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.queue.application.command.CreatePolicyCommand;
+import com.rushcrew.queue.presentation.dto.request.CreatePolicyRequest;
+import com.rushcrew.queue.presentation.dto.response.CreatePolicyResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/queue/policies")
+public class QueuePolicyController {
+
+    // API Gateway에서 인증 후, USER ID와 ROLE을 헤더에 담아 전달
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    public QueuePolicyController() {}
+
+    /**
+     * 타임딜 정책 생성 : MASTER 권한만 가능
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreatePolicyResponse>> registerPolicy(
+        @Valid @RequestBody CreatePolicyRequest request
+    ) {
+        CreatePolicyCommand command = request.toCommand();
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("TODO"));
+    }
+
+
+
+
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
@@ -2,14 +2,21 @@ package com.rushcrew.queue.presentation;
 
 import com.rushcrew.common.dto.ApiResponse;
 import com.rushcrew.queue.application.command.CreatePolicyCommand;
+import com.rushcrew.queue.application.command.SearchPolicyCommand;
+import com.rushcrew.queue.application.dto.PageQuery;
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.presentation.dto.request.CreatePolicyRequest;
 import com.rushcrew.queue.presentation.dto.response.CreatePolicyResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,6 +39,27 @@ public class QueuePolicyController {
         CreatePolicyCommand command = request.toCommand();
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("TODO"));
     }
+
+    /**
+     * MASTER 권한만 가능
+     * 타임딜 정책 목록 조회 : 상품별, 상태별(RUNNING, PAUSED, STOPPED)
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<Void>> getTimeDealPolicies(
+        @RequestParam(required = false) UUID productId,
+        @RequestParam(required = false) String status,
+        @RequestParam(name = "page", defaultValue = "1") int page,
+        @RequestParam(name = "size", defaultValue = "10") int size,
+        @RequestParam(name = "sort-by", defaultValue = "createdAt") String sortBy,
+        @RequestParam(name = "sort-direction", defaultValue = "DESC") Sort.Direction sortDirection
+    ) {
+
+        PageQuery pageQuery = PageQuery.of(page, size, sortBy, sortDirection);
+        SearchPolicyCommand command = SearchPolicyCommand.of(productId, QueuePolicyStatus.valueOf(status));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("TODO"));
+    }
+
+
 
 
 

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
@@ -3,17 +3,21 @@ package com.rushcrew.queue.presentation;
 import com.rushcrew.common.dto.ApiResponse;
 import com.rushcrew.queue.application.command.CreatePolicyCommand;
 import com.rushcrew.queue.application.command.SearchPolicyCommand;
+import com.rushcrew.queue.application.command.UpdatePolicyCommand;
 import com.rushcrew.queue.application.dto.PageQuery;
-import com.rushcrew.queue.application.dto.PolicyQueryResponse;
+import com.rushcrew.queue.application.dto.QueuePolicyResponse;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.presentation.dto.request.CreatePolicyRequest;
+import com.rushcrew.queue.presentation.dto.request.UpdatePolicyRequest;
 import com.rushcrew.queue.presentation.dto.response.CreatePolicyResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -66,15 +70,32 @@ public class QueuePolicyController {
      * 타임딜 정책 정보 조회 (단건)
      */
     @GetMapping("/{policy-id}")
-    public ResponseEntity<ApiResponse<PolicyQueryResponse>> getPolicyInfo(
+    public ResponseEntity<ApiResponse<QueuePolicyResponse>> getPolicyInfo(
         @PathVariable UUID policyId
     ) {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("TODO"));
     }
 
+    /**
+     * MASTER 권한만 가능
+     * 타임딜 정책 수정
+     */
+    @PatchMapping("/{policy-id}")
+    public ResponseEntity<ApiResponse<QueuePolicyResponse>> updatePolicy(
+        @PathVariable UUID policyId,
+        @RequestBody UpdatePolicyRequest request
+    ) {
+        UpdatePolicyCommand command = request.toCommand();
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("TODO"));
+    }
 
-
-
-
-
+    /**
+     * 타임딜 정책 삭제
+     */
+    @DeleteMapping("/{policy-id}")
+    public ResponseEntity<ApiResponse<Void>> deletePolicy(
+        @PathVariable UUID policyId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(null));
+    }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/QueuePolicyController.java
@@ -4,6 +4,7 @@ import com.rushcrew.common.dto.ApiResponse;
 import com.rushcrew.queue.application.command.CreatePolicyCommand;
 import com.rushcrew.queue.application.command.SearchPolicyCommand;
 import com.rushcrew.queue.application.dto.PageQuery;
+import com.rushcrew.queue.application.dto.PolicyQueryResponse;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.presentation.dto.request.CreatePolicyRequest;
 import com.rushcrew.queue.presentation.dto.response.CreatePolicyResponse;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,6 +58,17 @@ public class QueuePolicyController {
 
         PageQuery pageQuery = PageQuery.of(page, size, sortBy, sortDirection);
         SearchPolicyCommand command = SearchPolicyCommand.of(productId, QueuePolicyStatus.valueOf(status));
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("TODO"));
+    }
+
+    /**
+     * MASTER 권한만 가능
+     * 타임딜 정책 정보 조회 (단건)
+     */
+    @GetMapping("/{policy-id}")
+    public ResponseEntity<ApiResponse<PolicyQueryResponse>> getPolicyInfo(
+        @PathVariable UUID policyId
+    ) {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("TODO"));
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/CreatePolicyRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/CreatePolicyRequest.java
@@ -1,0 +1,46 @@
+package com.rushcrew.queue.presentation.dto.request;
+
+import com.rushcrew.queue.application.command.CreatePolicyCommand;
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreatePolicyRequest(
+    // TODO : 추후 추가 예정
+//    Long userId,
+//    UserRole role,
+    @NotBlank(message = "상품 ID는 필수입니다")
+    UUID productId,
+    @NotBlank(message = "타임딜 제목은 필수입니다")
+    String dealName,
+    @NotBlank(message = "초기 상태값은 필수입니다")
+    QueuePolicyStatus status,
+    @NotBlank(message = "시작 시간은 필수입니다")
+    LocalDateTime startTime,
+    @NotBlank(message = "종료 시간은 필수입니다")
+    LocalDateTime endTime,
+    @NotBlank(message = "허용 인원은 필수입니다")
+    @Min(value = 1, message = "허용 인원은 최소 1명 이상이어야 합니다")
+    Integer limitSize,
+    @NotBlank(message = "활성 체크 주기는 필수입니다")
+    @Min(value = 1, message = "활성 체크 주기는 최소 1 이상이어야 합니다")
+    Integer queueGap,
+    @NotBlank(message = "TTL은 필수입니다")
+    @Min(value = 60, message = "TTL은 최소 60초 이상이어야 합니다")
+    Integer ttl
+) {
+    public CreatePolicyCommand toCommand() {
+        return CreatePolicyCommand.builder()
+            .productId(productId)
+            .dealName(dealName)
+            .status(status)
+            .startTime(startTime)
+            .endTime(endTime)
+            .limitSize(limitSize)
+            .queueGap(queueGap)
+            .ttl(ttl)
+            .build();
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/CreatePolicyRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/CreatePolicyRequest.java
@@ -2,6 +2,8 @@ package com.rushcrew.queue.presentation.dto.request;
 
 import com.rushcrew.queue.application.command.CreatePolicyCommand;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import com.rushcrew.queue.domain.vo.TimePeriod;
+import com.rushcrew.queue.domain.vo.TrafficSetting;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
@@ -32,15 +34,16 @@ public record CreatePolicyRequest(
     Integer ttl
 ) {
     public CreatePolicyCommand toCommand() {
+        // vo 생성 시 유효성 검증
+        TimePeriod timePeriod = new TimePeriod(startTime, endTime);
+        TrafficSetting traffic = new TrafficSetting(limitSize, queueGap, ttl);
+
         return CreatePolicyCommand.builder()
             .productId(productId)
             .dealName(dealName)
             .status(status)
-            .startTime(startTime)
-            .endTime(endTime)
-            .limitSize(limitSize)
-            .queueGap(queueGap)
-            .ttl(ttl)
+            .timePeriod(timePeriod)
+            .trafficSetting(traffic)
             .build();
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/UpdatePolicyRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/UpdatePolicyRequest.java
@@ -1,0 +1,33 @@
+package com.rushcrew.queue.presentation.dto.request;
+
+import com.rushcrew.queue.application.command.UpdatePolicyCommand;
+import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UpdatePolicyRequest(
+    // TODO : 추후 추가 예정
+//    Long userId,
+//    UserRole role,
+    UUID productId,
+    String timeDealName,
+    QueuePolicyStatus status,
+    LocalDateTime startTime,
+    LocalDateTime endTime,
+    Integer limitSize,
+    Integer queueGap,
+    Integer ttl
+) {
+    public UpdatePolicyCommand toCommand() {
+        return UpdatePolicyCommand.builder()
+            .productId(productId)
+            .timeDealName(timeDealName)
+            .status(status)
+            .startTime(startTime)
+            .endTime(endTime)
+            .limitSize(limitSize)
+            .queueGap(queueGap)
+            .ttl(ttl)
+            .build();
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/UpdatePolicyRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/UpdatePolicyRequest.java
@@ -2,6 +2,8 @@ package com.rushcrew.queue.presentation.dto.request;
 
 import com.rushcrew.queue.application.command.UpdatePolicyCommand;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
+import com.rushcrew.queue.domain.vo.TimePeriod;
+import com.rushcrew.queue.domain.vo.TrafficSetting;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -19,15 +21,16 @@ public record UpdatePolicyRequest(
     Integer ttl
 ) {
     public UpdatePolicyCommand toCommand() {
+        // vo 생성 시 유효성 검증
+        TimePeriod timePeriod = new TimePeriod(startTime, endTime);
+        TrafficSetting traffic = new TrafficSetting(limitSize, queueGap, ttl);
+
         return UpdatePolicyCommand.builder()
             .productId(productId)
             .timeDealName(timeDealName)
             .status(status)
-            .startTime(startTime)
-            .endTime(endTime)
-            .limitSize(limitSize)
-            .queueGap(queueGap)
-            .ttl(ttl)
+            .timePeriod(timePeriod)
+            .trafficSetting(traffic)
             .build();
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/response/CreatePolicyResponse.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/response/CreatePolicyResponse.java
@@ -1,0 +1,11 @@
+package com.rushcrew.queue.presentation.dto.response;
+
+import java.util.UUID;
+
+public record CreatePolicyResponse(
+    UUID policyId,
+    UUID productId,
+    String dealName
+) {
+
+}


### PR DESCRIPTION
## 🧾 Summary
1. QueuePolicy(타임딜 정책) 도메인 레포지토리 구성
2. 타임딜 정책 presentation 계층 도메인 구성 (엔드포인트, DTO)
3. QueuePolicy 엔티티에서 타임딜 운영시간, 트래픽 제어 관련 컬럼 vo로 분리 (TimePeriod, TrafficSetting)
4. Request DTO(presentation)에서 command 생성 시 vo 적용하여 유효성 검증 처리
5. 타임딜 정책 CRUD API 엔드포인트 정의
 ```
  - 정책 생성 : POST /api/v1/queue/policies
  - 정책 목록 조회 및 검색(상품별, 상태별) : GET /api/v1/queue/policies
  - 정책 단건 조회 : GET /api/v1/queue/policies/{policy-id}
  - 정책 수정 : PATCH /api/v1/queue/policies/{policy-id}
  - 정책 삭제 : DELETE /api/v1/queue/policies/{policy-id}
```

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #이슈번호
