### PR TITLE
Feat(auth): Refresh Token 발급, 저장, 삭제 기능 구현

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -23,6 +23,12 @@ dependencies {
 	// feign client
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Jackson for JSON serialization
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 	// jjwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/AuthService.java
@@ -3,9 +3,9 @@ package com.rushcrew.auth_service.auth.application;
 import com.rushcrew.auth_service.auth.application.client.UserClient;
 import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
-import com.rushcrew.auth_service.auth.application.port.TokenProvider;
 import com.rushcrew.auth_service.auth.application.result.LoginResult;
 import com.rushcrew.auth_service.auth.application.result.SignUpResult;
+import com.rushcrew.auth_service.auth.application.result.TokenPairResult;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
 import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 import lombok.RequiredArgsConstructor;
@@ -18,13 +18,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final UserClient userClient;
-    private final TokenProvider accessTokenProvider;
+    private final TokenService tokenService;
 
     @Transactional
     public SignUpResult signUp(SignUpCommand command) {
         UserCreateResult result = userClient.createUser(command);
 
-        String accessToken = accessTokenProvider.generateToken(
+        TokenPairResult tokens = tokenService.issueTokenPair(
             result.userId(),
             result.email(),
             result.role()
@@ -34,14 +34,15 @@ public class AuthService {
             result.userId(),
             result.email(),
             result.name(),
-            accessToken
+            tokens.accessToken(),
+            tokens.refreshToken()
         );
     }
 
     public LoginResult login(LoginCommand command) {
         VerifyPasswordResult result = userClient.verifyPassword(command);
 
-        String accessToken = accessTokenProvider.generateToken(
+        TokenPairResult tokens = tokenService.issueTokenPair(
             result.userId(),
             result.email(),
             result.role()
@@ -51,7 +52,8 @@ public class AuthService {
             result.userId(),
             result.email(),
             result.name(),
-            accessToken
+            tokens.accessToken(),
+            tokens.refreshToken()
         );
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
@@ -1,0 +1,93 @@
+package com.rushcrew.auth_service.auth.application;
+
+import com.rushcrew.auth_service.auth.application.port.AccessTokenProvider;
+import com.rushcrew.auth_service.auth.application.port.RefreshTokenProvider;
+import com.rushcrew.auth_service.auth.application.result.TokenPairResult;
+import com.rushcrew.auth_service.auth.domain.entity.RefreshToken;
+import com.rushcrew.auth_service.auth.domain.policy.ConcurrentLoginPolicy;
+import com.rushcrew.auth_service.auth.domain.repository.RefreshTokenRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class TokenService {
+
+    private final AccessTokenProvider accessTokenProvider;
+    private final RefreshTokenProvider refreshTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final ConcurrentLoginPolicy concurrentLoginPolicy;
+    private final long refreshExpiration;
+
+    public TokenService(
+        AccessTokenProvider accessTokenProvider,
+        RefreshTokenProvider refreshTokenProvider,
+        RefreshTokenRepository refreshTokenRepository,
+        ConcurrentLoginPolicy concurrentLoginPolicy,
+        @Value("${jwt.refresh.expiration}") long refreshExpiration
+    ) {
+        this.accessTokenProvider = accessTokenProvider;
+        this.refreshTokenProvider = refreshTokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.concurrentLoginPolicy = concurrentLoginPolicy;
+        this.refreshExpiration = refreshExpiration;
+    }
+
+    @Transactional
+    public TokenPairResult issueTokenPair(
+        Long userId,
+        String email,
+        String role
+    ) {
+        String accessToken = accessTokenProvider.generateToken(
+            userId,
+            email,
+            role
+        );
+        String refreshToken = issueRefreshToken(userId);
+
+        return new TokenPairResult(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public String issueRefreshToken(Long userId) {
+        String tokenValue = refreshTokenProvider.generateToken(userId);
+
+        RefreshToken token = RefreshToken.create(
+            tokenValue,
+            userId,
+            refreshExpiration
+        );
+
+        refreshTokenRepository.save(token);
+
+        // 동시 로그인 제한 적용
+        List<String> existingTokens = refreshTokenRepository.findAllTokensByUserId(userId);
+
+        List<String> tokensToRevoke = concurrentLoginPolicy.getTokensToRevoke(existingTokens);
+
+        tokensToRevoke.forEach(refreshTokenRepository::deleteByToken);
+
+        return tokenValue;
+    }
+
+    public Optional<Long> validateToken(String tokenValue) {
+        return refreshTokenRepository
+            .findByToken(tokenValue)
+            .filter(token -> !token.isExpired())
+            .map(RefreshToken::getUserId);
+    }
+
+    @Transactional
+    public void revokeToken(String tokenValue) {
+        refreshTokenRepository.deleteByToken(tokenValue);
+    }
+
+    @Transactional
+    public void revokeAllTokens(Long userId) {
+        refreshTokenRepository.deleteAllByUserId(userId);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/port/AccessTokenProvider.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/port/AccessTokenProvider.java
@@ -1,6 +1,6 @@
 package com.rushcrew.auth_service.auth.application.port;
 
-public interface TokenProvider {
+public interface AccessTokenProvider {
 
     String generateToken(Long userId, String email, String role);
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/port/RefreshTokenProvider.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/port/RefreshTokenProvider.java
@@ -1,0 +1,6 @@
+package com.rushcrew.auth_service.auth.application.port;
+
+public interface RefreshTokenProvider {
+    String generateToken(Long userId);
+    Long getUserIdFromToken(String token);
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/LoginResult.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/LoginResult.java
@@ -4,5 +4,6 @@ public record LoginResult(
     Long userId,
     String email,
     String name,
-    String accessToken
+    String accessToken,
+    String refreshToken
 ) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/TokenPairResult.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/TokenPairResult.java
@@ -1,9 +1,6 @@
 package com.rushcrew.auth_service.auth.application.result;
 
-public record SignUpResult(
-    Long userId,
-    String email,
-    String name,
+public record TokenPairResult(
     String accessToken,
     String refreshToken
 ) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/entity/RefreshToken.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/entity/RefreshToken.java
@@ -1,0 +1,53 @@
+package com.rushcrew.auth_service.auth.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rushcrew.auth_service.auth.domain.vo.TokenExpiry;
+import com.rushcrew.auth_service.auth.domain.vo.TokenId;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefreshToken {
+
+    private final TokenId id;
+    private final Long userId;
+    private final LocalDateTime issuedAt;
+    private final TokenExpiry expiry;
+
+    public static RefreshToken create(
+        String tokenValue,
+        Long userId,
+        Long expiryMillis
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+        return new RefreshToken(
+            TokenId.of(tokenValue),
+            userId,
+            now,
+            TokenExpiry.fromMilliseconds(expiryMillis)
+        );
+    }
+
+
+    @JsonCreator
+    public static RefreshToken fromJson(
+        @JsonProperty("id") TokenId id,
+        @JsonProperty("userId") Long userId,
+        @JsonProperty("issuedAt") LocalDateTime issuedAt,
+        @JsonProperty("expiry") TokenExpiry expiry
+    ) {
+        return new RefreshToken(id, userId, issuedAt, expiry);
+    }
+
+    public boolean isExpired() {
+        return expiry.isExpired();
+    }
+
+    public String getTokenValue() {
+        return id.getValue();
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/policy/ConcurrentLoginPolicy.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/policy/ConcurrentLoginPolicy.java
@@ -1,0 +1,21 @@
+package com.rushcrew.auth_service.auth.domain.policy;
+
+import java.util.List;
+
+public class ConcurrentLoginPolicy {
+
+    private final int maxConcurrentSessions;
+
+    public ConcurrentLoginPolicy(int maxConcurrentSessions) {
+        this.maxConcurrentSessions = maxConcurrentSessions;
+    }
+
+    public List<String> getTokensToRevoke(List<String> existingTokens) {
+        if (existingTokens.size() <= maxConcurrentSessions) {
+            return List.of();
+        }
+
+        int removeCount = existingTokens.size() - maxConcurrentSessions;
+        return existingTokens.subList(0, removeCount);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/repository/RefreshTokenRepository.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.rushcrew.auth_service.auth.domain.repository;
+
+import com.rushcrew.auth_service.auth.domain.entity.RefreshToken;
+import java.util.List;
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void save(RefreshToken refreshToken);
+    Optional<RefreshToken> findByToken(String tokenValue);
+    List<String> findAllTokensByUserId(Long userId);
+    void deleteByToken(String tokenValue);
+    void deleteAllByUserId(Long userId);
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/vo/TokenExpiry.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/vo/TokenExpiry.java
@@ -1,0 +1,35 @@
+package com.rushcrew.auth_service.auth.domain.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenExpiry {
+
+    private final LocalDateTime expiresAt;
+
+    public static TokenExpiry fromMilliseconds(long millis) {
+        if (millis <= 0) {
+            throw new IllegalArgumentException("만료 일수는 양수여야 합니다");
+        }
+
+        return new TokenExpiry(LocalDateTime.now().plus(millis, ChronoUnit.MILLIS));
+    }
+
+    @JsonCreator
+    public static TokenExpiry fromJson(
+        @JsonProperty("expiresAt") LocalDateTime expiresAt
+    ) {
+        return new TokenExpiry(expiresAt);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/vo/TokenId.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/vo/TokenId.java
@@ -1,0 +1,26 @@
+package com.rushcrew.auth_service.auth.domain.vo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenId {
+
+    private final String value;
+
+    public static TokenId of(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Token ID는 필수입니다.");
+        }
+        return new TokenId(value);
+    }
+
+    @JsonCreator
+    public static TokenId fromJson(@JsonProperty("value") String value) {
+        return of(value);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/config/DomainConfig.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/config/DomainConfig.java
@@ -1,0 +1,19 @@
+package com.rushcrew.auth_service.auth.infrastructure.config;
+
+import com.rushcrew.auth_service.auth.domain.policy.ConcurrentLoginPolicy;
+import com.rushcrew.auth_service.auth.infrastructure.properties.ConcurrentLoginProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ConcurrentLoginProperties.class)
+public class DomainConfig {
+
+    @Bean
+    public ConcurrentLoginPolicy concurrentLoginPolicy(
+        ConcurrentLoginProperties properties
+    ) {
+        return new ConcurrentLoginPolicy(properties.maxSessions());
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/jwt/JwtAccessTokenProvider.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/jwt/JwtAccessTokenProvider.java
@@ -1,6 +1,7 @@
 package com.rushcrew.auth_service.auth.infrastructure.jwt;
 
-import com.rushcrew.auth_service.auth.application.port.TokenProvider;
+import com.rushcrew.auth_service.auth.application.port.AccessTokenProvider;
+import com.rushcrew.auth_service.auth.infrastructure.properties.JwtProperties;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class AccessTokenProvider implements TokenProvider {
+public class JwtAccessTokenProvider implements AccessTokenProvider {
 
     private final JwtProperties properties;
 

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/jwt/JwtRefreshTokenProvider.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/jwt/JwtRefreshTokenProvider.java
@@ -1,0 +1,56 @@
+package com.rushcrew.auth_service.auth.infrastructure.jwt;
+
+import com.rushcrew.auth_service.auth.application.port.RefreshTokenProvider;
+import com.rushcrew.auth_service.auth.infrastructure.properties.JwtProperties;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRefreshTokenProvider implements RefreshTokenProvider {
+
+    private final JwtProperties jwtProperties;
+    private SecretKey refreshSecretKey;
+
+    @PostConstruct
+    public void init() {
+        this.refreshSecretKey = Keys.hmacShaKeyFor(
+            jwtProperties.refresh().secret().getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    @Override
+    public String generateToken(Long userId) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + jwtProperties.refresh().expiration());
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim("tokenType", "refresh")
+            .id(UUID.randomUUID().toString())
+            .issuer("rush-deal")
+            .issuedAt(now)
+            .expiration(expiryDate)
+            .signWith(refreshSecretKey)
+            .compact();
+    }
+
+    @Override
+    public Long getUserIdFromToken(String token) {
+        return Long.parseLong(
+            Jwts.parser()
+                .verifyWith(refreshSecretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject()
+        );
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/properties/ConcurrentLoginProperties.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/properties/ConcurrentLoginProperties.java
@@ -1,0 +1,12 @@
+package com.rushcrew.auth_service.auth.infrastructure.properties;
+
+import jakarta.validation.constraints.Positive;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@ConfigurationProperties(prefix = "auth.concurrent")
+@Validated
+public record ConcurrentLoginProperties(
+    @Positive
+    int maxSessions
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/properties/JwtProperties.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/properties/JwtProperties.java
@@ -1,4 +1,4 @@
-package com.rushcrew.auth_service.auth.infrastructure.jwt;
+package com.rushcrew.auth_service.auth.infrastructure.properties;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,11 +10,15 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 public record JwtProperties(
     @NotNull
-    AccessToken access
+    TokenConfig access,
+
+    @NotNull
+    TokenConfig refresh
 ) {
-    public record AccessToken(
+    public record TokenConfig(
         @NotBlank
         String secret,
+
         @Positive
         Long expiration
     ) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/LoginResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/LoginResponse.java
@@ -6,14 +6,16 @@ public record LoginResponse(
     Long userId,
     String email,
     String name,
-    String accessToken
+    String accessToken,
+    String refreshToken
 ) {
     public static LoginResponse fromResult(LoginResult result) {
         return new LoginResponse(
             result.userId(),
             result.email(),
             result.name(),
-            result.accessToken()
+            result.accessToken(),
+            result.refreshToken()
         );
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/SignUpResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/SignUpResponse.java
@@ -6,14 +6,16 @@ public record SignUpResponse(
     Long userId,
     String email,
     String name,
-    String accessToken
+    String accessToken,
+    String refreshToken
 ) {
     public static SignUpResponse fromResult(SignUpResult result) {
         return new SignUpResponse(
             result.userId(),
             result.email(),
             result.name(),
-            result.accessToken()
+            result.accessToken(),
+            result.refreshToken()
         );
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/repository/RedisRefreshTokenRepository.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/repository/RedisRefreshTokenRepository.java
@@ -1,0 +1,138 @@
+package com.rushcrew.auth_service.auth.presentation.repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.auth_service.auth.domain.entity.RefreshToken;
+import com.rushcrew.auth_service.auth.domain.repository.RefreshTokenRepository;
+import com.rushcrew.auth_service.auth.infrastructure.properties.JwtProperties;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisRefreshTokenRepository implements RefreshTokenRepository {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final JwtProperties jwtProperties;
+
+    private static final String TOKEN_PREFIX = "refresh_token:";
+    private static final String USER_TOKENS_PREFIX = "user_tokens:";
+
+    @Override
+    public void save(RefreshToken token) {
+        try {
+            String json = objectMapper.writeValueAsString(token);
+
+            String tokenKey = TOKEN_PREFIX + token.getTokenValue();
+            String userTokensKey = USER_TOKENS_PREFIX + token.getUserId();
+
+            // JwtProperties에서 만료 시간 가져오기
+            long expirationMs = jwtProperties.refresh().expiration();
+
+            // Token 저장 (만료 시간 적용)
+            redisTemplate
+                .opsForValue()
+                .set(tokenKey, json, expirationMs, TimeUnit.MILLISECONDS);
+
+            // User의 Token 리스트에 추가
+            redisTemplate
+                .opsForList()
+                .rightPush(userTokensKey, token.getTokenValue());
+
+            // User Token 리스트에도 만료 시간 적용
+            redisTemplate.expire(
+                userTokensKey,
+                expirationMs,
+                TimeUnit.MILLISECONDS
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("토큰 저장 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public Optional<RefreshToken> findByToken(String tokenValue) {
+        try {
+            String json = redisTemplate
+                .opsForValue()
+                .get(TOKEN_PREFIX + tokenValue);
+
+            if (json == null) {
+                return Optional.empty();
+            }
+
+            RefreshToken token = objectMapper.readValue(
+                json,
+                RefreshToken.class
+            );
+            return Optional.of(token);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public List<String> findAllTokensByUserId(Long userId) {
+        String key = USER_TOKENS_PREFIX + userId.toString();
+
+        List<String> tokens = redisTemplate.opsForList().range(key, 0, -1);
+
+        if (tokens == null) {
+            return List.of();
+        }
+
+        return tokens;
+    }
+
+    @Override
+    public void deleteByToken(String tokenValue) {
+        Optional<RefreshToken> tokenOpt = findByToken(tokenValue);
+
+        if (tokenOpt.isEmpty()) {
+            log.debug("Token not found for deletion: token={}", tokenValue);
+            return;
+        }
+
+        RefreshToken token = tokenOpt.get();
+
+        // Token 삭제
+        redisTemplate.delete(TOKEN_PREFIX + tokenValue);
+
+        // User Token 리스트에서 제거
+        redisTemplate
+            .opsForList()
+            .remove(USER_TOKENS_PREFIX + token.getUserId(), 0, tokenValue);
+
+        log.debug(
+            "RefreshToken deleted: userId={}, token={}",
+            token.getUserId(),
+            tokenValue
+        );
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        String userTokenKey = USER_TOKENS_PREFIX + userId;
+
+        List<String> tokens = findAllTokensByUserId(userId);
+
+        if (!tokens.isEmpty()) {
+            // 모든 Token 삭제
+            List<String> tokenKeys = tokens
+                .stream()
+                .map(token -> TOKEN_PREFIX + token)
+                .toList();
+
+            redisTemplate.delete(tokenKeys);
+        }
+
+        // User Token 리스트 삭제
+        redisTemplate.delete(userTokenKey);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/global/config/RedisConfig.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/global/config/RedisConfig.java
@@ -1,0 +1,53 @@
+package com.rushcrew.auth_service.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    /**
+     * StringRedisTemplate: Key-Value 모두 String
+     */
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+
+    /**
+     * RedisTemplate: 객체 직렬화/역직렬화
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    /**
+     * ObjectMapper: JSON 직렬화/역직렬화
+     */
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/global/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.rushcrew.auth_service.config;
+package com.rushcrew.auth_service.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -40,4 +40,11 @@ eureka:
 jwt:
   access:
     secret: ${JWT_ACCESS_SECRET}
-    expiration: ${JWT_ACCESS_EXPIRED}
+    expiration: ${JWT_ACCESS_EXPIRED:3600000}
+  refresh:
+    secret: ${JWT_REFRESH_SECRET}
+    expiration: ${JWT_REFRESH_EXPIRED:604800000}
+
+auth:
+  concurrent:
+    max-sessions: ${AUTH_MAX_CONCURRENT_SESSIONS:3}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -13,6 +13,18 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+      timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 2
+          max-wait: -1ms
 
 server:
   port: 9000


### PR DESCRIPTION
## 🧾 Summary
Refresh Token 기반 인증 시스템을 구현하여 사용자 세션 관리 기능을 추가했습니다.

## 주요 변경사항
### 1.  비즈니스 로직
- 회원가입, 로그인 로직에 Refresh 토큰 추가
- 사용자당 최대 3개 세션 허용, 초과 시 오래된 토큰 자동 폐기

### 2. Redis 기반 저장소
- RefreshToken을 Redis에 저장하여 빠른 조회 및 만료 관리

### 3. DTO 구조
- RefreshToken 엔티티, TokenId/TokenExpiry VO, Repository 추가

### 4. Provider 리팩토링
- **TokenProvider 분리**: AccessTokenProvider와 RefreshTokenProvider로 역할 분리

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #73 
