### PR TITLE
Feat(order): 자동 구매확정 기능 구현

### DIFF
--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -21,6 +21,12 @@ dependencies {
     // 자체 공통 모듈
     implementation 'com.github.RushCrew:rush-deal-common:v0.0.7'
 
+    // Spring Batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+
+    // Quartz (스케줄러)
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
+
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -2,8 +2,6 @@ description = 'Order Service for rush-deal Project'
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
-    implementation 'org.springframework.boot:spring-boot-starter-batch'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/BatchConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/BatchConfig.java
@@ -1,0 +1,9 @@
+package com.rushcrew.order_service.order.batch.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableBatchProcessing
+public class BatchConfig {
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/BatchConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/BatchConfig.java
@@ -1,9 +1,17 @@
 package com.rushcrew.order_service.order.batch.config;
 
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
-@EnableBatchProcessing
+// @EnableBatchProcessing
 public class BatchConfig {
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/QuartzConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/QuartzConfig.java
@@ -1,0 +1,35 @@
+package com.rushcrew.order_service.order.batch.config;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.rushcrew.order_service.order.batch.job.AutoConfirmScheduler;
+
+@Configuration
+public class QuartzConfig {
+
+	/* 자동 구매확정 Job Detail */
+	@Bean
+	public JobDetail autoConfirmJobDeatail() {
+		return JobBuilder.newJob(AutoConfirmScheduler.class)
+			.withIdentity("autoConfirmPurchaseJob")
+			.storeDurably()
+			.build();
+	}
+
+	/* 자동 구매확정 Trigger - 매 시간 정각에 실행 */
+	@Bean
+	public Trigger autoConfirmTrigger() {
+		return TriggerBuilder.newTrigger()
+			.forJob(autoConfirmJobDeatail())
+			.withIdentity("autoConfirmPurchaseTrigger")
+			.withSchedule(
+				CronScheduleBuilder.cronSchedule("0 0 * * * ?")	// 매 시간 정각
+			).build();
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/QuartzConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/config/QuartzConfig.java
@@ -29,7 +29,11 @@ public class QuartzConfig {
 			.forJob(autoConfirmJobDeatail())
 			.withIdentity("autoConfirmPurchaseTrigger")
 			.withSchedule(
-				CronScheduleBuilder.cronSchedule("0 0 * * * ?")	// 매 시간 정각
+				// 테스트: 1분마다 실행
+				CronScheduleBuilder.cronSchedule("0 * * * * ?")
+
+				// // 운영: 매 시간 정각 실행
+				// CronScheduleBuilder.cronSchedule("0 0 * * * ?")
 			).build();
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/job/AutoConfirmPurchaseBatchJob.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/job/AutoConfirmPurchaseBatchJob.java
@@ -56,11 +56,7 @@ public class AutoConfirmPurchaseBatchJob {
 			.build();
 	}
 
-	/*
-	 * Reader: 자동 구매확정 대상 주문 조회
-	 * - 상태: PAID
-	 * - auto_confirm_scheduled_at <= 현재 시간
-	 */
+	/* Reader: 자동 구매확정 대상 주문 조회 */
 	@Bean
 	public RepositoryItemReader<Order> autoConfirmTargetOrderReader() {
 		return new RepositoryItemReaderBuilder<Order>()
@@ -77,12 +73,8 @@ public class AutoConfirmPurchaseBatchJob {
 	@Bean
 	public ItemProcessor<Order, Order> autoConfirmProcessor() {
 		return order -> {
-			log.info("자동 구매확정 처리중: orderId={}, userId={}",
-				order.getOrderId(), order.getUserId());
-
-			// 구매확정 처리 (Domain 메서드)
-			order.confirmPurchase();
-
+			log.info("자동 구매확정 처리 중 - 주문 ID: {}, 사용자 ID: {}", order.getOrderId(), order.getUserId());
+			order.confirmPurchase(); // 상태 변경 + OrderHistory 생성
 			return order;
 		};
 	}
@@ -91,17 +83,15 @@ public class AutoConfirmPurchaseBatchJob {
 	@Bean
 	public ItemWriter<Order> autoConfirmWriter() {
 		return orders -> {
-			// 1. 주문 저장
+			// 1. 주문 저장 (OrderHistory도 cascade로 저장됨)
 			orderJpaRepository.saveAll(orders);
 
 			// 2. 각 주문에 대해 포인트 적립 요청
 			for (Order order : orders) {
-				// 포인트 적립 금액 계산 (결제 금액의 5%) TODO: 포인트 적립 관련 적립 금액 넘겨주는지 결제한 금액을 넘겨주면 포인트에서 %계산해서 적립하는지
 				BigDecimal earnAmount = order.getFinalAmount()
-					.multiply(new BigDecimal("0.05"))
+					.multiply(new BigDecimal("0.05")) // TODO: 결제 금액 그대로 돌려주는지, 결제 금액의 몇% 적립할 포인트 돌려주는지
 					.setScale(0, RoundingMode.DOWN);
 
-				// 포인트 적립 요청 이벤트 발행
 				pointEventPort.publishPointEarnRequested(
 					order.getUserId(),
 					order.getOrderId().toString(),
@@ -110,12 +100,11 @@ public class AutoConfirmPurchaseBatchJob {
 					Instant.now()
 				);
 
-				log.info("자동 구매 확정 + 포인트 적립 요청: " +
-						"orderId={}, userId={}, earnAmount={}",
+				log.info("자동 구매확정 완료 + 포인트 적립 요청 - 주문 ID: {}, 사용자 ID: {}, 적립 포인트: {}",
 					order.getOrderId(), order.getUserId(), earnAmount);
 			}
 
-			log.info("Auto confirmed {} orders", orders.size());
+			log.info("총 {}건의 주문을 자동 구매확정 처리했습니다.", orders.size());
 		};
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/job/AutoConfirmPurchaseBatchJob.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/job/AutoConfirmPurchaseBatchJob.java
@@ -1,0 +1,121 @@
+package com.rushcrew.order_service.order.batch.job;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.rushcrew.order_service.order.application.port.out.PointEventPort;
+import com.rushcrew.order_service.order.domain.entity.Order;
+import com.rushcrew.order_service.order.domain.enums.OrderStatus;
+import com.rushcrew.order_service.order.infrastructure.adapter.out.persistence.OrderJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class AutoConfirmPurchaseBatchJob {
+
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
+	private final OrderJpaRepository orderJpaRepository;
+	private final PointEventPort pointEventPort;
+
+	/* 자동 구매확정 Job */
+	@Bean
+	public Job autoConfirmPurchaseJob() {
+		return new JobBuilder("autoConfirmPurchaseJob", jobRepository)
+			.start(autoConfirmPurchaseStep())
+			.build();
+	}
+
+	/* 자동 구매확정 Step */
+	@Bean
+	public Step autoConfirmPurchaseStep() {
+		return new StepBuilder("autoConfirmPurchaseStep", jobRepository)
+			.<Order, Order>chunk(100, transactionManager)
+			.reader(autoConfirmTargetOrderReader())
+			.processor(autoConfirmProcessor())
+			.writer(autoConfirmWriter())
+			.build();
+	}
+
+	/*
+	 * Reader: 자동 구매확정 대상 주문 조회
+	 * - 상태: PAID
+	 * - auto_confirm_scheduled_at <= 현재 시간
+	 */
+	@Bean
+	public RepositoryItemReader<Order> autoConfirmTargetOrderReader() {
+		return new RepositoryItemReaderBuilder<Order>()
+			.name("autoConfirmTargetOrderReader")
+			.repository(orderJpaRepository)
+			.methodName("findAllByStatusAndAutoConfirmScheduledAtBefore")
+			.arguments(OrderStatus.PAID, Instant.now())
+			.pageSize(100)
+			.sorts(Map.of("orderedAt", Sort.Direction.ASC))
+			.build();
+	}
+
+	/* Processor: 구매확정 처리 */
+	@Bean
+	public ItemProcessor<Order, Order> autoConfirmProcessor() {
+		return order -> {
+			log.info("자동 구매확정 처리중: orderId={}, userId={}",
+				order.getOrderId(), order.getUserId());
+
+			// 구매확정 처리 (Domain 메서드)
+			order.confirmPurchase();
+
+			return order;
+		};
+	}
+
+	/* Writer: DB 저장 및 포인트 적립 이벤트 발행 */
+	@Bean
+	public ItemWriter<Order> autoConfirmWriter() {
+		return orders -> {
+			// 1. 주문 저장
+			orderJpaRepository.saveAll(orders);
+
+			// 2. 각 주문에 대해 포인트 적립 요청
+			for (Order order : orders) {
+				// 포인트 적립 금액 계산 (결제 금액의 5%) TODO: 포인트 적립 관련 적립 금액 넘겨주는지 결제한 금액을 넘겨주면 포인트에서 %계산해서 적립하는지
+				BigDecimal earnAmount = order.getFinalAmount()
+					.multiply(new BigDecimal("0.05"))
+					.setScale(0, RoundingMode.DOWN);
+
+				// 포인트 적립 요청 이벤트 발행
+				pointEventPort.publishPointEarnRequested(
+					order.getUserId(),
+					order.getOrderId().toString(),
+					earnAmount,
+					"자동 구매확정",
+					Instant.now()
+				);
+
+				log.info("자동 구매 확정 + 포인트 적립 요청: " +
+						"orderId={}, userId={}, earnAmount={}",
+					order.getOrderId(), order.getUserId(), earnAmount);
+			}
+
+			log.info("Auto confirmed {} orders", orders.size());
+		};
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/order/batch/job/AutoConfirmScheduler.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/batch/job/AutoConfirmScheduler.java
@@ -1,0 +1,44 @@
+package com.rushcrew.order_service.order.batch.job;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/*
+* 자동 구매확정 Quartz Job - 매 시간 정각에 실행
+* */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AutoConfirmScheduler extends QuartzJobBean {
+
+	private final JobLauncher jobLauncher;
+	private final Job autoConfirmPurchaseJob;
+
+	@Override
+	protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+		log.info("====== 자동 구매확정 배치 작업 시작 ======");
+		try {
+			// Job parameters 생성 (매번 다른 파라미터로 실행되도록)
+			JobParameters params = new JobParametersBuilder()
+				.addLong("timestamp", System.currentTimeMillis())
+				.toJobParameters();
+
+			// Job 실행
+			jobLauncher.run(autoConfirmPurchaseJob, params);
+
+			log.info("====== 자동 구매확정 배치 작업 완료 ======");
+
+		} catch (Exception e) {
+			log.error("====== 자동 구매확정 배치 작업 실패 ======");
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/order/domain/entity/Order.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/domain/entity/Order.java
@@ -76,9 +76,10 @@ public class Order extends BaseEntity {
 	@Builder.Default
 	private List<OrderReservation> reservations = new ArrayList<>();
 
-	@OneToMany(mappedBy = "order", cascade = CascadeType.PERSIST)
+	@OneToMany(mappedBy = "order", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
 	@Builder.Default
 	private List<OrderHistory> histories = new ArrayList<>();
+
 
 
 	// ============================================

--- a/order-service/src/main/java/com/rushcrew/order_service/order/infrastructure/adapter/out/persistence/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/infrastructure/adapter/out/persistence/OrderJpaRepository.java
@@ -1,12 +1,16 @@
 package com.rushcrew.order_service.order.infrastructure.adapter.out.persistence;
 
+import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.rushcrew.order_service.order.domain.entity.Order;
+import com.rushcrew.order_service.order.domain.enums.OrderStatus;
 
 public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
 
@@ -22,4 +26,7 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
 		@Param("userId") Long userId,
 		@Param("timeDealId") String timeDealId
 	);
+
+	/* 자동 구매확정 대상 조회 */
+	Page<Order> findAllByStatusAndAutoConfirmScheduledAtBefore(OrderStatus status, Instant scheduledAt, Pageable pageable);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/order/presentation/BatchController.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/order/presentation/BatchController.java
@@ -1,0 +1,48 @@
+package com.rushcrew.order_service.order.presentation;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.order_service.global.util.RoleChecker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/batch")
+@RequiredArgsConstructor
+public class BatchController {
+
+	private final JobLauncher jobLauncher;
+	private final Job autoConfirmPurchaseJob;
+
+	/* 자동 구매확정 배치 수동 실행 - 관리자 전용 */
+	@PostMapping("/auto-confirm")
+	public ApiResponse<String> runAutoConfirmBatch(
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader(value = "X-User-Role", required = false) String role
+	) {
+		RoleChecker.checkRole(role, "MASTER");
+		log.info("====== 트리거 매뉴얼: 자동 구매확정 배치 ======");
+
+		try {
+			JobParameters params = new JobParametersBuilder()
+				.addLong("timestamp", System.currentTimeMillis())
+				.toJobParameters();
+			jobLauncher.run(autoConfirmPurchaseJob, params);
+			return ApiResponse.success("배치 작업 시작 성공");
+
+		} catch(Exception e) {
+			log.error("====== 배치 작업 시작 실패 ======");
+			return ApiResponse.error("배치 작업 시작 실패. 에러 메시지: " + e.getMessage());
+		}
+	}
+}

--- a/order-service/src/main/resources/application.yaml
+++ b/order-service/src/main/resources/application.yaml
@@ -1,37 +1,50 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration
+      -
   application:
     name: order-service
 
   batch:
     jdbc:
-      initialize-schema: always # 배치 메타 테이블 자동 생성
+      initialize-schema: always
     job:
-      enabled: false  # 애플리케이션 시작 시 자동 실행 방지 (Quartz가 관리)
-
-  quartz:
-    job-store-type: jdbc  # DB에 스케줄 정보 저장
-    jdbc:
-      initialize-schema: always # Quartz 테이블 자동 생성
-    properties:
-      org:
-        quartz:
-          scheduler:
-            instanceName: OrderScheduler
-            instanceId: AUTO
-          jobStore:
-            class: org.quartz.impl.jdbcjobstore.JobStoreTX
-            driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
-            dataSource: quartzDataSource
-            tablePrefix: QRTZ_
-            isClustered: true  # 클러스터 모드 (다중 인스턴스 환경)
-          threadPool:
-            threadCount: 10
+      enabled: false
 
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
+
+  quartz:
+    job-store-type: jdbc
+    jdbc:
+      initialize-schema: never       # 스키마는 schema.sql로 생성
+    properties:
+      org:
+        quartz:
+          scheduler:
+            instanceName: OrderScheduler
+            instanceId: AUTO
+
+          dataSource:
+            main:                          # ★ Quartz가 인식하는 이름
+              driver: org.postgresql.Driver
+              URL: ${DB_URL}
+              user: ${DB_USERNAME}
+              password: ${DB_PASSWORD}
+
+          jobStore:
+            class: org.quartz.impl.jdbcjobstore.JobStoreTX
+            driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+            dataSource: main               # ★ Quartz가 main datasource 사용
+            tablePrefix: quartz_schema.QRTZ_
+            isClustered: true
+
+          threadPool:
+            threadCount: 10
 
   jpa:
     hibernate:
@@ -40,11 +53,11 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        default_schema: order_schema
+        default_schema: order_schema     # ★ JPA는 order_schema 사용
 
   sql:
     init:
-      mode: always
+      mode: always                       # schema.sql 실행
 
   kafka:
     bootstrap-servers: localhost:9092

--- a/order-service/src/main/resources/application.yaml
+++ b/order-service/src/main/resources/application.yaml
@@ -2,13 +2,11 @@ spring:
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration
-      -
-  application:
-    name: order-service
 
   batch:
     jdbc:
-      initialize-schema: always
+      initialize-schema: never   # SQL 스크립트로 처리
+      table-prefix: order_schema.BATCH_   # 스키마 명시
     job:
       enabled: false
 
@@ -21,7 +19,7 @@ spring:
   quartz:
     job-store-type: jdbc
     jdbc:
-      initialize-schema: never       # 스키마는 schema.sql로 생성
+      initialize-schema: always   # Quartz 자동 초기화 사용
     properties:
       org:
         quartz:
@@ -30,7 +28,7 @@ spring:
             instanceId: AUTO
 
           dataSource:
-            main:                          # ★ Quartz가 인식하는 이름
+            main:
               driver: org.postgresql.Driver
               URL: ${DB_URL}
               user: ${DB_USERNAME}
@@ -39,9 +37,9 @@ spring:
           jobStore:
             class: org.quartz.impl.jdbcjobstore.JobStoreTX
             driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
-            dataSource: main               # ★ Quartz가 main datasource 사용
             tablePrefix: quartz_schema.QRTZ_
             isClustered: true
+            useProperties: false
 
           threadPool:
             threadCount: 10
@@ -53,11 +51,15 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        default_schema: order_schema     # ★ JPA는 order_schema 사용
+        default_schema: order_schema
 
   sql:
     init:
-      mode: always                       # schema.sql 실행
+      mode: always
+      encoding: UTF-8
+      schema-locations:
+        - classpath:schema.sql
+        - classpath:sql/batch-schema.sql
 
   kafka:
     bootstrap-servers: localhost:9092

--- a/order-service/src/main/resources/application.yaml
+++ b/order-service/src/main/resources/application.yaml
@@ -2,6 +2,31 @@ spring:
   application:
     name: order-service
 
+  batch:
+    jdbc:
+      initialize-schema: always # 배치 메타 테이블 자동 생성
+    job:
+      enabled: false  # 애플리케이션 시작 시 자동 실행 방지 (Quartz가 관리)
+
+  quartz:
+    job-store-type: jdbc  # DB에 스케줄 정보 저장
+    jdbc:
+      initialize-schema: always # Quartz 테이블 자동 생성
+    properties:
+      org:
+        quartz:
+          scheduler:
+            instanceName: OrderScheduler
+            instanceId: AUTO
+          jobStore:
+            class: org.quartz.impl.jdbcjobstore.JobStoreTX
+            driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+            dataSource: quartzDataSource
+            tablePrefix: QRTZ_
+            isClustered: true  # 클러스터 모드 (다중 인스턴스 환경)
+          threadPool:
+            threadCount: 10
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/order-service/src/main/resources/schema.sql
+++ b/order-service/src/main/resources/schema.sql
@@ -1,1 +1,2 @@
 CREATE SCHEMA IF NOT EXISTS order_schema;
+CREATE SCHEMA IF NOT EXISTS quartz_schema;

--- a/order-service/src/main/resources/sql/batch-schema.sql
+++ b/order-service/src/main/resources/sql/batch-schema.sql
@@ -1,0 +1,91 @@
+-- order_schema에 Spring Batch 테이블 생성
+SET search_path TO order_schema;
+
+-- 기존 테이블 삭제 (있다면)
+DROP TABLE IF EXISTS BATCH_STEP_EXECUTION_CONTEXT CASCADE;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION_CONTEXT CASCADE;
+DROP TABLE IF EXISTS BATCH_STEP_EXECUTION CASCADE;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION_PARAMS CASCADE;
+DROP TABLE IF EXISTS BATCH_JOB_EXECUTION CASCADE;
+DROP TABLE IF EXISTS BATCH_JOB_INSTANCE CASCADE;
+DROP SEQUENCE IF EXISTS BATCH_STEP_EXECUTION_SEQ;
+DROP SEQUENCE IF EXISTS BATCH_JOB_EXECUTION_SEQ;
+DROP SEQUENCE IF EXISTS BATCH_JOB_SEQ;
+
+-- 테이블 생성
+CREATE TABLE BATCH_JOB_INSTANCE  (
+                                     JOB_INSTANCE_ID BIGINT  NOT NULL PRIMARY KEY ,
+                                     VERSION BIGINT ,
+                                     JOB_NAME VARCHAR(100) NOT NULL,
+                                     JOB_KEY VARCHAR(32) NOT NULL,
+                                     constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
+);
+
+CREATE TABLE BATCH_JOB_EXECUTION  (
+                                      JOB_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY ,
+                                      VERSION BIGINT  ,
+                                      JOB_INSTANCE_ID BIGINT NOT NULL,
+                                      CREATE_TIME TIMESTAMP NOT NULL,
+                                      START_TIME TIMESTAMP DEFAULT NULL ,
+                                      END_TIME TIMESTAMP DEFAULT NULL ,
+                                      STATUS VARCHAR(10) ,
+                                      EXIT_CODE VARCHAR(2500) ,
+                                      EXIT_MESSAGE VARCHAR(2500) ,
+                                      LAST_UPDATED TIMESTAMP,
+                                      constraint JOB_INST_EXEC_FK foreign key (JOB_INSTANCE_ID)
+                                          references BATCH_JOB_INSTANCE(JOB_INSTANCE_ID)
+);
+
+CREATE TABLE BATCH_JOB_EXECUTION_PARAMS  (
+                                             JOB_EXECUTION_ID BIGINT NOT NULL ,
+                                             PARAMETER_NAME VARCHAR(100) NOT NULL ,
+                                             PARAMETER_TYPE VARCHAR(100) NOT NULL ,
+                                             PARAMETER_VALUE VARCHAR(2500) ,
+                                             IDENTIFYING CHAR(1) NOT NULL ,
+                                             constraint JOB_EXEC_PARAMS_FK foreign key (JOB_EXECUTION_ID)
+                                                 references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+);
+
+CREATE TABLE BATCH_STEP_EXECUTION  (
+                                       STEP_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY ,
+                                       VERSION BIGINT NOT NULL,
+                                       STEP_NAME VARCHAR(100) NOT NULL,
+                                       JOB_EXECUTION_ID BIGINT NOT NULL,
+                                       CREATE_TIME TIMESTAMP NOT NULL,
+                                       START_TIME TIMESTAMP DEFAULT NULL ,
+                                       END_TIME TIMESTAMP DEFAULT NULL ,
+                                       STATUS VARCHAR(10) ,
+                                       COMMIT_COUNT BIGINT ,
+                                       READ_COUNT BIGINT ,
+                                       FILTER_COUNT BIGINT ,
+                                       WRITE_COUNT BIGINT ,
+                                       READ_SKIP_COUNT BIGINT ,
+                                       WRITE_SKIP_COUNT BIGINT ,
+                                       PROCESS_SKIP_COUNT BIGINT ,
+                                       ROLLBACK_COUNT BIGINT ,
+                                       EXIT_CODE VARCHAR(2500) ,
+                                       EXIT_MESSAGE VARCHAR(2500) ,
+                                       LAST_UPDATED TIMESTAMP,
+                                       constraint JOB_EXEC_STEP_FK foreign key (JOB_EXECUTION_ID)
+                                           references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+);
+
+CREATE TABLE BATCH_STEP_EXECUTION_CONTEXT  (
+                                               STEP_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+                                               SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+                                               SERIALIZED_CONTEXT TEXT ,
+                                               constraint STEP_EXEC_CTX_FK foreign key (STEP_EXECUTION_ID)
+                                                   references BATCH_STEP_EXECUTION(STEP_EXECUTION_ID)
+);
+
+CREATE TABLE BATCH_JOB_EXECUTION_CONTEXT  (
+                                              JOB_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+                                              SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+                                              SERIALIZED_CONTEXT TEXT ,
+                                              constraint JOB_EXEC_CTX_FK foreign key (JOB_EXECUTION_ID)
+                                                  references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+);
+
+CREATE SEQUENCE BATCH_STEP_EXECUTION_SEQ START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT BY 1;
+CREATE SEQUENCE BATCH_JOB_EXECUTION_SEQ START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT BY 1;
+CREATE SEQUENCE BATCH_JOB_SEQ START WITH 1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT BY 1;


### PR DESCRIPTION
## 🧾 Summary
- 결제 완료 후 7일이 지나면 주문을 자동으로 구매확정 처리하는 배치 기능 추가
- 구매확정 시 포인트 적립 이벤트도 함께 발행
- 동작 방식
  - Order 엔티티에서 결제 완료 시 autoConfirmScheduledAt에 7일 후 날짜 설정
  - 배치(AutoConfirmPurchaseBatchJob)가 스케줄에 따라 미확정 주문 조회
  - 각 주문에 대해 구매확정 처리 및 포인트 적립 이벤트 발행
  - OrderHistory에 구매확정 기록 저장

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #80 
