### PR TITLE
Feat(queue) :  Redis 대기열 상태 관리(대기열 등록, 대기 순번 조회, Fast Track 진입 정책 적용)

### DIFF
--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/EnterQueueCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/EnterQueueCommand.java
@@ -1,16 +1,13 @@
 package com.rushcrew.queue.application.command;
 
-import com.rushcrew.queue.domain.enums.QueueStatus;
-import com.rushcrew.queue.domain.vo.TokenId;
 import java.util.UUID;
 
 public record EnterQueueCommand(
-    TokenId id, // Redis 토큰 발급
     Long userId,
     UUID productId,
-    QueueStatus status,
-    Long requestTime, // 대기열 진입 요청 시간 (Score용)
-    Long activeTime  // 활성화 시간 (TTL 계산용)
+    String role
 ) {
-
+    public static EnterQueueCommand of(UUID productId, Long userId, String role) {
+        return new EnterQueueCommand(userId, productId, role);
+    }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/policy/CreatePolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/policy/CreatePolicyCommand.java
@@ -1,4 +1,4 @@
-package com.rushcrew.queue.application.command;
+package com.rushcrew.queue.application.command.policy;
 
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.domain.vo.TimePeriod;
@@ -7,9 +7,9 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record UpdatePolicyCommand(
+public record CreatePolicyCommand(
     UUID productId,
-    String timeDealName,
+    String dealName,
     QueuePolicyStatus status,
     TimePeriod timePeriod,
     TrafficSetting trafficSetting

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/policy/SearchPolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/policy/SearchPolicyCommand.java
@@ -1,4 +1,4 @@
-package com.rushcrew.queue.application.command;
+package com.rushcrew.queue.application.command.policy;
 
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import java.util.UUID;

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/policy/UpdatePolicyCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/policy/UpdatePolicyCommand.java
@@ -1,4 +1,4 @@
-package com.rushcrew.queue.application.command;
+package com.rushcrew.queue.application.command.policy;
 
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.domain.vo.TimePeriod;
@@ -7,9 +7,9 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record CreatePolicyCommand(
+public record UpdatePolicyCommand(
     UUID productId,
-    String dealName,
+    String timeDealName,
     QueuePolicyStatus status,
     TimePeriod timePeriod,
     TrafficSetting trafficSetting

--- a/queue-service/src/main/java/com/rushcrew/queue/application/command/queue/EnterQueueCommand.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/command/queue/EnterQueueCommand.java
@@ -1,4 +1,4 @@
-package com.rushcrew.queue.application.command;
+package com.rushcrew.queue.application.command.queue;
 
 import java.util.UUID;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -1,6 +1,6 @@
 package com.rushcrew.queue.application.port.in;
 
-import com.rushcrew.queue.application.command.EnterQueueCommand;
+import com.rushcrew.queue.application.command.queue.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import java.util.UUID;
 
@@ -13,5 +13,5 @@ public interface QueuePort {
     /**
      * 대기 상태 조회 (Polling)
      */
-    QueueRedisResponse getQueueRank(UUID productId, String tokenValue);
+    QueueRedisResponse getQueueRank(UUID productId, String token, Long userId, String role);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -2,9 +2,16 @@ package com.rushcrew.queue.application.port.in;
 
 import com.rushcrew.queue.application.command.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
+import java.util.UUID;
 
 public interface QueuePort {
-    // 대기열 진입 (토큰 발급)
+    /**
+     * 대기열 진입 (토큰 발급)
+     */
     QueueRedisResponse enterQueue(EnterQueueCommand command);
 
+    /**
+     * 대기 상태 조회 (Polling)
+     */
+    QueueRedisResponse getQueueRank(UUID productId, String tokenValue);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -1,6 +1,6 @@
 package com.rushcrew.queue.application.service;
 
-import com.rushcrew.queue.application.command.EnterQueueCommand;
+import com.rushcrew.queue.application.command.queue.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.domain.entity.QueueToken;
@@ -49,8 +49,8 @@ public class QueueService implements QueuePort {
      * 대기열 순번, 상태 조회 (polling)
      */
     @Override
-    public QueueRedisResponse getQueueRank(UUID productId, String tokenValue) {
-        TokenId tokenId = TokenId.of(UUID.fromString(tokenValue));
+    public QueueRedisResponse getQueueRank(UUID productId, String token, Long userId, String role) {
+        TokenId tokenId = TokenId.of(UUID.fromString(token));
 
         // 요청시간 LocalDateTime 타입으로 변환
         Long requestTime = getRequestTime(productId, tokenId);

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -4,10 +4,13 @@ import com.rushcrew.queue.application.command.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.domain.entity.QueueToken;
+import com.rushcrew.queue.domain.enums.QueueStatus;
 import com.rushcrew.queue.domain.repository.QueueRepository;
+import com.rushcrew.queue.domain.vo.TokenId;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -29,7 +32,7 @@ public class QueueService implements QueuePort {
         queueRepository.register(queueToken);
 
         // 현재 순번 조회
-        Long waitingRank = queueRepository.getWaitingRank(command.productId(), queueToken);
+        Long waitingRank = queueRepository.getWaitingRank(command.productId(), queueToken.getId());
         // 요청시간 LocalDateTime 타입으로 변환
         LocalDateTime enteredAt = convertLocalDateTime(queueToken.getRequestTime());
 
@@ -42,6 +45,44 @@ public class QueueService implements QueuePort {
             .build();
     }
 
+    /**
+     * 대기열 순번, 상태 조회 (polling)
+     */
+    @Override
+    public QueueRedisResponse getQueueRank(UUID productId, String tokenValue) {
+        TokenId tokenId = TokenId.of(UUID.fromString(tokenValue));
+
+        // 요청시간 LocalDateTime 타입으로 변환
+        Long requestTime = getRequestTime(productId, tokenId);
+        LocalDateTime enteredAt = convertLocalDateTime(requestTime);
+
+        // 이미 활성상태인지 확인
+        if (queueRepository.isActivatedToken(productId, tokenId)) {
+            return QueueRedisResponse.builder()
+                .token(tokenId.getValue())
+                .productId(productId)
+                .rank(0L) // 활성 상태는 순번 0 (이미 활성열에 있으므로)
+                .status(QueueStatus.ACTIVE)
+                .enteredAt(enteredAt)
+                .build();
+        }
+
+        // 대기열 순번 확인 (Redis ZRANK)
+        // rank는 0부터 시작
+        Long waitingRank = queueRepository.getWaitingRank(productId, tokenId);
+        if (waitingRank == null) {
+            // Redis에 없으면 만료되었거나 잘못된 토큰
+            throw new IllegalArgumentException("대기열에 존재하지 않는 토큰입니다.");
+        }
+
+        return QueueRedisResponse.builder()
+            .token(tokenId.getValue())
+            .productId(productId)
+            .rank(waitingRank + 1) // 사용자 친화적 순번 (0번대신 1번부터 표시)
+            .status(QueueStatus.WAITING)
+            .enteredAt(enteredAt)
+            .build();
+    }
 
     /**
      * 타임스탬프 -> LocalDateTime 변환
@@ -52,5 +93,11 @@ public class QueueService implements QueuePort {
         return Instant.ofEpochMilli(timestamp)
             .atZone(ZoneId.systemDefault())
             .toLocalDateTime();
+    }
+
+    private Long getRequestTime(UUID productId, TokenId tokenId) {
+        // 진입 요청 시간 반환
+        Double score = queueRepository.getWaitingScore(productId, tokenId);
+        return score != null ? score.longValue() : System.currentTimeMillis();
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -48,7 +48,8 @@ public class QueueService implements QueuePort {
         QueueToken queueToken = QueueToken.create(command.productId(), command.userId());
 
         // redis 대기열 저장소 저장 & 중복 진입 차단
-        boolean isSuccess = queueRepository.register(queueToken, policy.getTimePeriod().getEndTime());
+        boolean isSuccess = queueRepository.register(queueToken, policy.getTimePeriod().getEndTime(),
+            policy.getTrafficSetting().getTtl());
         if (!isSuccess) {
             // 이미 대기열에 있는 경우 예외 처리
             throw new IllegalStateException("이미 대기열에 등록된 사용자입니다.");

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -68,7 +68,7 @@ public class QueueService implements QueuePort {
         }
 
         // 대기열 순번 확인 (Redis ZRANK)
-        // rank는 0부터 시작
+        // rank는 0부터 시작 (내 앞의 대기 인원 수 (0이면 내가 1빠))
         Long waitingRank = queueRepository.getWaitingRank(productId, tokenId);
         if (waitingRank == null) {
             // Redis에 없으면 만료되었거나 잘못된 토큰

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -26,6 +26,7 @@ public class QueueService implements QueuePort {
      */
     @Override
     public QueueRedisResponse enterQueue(EnterQueueCommand command) {
+        // TODO: ProductId 유효성 검증 필요
         QueueToken queueToken = QueueToken.create(command.productId(), command.userId());
 
         // redis 대기열 저장소 저장
@@ -50,6 +51,7 @@ public class QueueService implements QueuePort {
      */
     @Override
     public QueueRedisResponse getQueueRank(UUID productId, String token, Long userId, String role) {
+        // TODO: ProductId 유효성 검증 필요
         TokenId tokenId = TokenId.of(UUID.fromString(token));
 
         // 요청시간 LocalDateTime 타입으로 변환

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -9,14 +9,17 @@ import com.rushcrew.queue.domain.enums.QueueStatus;
 import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
 import com.rushcrew.queue.domain.repository.QueueRepository;
 import com.rushcrew.queue.domain.vo.TokenId;
+import com.rushcrew.queue.infrastructure.repository.RedisQueueRepository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 public class QueueService implements QueuePort {
     private final QueueRepository queueRepository;
@@ -45,7 +48,7 @@ public class QueueService implements QueuePort {
         QueueToken queueToken = QueueToken.create(command.productId(), command.userId());
 
         // redis 대기열 저장소 저장 & 중복 진입 차단
-        boolean isSuccess = queueRepository.register(queueToken);
+        boolean isSuccess = queueRepository.register(queueToken, policy.getTimePeriod().getEndTime());
         if (!isSuccess) {
             // 이미 대기열에 있는 경우 예외 처리
             throw new IllegalStateException("이미 대기열에 등록된 사용자입니다.");
@@ -70,6 +73,13 @@ public class QueueService implements QueuePort {
      */
     @Override
     public QueueRedisResponse getQueueRank(UUID productId, String token, Long userId, String role) {
+        // 토큰 유효성 검증: 본인 확인 (대기열 토큰 소유권 검증)
+        boolean isOwner = ((RedisQueueRepository) queueRepository).verifyTokenOwner(productId, userId, token);
+        if (!isOwner) {
+            log.warn("[QUEUE:ERROR] 토큰 도용 시도 감지: User {}, Token {}", userId, token);
+            throw new SecurityException("토큰 소유자가 일치하지 않습니다.");
+        }
+
         TokenId tokenId = validateQueueToken(token);
 
         // 활성 상태 여부 확인

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -23,10 +23,11 @@ public class QueueService implements QueuePort {
 
     /**
      * 대기열 진입
+     * TODO: product ID는 타임딜 정책(QueuePolicy) 테이블에서 유효성 검증
+     * 관리자가 정책을 등록하지 않은 상품은 대기열을 생성할 수 없음
      */
     @Override
     public QueueRedisResponse enterQueue(EnterQueueCommand command) {
-        // TODO: ProductId 유효성 검증 필요
         QueueToken queueToken = QueueToken.create(command.productId(), command.userId());
 
         // redis 대기열 저장소 저장
@@ -51,21 +52,16 @@ public class QueueService implements QueuePort {
      */
     @Override
     public QueueRedisResponse getQueueRank(UUID productId, String token, Long userId, String role) {
-        // TODO: ProductId 유효성 검증 필요
-        TokenId tokenId = TokenId.of(UUID.fromString(token));
+        TokenId tokenId = validateQueueToken(token);
 
-        // 요청시간 LocalDateTime 타입으로 변환
-        Long requestTime = getRequestTime(productId, tokenId);
-        LocalDateTime enteredAt = convertLocalDateTime(requestTime);
-
-        // 이미 활성상태인지 확인
+        // 활성 상태 여부 확인
         if (queueRepository.isActivatedToken(productId, tokenId)) {
             return QueueRedisResponse.builder()
                 .token(tokenId.getValue())
                 .productId(productId)
                 .rank(0L) // 활성 상태는 순번 0 (이미 활성열에 있으므로)
                 .status(QueueStatus.ACTIVE)
-                .enteredAt(enteredAt)
+                .enteredAt(LocalDateTime.now()) // 활성 상태일 때, 진입시간 현재시간으로 설정
                 .build();
         }
 
@@ -76,6 +72,10 @@ public class QueueService implements QueuePort {
             // Redis에 없으면 만료되었거나 잘못된 토큰
             throw new IllegalArgumentException("대기열에 존재하지 않는 토큰입니다.");
         }
+
+        // 요청시간 LocalDateTime 타입으로 변환
+        Long requestTime = getRequestTime(productId, tokenId);
+        LocalDateTime enteredAt = convertLocalDateTime(requestTime);
 
         return QueueRedisResponse.builder()
             .token(tokenId.getValue())
@@ -101,5 +101,16 @@ public class QueueService implements QueuePort {
         // 진입 요청 시간 반환
         Double score = queueRepository.getWaitingScore(productId, tokenId);
         return score != null ? score.longValue() : System.currentTimeMillis();
+    }
+
+    private TokenId validateQueueToken(String token) {
+        TokenId tokenId;
+        try {
+            tokenId = TokenId.of(UUID.fromString(token));
+        } catch (IllegalArgumentException e) {
+            // TODO : BUSINESSEXCEPTION으로 수정 필요
+            throw new IllegalArgumentException("잘못된 토큰 형식입니다.");
+        }
+        return tokenId;
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -3,22 +3,28 @@ package com.rushcrew.queue.application.service;
 import com.rushcrew.queue.application.command.queue.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import com.rushcrew.queue.application.port.in.QueuePort;
+import com.rushcrew.queue.domain.entity.QueuePolicy;
 import com.rushcrew.queue.domain.entity.QueueToken;
 import com.rushcrew.queue.domain.enums.QueueStatus;
+import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
 import com.rushcrew.queue.domain.repository.QueueRepository;
 import com.rushcrew.queue.domain.vo.TokenId;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class QueueService implements QueuePort {
     private final QueueRepository queueRepository;
+    private final QueuePolicyRepository queuePolicyRepository;
 
-    public QueueService(QueueRepository queueRepository) {
+    public QueueService(QueueRepository queueRepository, QueuePolicyRepository queuePolicyRepository) {
         this.queueRepository = queueRepository;
+        this.queuePolicyRepository = queuePolicyRepository;
     }
 
     /**
@@ -27,11 +33,23 @@ public class QueueService implements QueuePort {
      * 관리자가 정책을 등록하지 않은 상품은 대기열을 생성할 수 없음
      */
     @Override
+    @Transactional(readOnly = true)
     public QueueRedisResponse enterQueue(EnterQueueCommand command) {
+        // 대기열 정책 확인 (RDB 조회 - 상품 존재 여부 및 시간 확인)
+        QueuePolicy policy = queuePolicyRepository.findByProductId(command.productId())
+            .orElseThrow(() -> new NoSuchElementException("타임딜이 운영되지 않는 상품입니다."));
+
+        // TODO: 대기열 정책에서 대기열 진입 시간 확인 로직 추가 필요
+//        if (policy.isOpen()) {}
+
         QueueToken queueToken = QueueToken.create(command.productId(), command.userId());
 
-        // redis 대기열 저장소 저장
-        queueRepository.register(queueToken);
+        // redis 대기열 저장소 저장 & 중복 진입 차단
+        boolean isSuccess = queueRepository.register(queueToken);
+        if (!isSuccess) {
+            // 이미 대기열에 있는 경우 예외 처리
+            throw new IllegalStateException("이미 대기열에 등록된 사용자입니다.");
+        }
 
         // 현재 순번 조회
         Long waitingRank = queueRepository.getWaitingRank(command.productId(), queueToken.getId());

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/enums/QueueStatus.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/enums/QueueStatus.java
@@ -23,4 +23,8 @@ public enum QueueStatus {
             .findFirst()
             .orElseThrow(() -> new BusinessException(CommonErrorCode.RESOURCE_NOT_FOUND));
     }
+
+    public String getDescription() {
+        return this.description;
+    }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -1,19 +1,50 @@
 package com.rushcrew.queue.domain.repository;
 
 import com.rushcrew.queue.domain.entity.QueueToken;
+import com.rushcrew.queue.domain.vo.TokenId;
 import java.util.List;
 import java.util.UUID;
 
 public interface QueueRepository {
-    // 대기열 등록 (ZSet add)
+    /**
+     * Redis의 대기열에 Sorted Set (ZSet) 타입으로 저장
+     * Score에 타임스탬프를 사용하는 구조 (선착순 진입 순서 보장)
+     * @param token
+     */
     void register(QueueToken token);
 
-    // 토큰 활성화 (대기열 -> 활성열)
-    void activateTokens(Long productId, List<String> tokens);
+    /**
+     * 토큰 활성화 (대기열 -> 활성열)
+     * 스케줄러용: 대기열에서 N명을 활성열로 이동
+     * @param productId
+     * @param tokens
+     */
+    void activateTokens(UUID productId, List<String> tokens);
 
-    // 활성 토큰 검증 (주문 서비스에서 검증 요청 시 사용)
-    boolean isActivatedToken(Long productId, QueueToken token);
+    /**
+     * 활성 토큰 검증 (주문 서비스에서 검증 요청 시 사용)
+     * SET ISMEMBER
+     * @param productId
+     * @param tokenId
+     * @return
+     */
+    boolean isActivatedToken(UUID productId, TokenId tokenId);
 
-    // 토큰 상태/대기 순번 확인 (ZSet rank -> polling)
-    Long getWaitingRank(UUID productId, QueueToken token);
+    /**
+     * 토큰 상태/대기 순번 확인 (ZSet rank -> polling)
+     * (ZSet 조회 - O(logN))
+     * @param productId
+     * @param tokenId
+     * @return
+     */
+    Long getWaitingRank(UUID productId, TokenId tokenId);
+
+    /**
+     * 토큰 Score 조회 (요청 시간)
+     * Redis ZSCORE로 진입 시간 조회
+     * @param productId
+     * @param tokenId
+     * @return
+     */
+    Double getWaitingScore(UUID productId, TokenId tokenId);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -2,6 +2,7 @@ package com.rushcrew.queue.domain.repository;
 
 import com.rushcrew.queue.domain.entity.QueueToken;
 import com.rushcrew.queue.domain.vo.TokenId;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,7 +12,7 @@ public interface QueueRepository {
      * Score에 타임스탬프를 사용하는 구조 (선착순 진입 순서 보장)
      * @param token
      */
-    boolean register(QueueToken token);
+    boolean register(QueueToken token, LocalDateTime dealEndTime);
 
     /**
      * 토큰 활성화 (대기열 -> 활성열)

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -11,7 +11,7 @@ public interface QueueRepository {
      * Score에 타임스탬프를 사용하는 구조 (선착순 진입 순서 보장)
      * @param token
      */
-    void register(QueueToken token);
+    boolean register(QueueToken token);
 
     /**
      * 토큰 활성화 (대기열 -> 활성열)

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -10,9 +10,11 @@ public interface QueueRepository {
     /**
      * Redis의 대기열에 Sorted Set (ZSet) 타입으로 저장
      * Score에 타임스탬프를 사용하는 구조 (선착순 진입 순서 보장)
+     * 진입 정책(Fast Track) : 현재 활성(Active) 상태인 토큰 수가 100개 미만이면 곧바로 활성열로 추가
+     * 100개 이상일 경우, 대기열로 추가
      * @param token
      */
-    boolean register(QueueToken token, LocalDateTime dealEndTime);
+    boolean register(QueueToken token, LocalDateTime dealEndTime, Integer activeTtl);
 
     /**
      * 토큰 활성화 (대기열 -> 활성열)
@@ -30,6 +32,22 @@ public interface QueueRepository {
      * @return
      */
     boolean isActivatedToken(UUID productId, TokenId tokenId);
+
+    /**
+     * 현재 활성화된 인원 수 조회 (Set Size)
+     * @param productId
+     * @return
+     */
+    Long countActiveTokens(UUID productId);
+
+    /**
+     * 대기열 토큰 소유권 검증 (본인 확인)
+     * @param productId
+     * @param userId
+     * @param token
+     * @return
+     */
+    boolean verifyTokenOwner(UUID productId, Long userId, String token);
 
     /**
      * 토큰 상태/대기 순번 확인 (ZSet rank -> polling)

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -26,7 +26,6 @@ public interface QueueRepository {
 
     /**
      * 활성 토큰 검증 (주문 서비스에서 검증 요청 시 사용)
-     * SET ISMEMBER
      * @param productId
      * @param tokenId
      * @return
@@ -34,7 +33,7 @@ public interface QueueRepository {
     boolean isActivatedToken(UUID productId, TokenId tokenId);
 
     /**
-     * 현재 활성화된 인원 수 조회 (Set Size)
+     * 현재 활성화된 인원 수 조회 (ZCard)
      * @param productId
      * @return
      */

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -4,6 +4,7 @@ import com.rushcrew.queue.domain.entity.QueueToken;
 import com.rushcrew.queue.domain.repository.QueueRepository;
 import com.rushcrew.queue.domain.vo.TokenId;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -24,17 +25,25 @@ public class RedisQueueRepository implements QueueRepository {
         this.redisTemplate = redisTemplate;
     }
 
-
     /**
      * 대기열 등록 (ZSet : Sorted Set)
      */
     @Override
-    public boolean register(QueueToken token) {
+    public boolean register(QueueToken token, LocalDateTime dealEndTime) {
+        // TTL 계산 : (이벤트 종료 시간 - 현재 시간)
+        long secondsUntilClose = Duration.between(LocalDateTime.now(), dealEndTime).getSeconds();
+
+        if (secondsUntilClose < 0) {
+            // 이미 종료된 이벤트면 진입 불가 처리
+            return false;
+        }
+
         // 중복 방지 : 유저별 대기열 키 생성 (SETNX)
-        // Key: queue:user:product:{productId}:{userId} -> Value: TokenUUID
+        // KEY: queue:user:product:{productId}:{userId} / VALUE: 토큰 UUID
         Boolean isNewUser = redisTemplate.opsForValue().setIfAbsent(
             getUserIndexKey(token.getProductId(), token.getUserId()),
-            token.getId().getValue().toString()
+            token.getId().getValue().toString(),
+            Duration.ofMinutes(secondsUntilClose) // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
         );
 
         if (Objects.equals(isNewUser, Boolean.FALSE)) {
@@ -82,6 +91,19 @@ public class RedisQueueRepository implements QueueRepository {
             .score(getWaitingKey(productId),
                 tokenId.getValue().toString()
             );
+    }
+
+    /**
+     * 본인 확인 (대기열 토큰 소유권 검증)
+     */
+    public boolean verifyTokenOwner(UUID productId, Long userId, String token) {
+        // redis에 저장된 해당 유저 토큰 조회
+        String savedToken = redisTemplate.opsForValue().get(
+            getUserIndexKey(productId, userId)
+        );
+
+        // 저장된 토큰 없거나, 요청 토큰과 다르면 본인 아님
+        return savedToken != null && savedToken.equals(token);
     }
 
     private String getWaitingKey(UUID productId) {

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -23,7 +23,6 @@ public class RedisQueueRepository implements QueueRepository {
     private static final String WAITING_KEY = "queue:wait:product:%s";
     private static final String ACTIVE_KEY = "queue:active:product:%s";
     private static final String USER_INDEX_KEY = "queue:user:product:%s:%s"; // String (중복방지용)
-    private static final String ACTIVE_TOKEN_KEY = "queue:activeToken:%s:%s"; // String (개별 활성 토큰 TTL 관리용)
 
     // FAST TRACK(대기열 진입 정책) 기준 인원 (100인 미만이면 대기열 토큰 생성 시 바로 활성열로 이동)
     // TODO: 추후 QueuePolicy (정책 DB)에서 관리하도록 수정 예정
@@ -81,18 +80,34 @@ public class RedisQueueRepository implements QueueRepository {
 
     @Override
     public boolean isActivatedToken(UUID productId, TokenId tokenId) {
-        return Boolean.TRUE.equals(redisTemplate.opsForSet()
-            .isMember(getActiveKey(productId),
-                tokenId.getValue().toString()
-            ));
+        // ZSet에서 Score(만료시간) 조회
+        String activeKey = getActiveKey(productId);
+        Double expireTime = redisTemplate.opsForZSet().score(activeKey, tokenId.getValue());
+
+        // 활성열에 없음
+        if (expireTime == null) return false;
+
+        // 만료 시간 지났는지 확인 (Lazy Validation)
+        long now = System.currentTimeMillis();
+        if (expireTime < now) {
+            // 만료되었으면 삭제
+            redisTemplate.opsForZSet().remove(
+                activeKey,
+                tokenId.getValue()
+            );
+            log.info("[QUEUE:EXPIRE:ACTIVE] 활성 토큰 만료됨. token={}", tokenId);
+            return false;
+        }
+        return true;
     }
 
     /**
-     * 활성 토큰 수 확인
+     * 활성 토큰 수 확인 (ZSet Size 조회)
      */
     @Override
     public Long countActiveTokens(UUID productId) {
-        return redisTemplate.opsForSet().size(getActiveKey(productId));
+        Long count = redisTemplate.opsForZSet().zCard(getActiveKey(productId));
+        return count != null ? count : 0L;
     }
 
     @Override
@@ -129,26 +144,21 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     /**
-     * Fast Track: 즉시 활성열 등록
+     * Fast Track: 즉시 활성열 등록 (ZSet 등록)
      */
     private boolean registerFastTrack(QueueToken token, LocalDateTime dealEndTime, Integer activeTtl,
         String userIndexKey) {
         // ActiveKey(활성열 키) 생성
         String activeKey = getActiveKey(token.getProductId());
         try {
-            // active set에 추가
-            redisTemplate.opsForSet().add(
-                activeKey,
-                token.getId().getValue().toString()
-            );
+            // 만료 시간(score) 계산: 현재시간
+            double expireAt = System.currentTimeMillis() + (activeTtl * 1000L);
 
-            // 활성 상태 등록 (Set 추가 + 개별 TTL 설정을 위한 Shadow Key 생성)
-            // Key: queue:activeToken:{productId}:{tokenId} / Value: userId
-            String activeTokenKey = getActiveTokenKey(token.getProductId(), token.getId().toString());
-            redisTemplate.opsForValue().set(
-                activeTokenKey,
-                token.getUserId().toString(),
-                Duration.of(activeTtl, ChronoUnit.SECONDS)
+            // active(활성열) ZSet에 저장 (Score = 만료시간)
+            redisTemplate.opsForZSet().add(
+                activeKey,
+                token.getId().getValue().toString(),
+                expireAt
             );
             log.info("[QUEUE:REDIS] FAST TRACK 활성열 등록 성공: user={}, token={}", token.getUserId(), token.getId());
             return true;
@@ -194,10 +204,5 @@ public class RedisQueueRepository implements QueueRepository {
 
     private String getUserIndexKey(UUID productId, Long userId) {
         return String.format(USER_INDEX_KEY, productId, userId);
-    }
-
-    // 개별 활성 토큰 검증용 키
-    private String getActiveTokenKey(UUID productId, String tokenId) {
-        return String.format(ACTIVE_TOKEN_KEY, productId, tokenId);
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -8,10 +8,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 public class RedisQueueRepository implements QueueRepository {
 
@@ -38,10 +40,13 @@ public class RedisQueueRepository implements QueueRepository {
             return false;
         }
 
+        // redis 사용자 인덱스 키 생성
+        String userIndexKey = getUserIndexKey(token.getProductId(), token.getUserId());
+
         // 중복 방지 : 유저별 대기열 키 생성 (SETNX)
         // KEY: queue:user:product:{productId}:{userId} / VALUE: 토큰 UUID
         Boolean isNewUser = redisTemplate.opsForValue().setIfAbsent(
-            getUserIndexKey(token.getProductId(), token.getUserId()),
+            userIndexKey,
             token.getId().getValue().toString(),
             Duration.ofMinutes(secondsUntilClose) // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
         );
@@ -52,13 +57,20 @@ public class RedisQueueRepository implements QueueRepository {
         }
 
         // 대기열 추가 : ZSet에 등록
-        double score = System.currentTimeMillis();
-        redisTemplate.opsForZSet().add(
+        try {
+            double score = System.currentTimeMillis();
+            redisTemplate.opsForZSet().add(
                 getWaitingKey(token.getProductId()),
                 token.getId().getValue().toString(),
                 score
             );
-        return true;
+            return true;
+        } catch (Exception e) {
+            // 보상 트랜잭션 : ZSet 저장 실패 시, 중복 방지 키(userIndexKey)도 삭제해줘야 유저가 다시 시도 가능
+            log.error("[QUEUE:REDIS:ERROR] 대기열 등록 실패로 인한 롤백 수행: userId={}, tokenId={}", token.getUserId(), token.getId());
+            redisTemplate.delete(userIndexKey);
+            throw e;
+        }
     }
 
     @Override

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -5,6 +5,7 @@ import com.rushcrew.queue.domain.repository.QueueRepository;
 import com.rushcrew.queue.domain.vo.TokenId;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -22,6 +23,11 @@ public class RedisQueueRepository implements QueueRepository {
     private static final String WAITING_KEY = "queue:wait:product:%s";
     private static final String ACTIVE_KEY = "queue:active:product:%s";
     private static final String USER_INDEX_KEY = "queue:user:product:%s:%s"; // String (중복방지용)
+    private static final String ACTIVE_TOKEN_KEY = "queue:activeToken:%s:%s"; // String (개별 활성 토큰 TTL 관리용)
+
+    // FAST TRACK(대기열 진입 정책) 기준 인원 (100인 미만이면 대기열 토큰 생성 시 바로 활성열로 이동)
+    // TODO: 추후 QueuePolicy (정책 DB)에서 관리하도록 수정 예정
+    private static final Long MAX_ACTIVE_COUNT = 100L;
 
     public RedisQueueRepository(StringRedisTemplate redisTemplate) {
         this.redisTemplate = redisTemplate;
@@ -31,12 +37,13 @@ public class RedisQueueRepository implements QueueRepository {
      * 대기열 등록 (ZSet : Sorted Set)
      */
     @Override
-    public boolean register(QueueToken token, LocalDateTime dealEndTime) {
+    public boolean register(QueueToken token, LocalDateTime dealEndTime, Integer activeTtl) {
         // TTL 계산 : (이벤트 종료 시간 - 현재 시간)
         long secondsUntilClose = Duration.between(LocalDateTime.now(), dealEndTime).getSeconds();
 
         if (secondsUntilClose < 0) {
             // 이미 종료된 이벤트면 진입 불가 처리
+            log.warn("[QUEUE:ERROR] 이미 종료된 이벤트입니다. productId={}", token.getProductId());
             return false;
         }
 
@@ -53,29 +60,23 @@ public class RedisQueueRepository implements QueueRepository {
 
         if (Objects.equals(isNewUser, Boolean.FALSE)) {
             // 이미 대기 중인 유저
+            log.warn("[QUEUE:ERROR] 이미 대기 중인 사용자입니다. userId={}", token.getUserId());
             return false;
         }
 
-        // 대기열 추가 : ZSet에 등록
-        try {
-            double score = System.currentTimeMillis();
-            redisTemplate.opsForZSet().add(
-                getWaitingKey(token.getProductId()),
-                token.getId().getValue().toString(),
-                score
-            );
-            return true;
-        } catch (Exception e) {
-            // 보상 트랜잭션 : ZSet 저장 실패 시, 중복 방지 키(userIndexKey)도 삭제해줘야 유저가 다시 시도 가능
-            log.error("[QUEUE:REDIS:ERROR] 대기열 등록 실패로 인한 롤백 수행: userId={}, tokenId={}", token.getUserId(), token.getId());
-            redisTemplate.delete(userIndexKey);
-            throw e;
+        // FAST TRACK 판단 : 활성열 인원 조회
+        Long activeCount = countActiveTokens(token.getProductId());
+        if (activeCount != null && activeCount < MAX_ACTIVE_COUNT) {
+            // [Fast Track] 대기 없이 바로 활성 상태 진입
+            return registerFastTrack(token, dealEndTime, activeTtl, userIndexKey);
+        } else {
+            // 대기열 등록 (ZSet)
+            return registerWaitingQueue(token, userIndexKey);
         }
     }
 
     @Override
     public void activateTokens(UUID productId, List<String> tokens) {
-
     }
 
     @Override
@@ -84,6 +85,14 @@ public class RedisQueueRepository implements QueueRepository {
             .isMember(getActiveKey(productId),
                 tokenId.getValue().toString()
             ));
+    }
+
+    /**
+     * 활성 토큰 수 확인
+     */
+    @Override
+    public Long countActiveTokens(UUID productId) {
+        return redisTemplate.opsForSet().size(getActiveKey(productId));
     }
 
     @Override
@@ -108,6 +117,7 @@ public class RedisQueueRepository implements QueueRepository {
     /**
      * 본인 확인 (대기열 토큰 소유권 검증)
      */
+    @Override
     public boolean verifyTokenOwner(UUID productId, Long userId, String token) {
         // redis에 저장된 해당 유저 토큰 조회
         String savedToken = redisTemplate.opsForValue().get(
@@ -116,6 +126,62 @@ public class RedisQueueRepository implements QueueRepository {
 
         // 저장된 토큰 없거나, 요청 토큰과 다르면 본인 아님
         return savedToken != null && savedToken.equals(token);
+    }
+
+    /**
+     * Fast Track: 즉시 활성열 등록
+     */
+    private boolean registerFastTrack(QueueToken token, LocalDateTime dealEndTime, Integer activeTtl,
+        String userIndexKey) {
+        // ActiveKey(활성열 키) 생성
+        String activeKey = getActiveKey(token.getProductId());
+        try {
+            // active set에 추가
+            redisTemplate.opsForSet().add(
+                activeKey,
+                token.getId().getValue().toString()
+            );
+
+            // 활성 상태 등록 (Set 추가 + 개별 TTL 설정을 위한 Shadow Key 생성)
+            // Key: queue:activeToken:{productId}:{tokenId} / Value: userId
+            String activeTokenKey = getActiveTokenKey(token.getProductId(), token.getId().toString());
+            redisTemplate.opsForValue().set(
+                activeTokenKey,
+                token.getUserId().toString(),
+                Duration.of(activeTtl, ChronoUnit.SECONDS)
+            );
+            log.info("[QUEUE:REDIS] FAST TRACK 활성열 등록 성공: user={}, token={}", token.getUserId(), token.getId());
+            return true;
+        } catch (Exception e) {
+            // 롤백: 문제 발생 시 유저 인덱스 삭제 (재진입 허용)
+            // 보상 트랜잭션 : Set 저장 실패 시, 중복 방지 키(userIndexKey)와 activeKey도 삭제해줘야 유저가 다시 시도 가능
+            log.error("[QUEUE:REDIS:ERROR] FAST TRACK 활성열 진입 실패로 인한 롤백 수행: userId={}, tokenId={}", token.getUserId(), token.getId());
+            redisTemplate.delete(userIndexKey);
+            redisTemplate.opsForSet().remove(activeKey, token.getId().toString());
+            throw e;
+        }
+    }
+
+    /**
+     * 대기열 등록 (ZSet 등록)
+     */
+    private boolean registerWaitingQueue(QueueToken token, String userIndexKey) {
+        try {
+            // TODO: 추후 확인 -> System.currentTimeMillis()는 동시성 이슈가 미세하게 있을 수 있으므로 nanoTime 혼용 추천
+            double score = System.currentTimeMillis();
+            redisTemplate.opsForZSet().add(
+                getWaitingKey(token.getProductId()),
+                token.getId().getValue().toString(),
+                score
+            );
+            log.info("[QUEUE:REDIS] 대기열 진입 성공: user={}, score={}", token.getUserId(), score);
+            return true;
+        } catch (Exception e) {
+            // 보상 트랜잭션 : ZSet 저장 실패 시, 중복 방지 키(userIndexKey)도 삭제해줘야 유저가 다시 시도 가능
+            log.error("[QUEUE:REDIS:ERROR] 대기열 진입 실패로 인한 롤백 수행: userId={}, tokenId={}", token.getUserId(), token.getId());
+            redisTemplate.delete(userIndexKey);
+            throw e;
+        }
     }
 
     private String getWaitingKey(UUID productId) {
@@ -128,5 +194,10 @@ public class RedisQueueRepository implements QueueRepository {
 
     private String getUserIndexKey(UUID productId, Long userId) {
         return String.format(USER_INDEX_KEY, productId, userId);
+    }
+
+    // 개별 활성 토큰 검증용 키
+    private String getActiveTokenKey(UUID productId, String tokenId) {
+        return String.format(ACTIVE_TOKEN_KEY, productId, tokenId);
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -3,7 +3,9 @@ package com.rushcrew.queue.infrastructure.repository;
 import com.rushcrew.queue.domain.entity.QueueToken;
 import com.rushcrew.queue.domain.repository.QueueRepository;
 import com.rushcrew.queue.domain.vo.TokenId;
+import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,22 +18,38 @@ public class RedisQueueRepository implements QueueRepository {
 
     private static final String WAITING_KEY = "queue:wait:product:%s";
     private static final String ACTIVE_KEY = "queue:active:product:%s";
+    private static final String USER_INDEX_KEY = "queue:user:product:%s:%s"; // String (중복방지용)
 
     public RedisQueueRepository(StringRedisTemplate redisTemplate) {
         this.redisTemplate = redisTemplate;
     }
 
+
     /**
      * 대기열 등록 (ZSet : Sorted Set)
      */
     @Override
-    public void register(QueueToken token) {
+    public boolean register(QueueToken token) {
+        // 중복 방지 : 유저별 대기열 키 생성 (SETNX)
+        // Key: queue:user:product:{productId}:{userId} -> Value: TokenUUID
+        Boolean isNewUser = redisTemplate.opsForValue().setIfAbsent(
+            getUserIndexKey(token.getProductId(), token.getUserId()),
+            token.getId().getValue().toString()
+        );
+
+        if (Objects.equals(isNewUser, Boolean.FALSE)) {
+            // 이미 대기 중인 유저
+            return false;
+        }
+
+        // 대기열 추가 : ZSet에 등록
         double score = System.currentTimeMillis();
         redisTemplate.opsForZSet().add(
                 getWaitingKey(token.getProductId()),
                 token.getId().getValue().toString(),
                 score
             );
+        return true;
     }
 
     @Override
@@ -72,5 +90,9 @@ public class RedisQueueRepository implements QueueRepository {
 
     private String getActiveKey(UUID productId) {
         return String.format(ACTIVE_KEY, productId);
+    }
+
+    private String getUserIndexKey(UUID productId, Long userId) {
+        return String.format(USER_INDEX_KEY, productId, userId);
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -2,6 +2,7 @@ package com.rushcrew.queue.infrastructure.repository;
 
 import com.rushcrew.queue.domain.entity.QueueToken;
 import com.rushcrew.queue.domain.repository.QueueRepository;
+import com.rushcrew.queue.domain.vo.TokenId;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -34,24 +35,34 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     @Override
-    public void activateTokens(Long productId, List<String> tokens) {
+    public void activateTokens(UUID productId, List<String> tokens) {
 
     }
 
     @Override
-    public boolean isActivatedToken(Long productId, QueueToken token) {
+    public boolean isActivatedToken(UUID productId, TokenId tokenId) {
         return Boolean.TRUE.equals(redisTemplate.opsForSet()
-            .isMember(getActiveKey(token.getProductId()),
-                token.getId().getValue().toString()
+            .isMember(getActiveKey(productId),
+                tokenId.getValue().toString()
             ));
     }
 
     @Override
-    public Long getWaitingRank(UUID productId, QueueToken token) {
-        // ZRANK key member
+    public Long getWaitingRank(UUID productId, TokenId tokenId) {
+        // ZRANK key member (ZSet 조회)
+        // Redis ZRANK 통하여 대기 순번 조회 성능을 O(log N)으로 최적화
         return redisTemplate.opsForZSet()
-            .rank(getWaitingKey(token.getProductId()),
-                token.getId().getValue().toString()
+            .rank(getWaitingKey(productId),
+                tokenId.getValue().toString()
+            );
+    }
+
+    @Override
+    public Double getWaitingScore(UUID productId, TokenId tokenId) {
+        // Redis ZSCORE로 진입 시간 조회
+        return redisTemplate.opsForZSet()
+            .score(getWaitingKey(productId),
+                tokenId.getValue().toString()
             );
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
@@ -26,6 +26,7 @@ public class QueueController {
     // API Gateway에서 인증 후, USER ID와 ROLE을 헤더에 담아 전달
     private static final String USER_ID_HEADER = "X-User-Id";
     private static final String USER_ROLE_HEADER = "X-User-Role";
+    private static final String QUEUE_TOKEN_HEADER = "X-Queue-Token";
 
     public QueueController(QueuePort queuePort) {
         this.queuePort = queuePort;
@@ -52,11 +53,11 @@ public class QueueController {
     @GetMapping("/rank")
     public ResponseEntity<ApiResponse<QueueResponse>> getQueueRank(
         @RequestParam UUID productId,
-        @RequestParam String token,
+        @RequestHeader(QUEUE_TOKEN_HEADER) String queueToken,
         @RequestHeader(USER_ID_HEADER) Long currUserId,
         @RequestHeader(USER_ROLE_HEADER) String role
     ) {
-        QueueRedisResponse redisResult = queuePort.getQueueRank(productId, token, currUserId, role);
+        QueueRedisResponse redisResult = queuePort.getQueueRank(productId, queueToken, currUserId, role);
         QueueResponse response = toQueueResponse(redisResult);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
@@ -6,12 +6,15 @@ import com.rushcrew.queue.application.command.queue.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.domain.enums.QueueStatus;
+import com.rushcrew.queue.presentation.dto.request.EnterQueueRequest;
 import com.rushcrew.queue.presentation.dto.response.QueueResponse;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,11 +40,11 @@ public class QueueController {
      */
     @PostMapping("/enter")
     public ResponseEntity<ApiResponse<QueueResponse>> enterQueue(
-        @RequestParam UUID productId,
+        @Valid @RequestBody EnterQueueRequest request,
         @RequestHeader(USER_ID_HEADER) Long currUserId,
         @RequestHeader(USER_ROLE_HEADER) String role
     ) {
-        EnterQueueCommand command = EnterQueueCommand.of(productId, currUserId, role);
+        EnterQueueCommand command = EnterQueueCommand.of(request.productId(), currUserId, role);
         QueueRedisResponse redisResult = queuePort.enterQueue(command);
         QueueResponse response = toQueueResponse(redisResult);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
@@ -1,0 +1,62 @@
+package com.rushcrew.queue.presentation.controller;
+
+
+import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.queue.application.command.EnterQueueCommand;
+import com.rushcrew.queue.application.dto.QueueRedisResponse;
+import com.rushcrew.queue.application.port.in.QueuePort;
+import com.rushcrew.queue.domain.enums.QueueStatus;
+import com.rushcrew.queue.presentation.dto.response.QueueResponse;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/queues")
+public class QueueController {
+
+    private final QueuePort queuePort; // Service 대신 인터페이스 의존 (DIP)
+
+    // API Gateway에서 인증 후, USER ID와 ROLE을 헤더에 담아 전달
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    public QueueController(QueuePort queuePort) {
+        this.queuePort = queuePort;
+    }
+
+    /**
+     * 대기열 진입 요청 API
+     */
+    @PostMapping("/enter")
+    public ResponseEntity<ApiResponse<QueueResponse>> enterQueue(
+        @RequestParam UUID productId,
+        @RequestHeader(USER_ID_HEADER) Long currUserId,
+        @RequestHeader(USER_ROLE_HEADER) String role
+    ) {
+        EnterQueueCommand command = EnterQueueCommand.of(productId, currUserId, role);
+        QueueRedisResponse redisResult = queuePort.enterQueue(command);
+        QueueResponse response = toQueueResponse(redisResult);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    // TODO: 추후 presenataion mapper 클래스로 이동 예정
+    private QueueResponse toQueueResponse(QueueRedisResponse redisResponse) {
+        String message = redisResponse.status().equals(QueueStatus.WAITING) ?
+            "대기 중입니다." : "입장 가능합니다.";
+        return QueueResponse.builder()
+            .token(redisResponse.token())
+            .productId(redisResponse.productId())
+            .rank(redisResponse.rank())
+            .status(redisResponse.status().getDescription())
+            .enteredAt(redisResponse.enteredAt())
+            .message(message)
+            .build();
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
@@ -2,7 +2,7 @@ package com.rushcrew.queue.presentation.controller;
 
 
 import com.rushcrew.common.dto.ApiResponse;
-import com.rushcrew.queue.application.command.EnterQueueCommand;
+import com.rushcrew.queue.application.command.queue.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.domain.enums.QueueStatus;
@@ -44,6 +44,21 @@ public class QueueController {
         QueueRedisResponse redisResult = queuePort.enterQueue(command);
         QueueResponse response = toQueueResponse(redisResult);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 대기열 순번 조회(Polling) API
+     */
+    @GetMapping("/rank")
+    public ResponseEntity<ApiResponse<QueueResponse>> getQueueRank(
+        @RequestParam UUID productId,
+        @RequestParam String token,
+        @RequestHeader(USER_ID_HEADER) Long currUserId,
+        @RequestHeader(USER_ROLE_HEADER) String role
+    ) {
+        QueueRedisResponse redisResult = queuePort.getQueueRank(productId, token, currUserId, role);
+        QueueResponse response = toQueueResponse(redisResult);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
     }
 
     // TODO: 추후 presenataion mapper 클래스로 이동 예정

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueuePolicyController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueuePolicyController.java
@@ -1,9 +1,9 @@
 package com.rushcrew.queue.presentation.controller;
 
 import com.rushcrew.common.dto.ApiResponse;
-import com.rushcrew.queue.application.command.CreatePolicyCommand;
-import com.rushcrew.queue.application.command.SearchPolicyCommand;
-import com.rushcrew.queue.application.command.UpdatePolicyCommand;
+import com.rushcrew.queue.application.command.policy.CreatePolicyCommand;
+import com.rushcrew.queue.application.command.policy.SearchPolicyCommand;
+import com.rushcrew.queue.application.command.policy.UpdatePolicyCommand;
 import com.rushcrew.queue.application.dto.PageQuery;
 import com.rushcrew.queue.application.dto.QueuePolicyQueryResponse;
 import com.rushcrew.queue.application.service.QueuePolicyService;

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueuePolicyController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueuePolicyController.java
@@ -1,4 +1,4 @@
-package com.rushcrew.queue.presentation;
+package com.rushcrew.queue.presentation.controller;
 
 import com.rushcrew.common.dto.ApiResponse;
 import com.rushcrew.queue.application.command.CreatePolicyCommand;

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/CreatePolicyRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/CreatePolicyRequest.java
@@ -1,6 +1,6 @@
 package com.rushcrew.queue.presentation.dto.request;
 
-import com.rushcrew.queue.application.command.CreatePolicyCommand;
+import com.rushcrew.queue.application.command.policy.CreatePolicyCommand;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.domain.vo.TimePeriod;
 import com.rushcrew.queue.domain.vo.TrafficSetting;

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/EnterQueueRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/EnterQueueRequest.java
@@ -1,10 +1,10 @@
 package com.rushcrew.queue.presentation.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record EnterQueueRequest(
-    @NotBlank(message = "상품 ID는 필수입니다")
+    @NotNull(message = "상품 ID는 필수입니다")
     UUID productId
 ) {
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/EnterQueueRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/EnterQueueRequest.java
@@ -1,0 +1,10 @@
+package com.rushcrew.queue.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
+
+public record EnterQueueRequest(
+    @NotBlank(message = "상품 ID는 필수입니다")
+    UUID productId
+) {
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/UpdatePolicyRequest.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/request/UpdatePolicyRequest.java
@@ -1,6 +1,6 @@
 package com.rushcrew.queue.presentation.dto.request;
 
-import com.rushcrew.queue.application.command.UpdatePolicyCommand;
+import com.rushcrew.queue.application.command.policy.UpdatePolicyCommand;
 import com.rushcrew.queue.domain.enums.QueuePolicyStatus;
 import com.rushcrew.queue.domain.vo.TimePeriod;
 import com.rushcrew.queue.domain.vo.TrafficSetting;

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/response/QueueResponse.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/dto/response/QueueResponse.java
@@ -1,0 +1,18 @@
+package com.rushcrew.queue.presentation.dto.response;
+
+import com.rushcrew.queue.domain.enums.QueueStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record QueueResponse(
+    UUID token,
+    UUID productId,
+    Long rank,
+    String status,
+    LocalDateTime enteredAt, // 대기열 진입 요청 시간
+    String message
+) {
+
+}


### PR DESCRIPTION
## 🧾 Summary
- 대기열 진입 API, service 구현
- 대기 순번 조회 API, service 구현
- FAST TRACK 정책 적용 : 대기열 진입 요청 시점 ACTIVE 토큰 수 100개 미만일 경우, 바로 활성열로 이동시키도록 처리
- 유효성 검사 : 토큰 본인 소유 검증(중복 검사), 대기열 등록 시 중복 차단 처리 
- Redis 대기열/활성열 등록 실패 시, 중복 방지 키 등 삭제(중복 차단당하지 않고 재진입하도록 허용)
- Redis 유저 인덱스 키, 활성 토큰 키(활성 토큰 검증용 & ACTIVE KEY에 TTL 설정 위한 Shadow key 적용)
=> 활성 토큰 TTL 관련 shadow key를 만들어서 관리했으나, 레디스 메모리 복잡도 증가 및 롤백 시점에 해당 shadow key도 같이 지워야 하는 등 관리의 복잡성으로 인하여 ActiveKey(redis)의 데이터 구조를 기존의 Set에서 ZSet으로 변경

이런저런 고려사항들이 많아짐과 동시에 수정을 여러 번 하다보니
커밋이 길어져 토큰 활성화 및 스케줄러 처리는 별도의 브랜치에서 작업하도록 할 예정입니다.

최종 REDIS 데이터 구조
<img width="797" height="320" alt="스크린샷 2025-12-05 오후 12 32 07" src="https://github.com/user-attachments/assets/227b77cf-0112-4a67-aad3-159c0039d0f9" />


## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
#56 
