### PR TITLE
feat(auth): 로그아웃 및 토큰 갱신 기능 구현

### DIFF
--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/AuthService.java
@@ -2,11 +2,15 @@ package com.rushcrew.auth_service.auth.application;
 
 import com.rushcrew.auth_service.auth.application.client.UserClient;
 import com.rushcrew.auth_service.auth.application.command.LoginCommand;
+import com.rushcrew.auth_service.auth.application.command.LogoutAllCommand;
+import com.rushcrew.auth_service.auth.application.command.LogoutCommand;
+import com.rushcrew.auth_service.auth.application.command.RefreshCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.result.LoginResult;
 import com.rushcrew.auth_service.auth.application.result.SignUpResult;
 import com.rushcrew.auth_service.auth.application.result.TokenPairResult;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+import com.rushcrew.auth_service.auth.application.result.UserInfoResult;
 import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/BlacklistService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/BlacklistService.java
@@ -1,0 +1,48 @@
+package com.rushcrew.auth_service.auth.application;
+
+import com.rushcrew.auth_service.auth.domain.entity.BlacklistedToken;
+import com.rushcrew.auth_service.auth.domain.entity.BlacklistedUser;
+import com.rushcrew.auth_service.auth.domain.repository.AccessTokenBlacklistRepository;
+import com.rushcrew.auth_service.auth.domain.repository.UserBlacklistRepository;
+import com.rushcrew.auth_service.auth.domain.vo.TokenId;
+import com.rushcrew.auth_service.auth.domain.vo.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlacklistService {
+
+    private final UserBlacklistRepository userBlacklistRepository;
+    private final AccessTokenBlacklistRepository accessTokenBlacklistRepository;
+
+    /**
+     * Access 토큰을 블랙리스트에 추가
+     */
+    @Transactional
+    public void blacklistAccessToken(
+        String accessToken,
+        java.time.LocalDateTime expiresAt
+    ) {
+        if (expiresAt.isAfter(java.time.LocalDateTime.now())) {
+            accessTokenBlacklistRepository.addToBlacklist(
+                BlacklistedToken.create(TokenId.of(accessToken), expiresAt)
+            );
+        }
+    }
+
+    /**
+     * 특정 유저를 블랙리스트에 추가
+     */
+    @Transactional
+    public void blacklistUser(Long userId, java.time.LocalDateTime expiresAt) {
+        if (expiresAt.isAfter(java.time.LocalDateTime.now())) {
+            BlacklistedUser blacklistedUser = BlacklistedUser.create(
+                UserId.of(userId),
+                expiresAt
+            );
+            userBlacklistRepository.blacklistUser(blacklistedUser);
+        }
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/BlacklistService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/BlacklistService.java
@@ -6,6 +6,7 @@ import com.rushcrew.auth_service.auth.domain.repository.AccessTokenBlacklistRepo
 import com.rushcrew.auth_service.auth.domain.repository.UserBlacklistRepository;
 import com.rushcrew.auth_service.auth.domain.vo.TokenId;
 import com.rushcrew.auth_service.auth.domain.vo.UserId;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,9 +24,9 @@ public class BlacklistService {
     @Transactional
     public void blacklistAccessToken(
         String accessToken,
-        java.time.LocalDateTime expiresAt
+        LocalDateTime expiresAt
     ) {
-        if (expiresAt.isAfter(java.time.LocalDateTime.now())) {
+        if (expiresAt.isAfter(LocalDateTime.now())) {
             accessTokenBlacklistRepository.addToBlacklist(
                 BlacklistedToken.create(TokenId.of(accessToken), expiresAt)
             );
@@ -36,8 +37,8 @@ public class BlacklistService {
      * 특정 유저를 블랙리스트에 추가
      */
     @Transactional
-    public void blacklistUser(Long userId, java.time.LocalDateTime expiresAt) {
-        if (expiresAt.isAfter(java.time.LocalDateTime.now())) {
+    public void blacklistUser(Long userId, LocalDateTime expiresAt) {
+        if (expiresAt.isAfter(LocalDateTime.now())) {
             BlacklistedUser blacklistedUser = BlacklistedUser.create(
                 UserId.of(userId),
                 expiresAt

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
@@ -1,40 +1,31 @@
 package com.rushcrew.auth_service.auth.application;
 
+import com.rushcrew.auth_service.auth.application.policy.TokenPolicy;
 import com.rushcrew.auth_service.auth.application.port.AccessTokenProvider;
 import com.rushcrew.auth_service.auth.application.port.RefreshTokenProvider;
 import com.rushcrew.auth_service.auth.application.result.TokenPairResult;
+import com.rushcrew.auth_service.auth.application.result.UserInfoResult;
 import com.rushcrew.auth_service.auth.domain.entity.RefreshToken;
 import com.rushcrew.auth_service.auth.domain.policy.ConcurrentLoginPolicy;
 import com.rushcrew.auth_service.auth.domain.repository.RefreshTokenRepository;
+import com.rushcrew.auth_service.auth.domain.vo.UserId;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class TokenService {
 
+    private final TokenPolicy tokenPolicy;
     private final AccessTokenProvider accessTokenProvider;
     private final RefreshTokenProvider refreshTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistService tokenBlacklistService;
     private final ConcurrentLoginPolicy concurrentLoginPolicy;
-    private final long refreshExpiration;
-
-    public TokenService(
-        AccessTokenProvider accessTokenProvider,
-        RefreshTokenProvider refreshTokenProvider,
-        RefreshTokenRepository refreshTokenRepository,
-        ConcurrentLoginPolicy concurrentLoginPolicy,
-        @Value("${jwt.refresh.expiration}") long refreshExpiration
-    ) {
-        this.accessTokenProvider = accessTokenProvider;
-        this.refreshTokenProvider = refreshTokenProvider;
-        this.refreshTokenRepository = refreshTokenRepository;
-        this.concurrentLoginPolicy = concurrentLoginPolicy;
-        this.refreshExpiration = refreshExpiration;
-    }
 
     @Transactional
     public TokenPairResult issueTokenPair(
@@ -47,38 +38,25 @@ public class TokenService {
             email,
             role
         );
-        String refreshToken = issueRefreshToken(userId);
-
-        return new TokenPairResult(accessToken, refreshToken);
-    }
-
-    @Transactional
-    public String issueRefreshToken(Long userId) {
-        String tokenValue = refreshTokenProvider.generateToken(userId);
+        String refreshToken = refreshTokenProvider.generateToken(userId);
 
         RefreshToken token = RefreshToken.create(
-            tokenValue,
-            userId,
-            refreshExpiration
+            refreshToken,
+            UserId.of(userId),
+            tokenPolicy.refreshExpirationMillis()
         );
 
         refreshTokenRepository.save(token);
 
-        // 동시 로그인 제한 적용
-        List<String> existingTokens = refreshTokenRepository.findAllTokensByUserId(userId);
-
-        List<String> tokensToRevoke = concurrentLoginPolicy.getTokensToRevoke(existingTokens);
-
+        // 동시 로그인 정책 적용
+        List<String> existingTokens =
+            refreshTokenRepository.findAllTokensByUserId(userId);
+        List<String> tokensToRevoke = concurrentLoginPolicy.getTokensToRevoke(
+            existingTokens
+        );
         tokensToRevoke.forEach(refreshTokenRepository::deleteByToken);
 
-        return tokenValue;
-    }
-
-    public Optional<Long> validateToken(String tokenValue) {
-        return refreshTokenRepository
-            .findByToken(tokenValue)
-            .filter(token -> !token.isExpired())
-            .map(RefreshToken::getUserId);
+        return new TokenPairResult(accessToken, refreshToken);
     }
 
     @Transactional
@@ -87,7 +65,39 @@ public class TokenService {
     }
 
     @Transactional
-    public void revokeAllTokens(Long userId) {
+    public void revokeToken(String accessToken, String refreshToken) {
+        // 1. Refresh Token 삭제
+        Optional.ofNullable(refreshToken).ifPresent(
+            refreshTokenRepository::deleteByToken
+        );
+
+        // 2. Access Token 블랙리스트 처리
+        java.time.LocalDateTime expiryDate = accessTokenProvider.getExpiryDate(
+            accessToken
+        );
+        tokenBlacklistService.blacklistAccessToken(accessToken, expiryDate);
+    }
+
+    /**
+     * 모든 토큰 폐기 (전체 로그아웃)
+     */
+    @Transactional
+    public void revokeAllTokens(Long userId, String currentAccessToken) {
+        // 1. 해당 유저의 모든 Refresh Token 삭제
         refreshTokenRepository.deleteAllByUserId(userId);
+
+        // 2. 현재 Access Token 및 유저 자체를 블랙리스트 처리
+        java.time.LocalDateTime expiryDate = accessTokenProvider.getExpiryDate(
+            currentAccessToken
+        );
+        tokenBlacklistService.blacklistAccessToken(
+            currentAccessToken,
+            expiryDate
+        );
+        tokenBlacklistService.blacklistUser(userId, expiryDate);
+    }
+
+    public Long getUserIdFromRefreshToken(String refreshToken) {
+        return refreshTokenProvider.getUserIdFromToken(refreshToken);
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
@@ -60,8 +60,21 @@ public class TokenService {
     }
 
     @Transactional
-    public void revokeToken(String tokenValue) {
-        refreshTokenRepository.deleteByToken(tokenValue);
+    public String refreshAccessToken(
+        UserInfoResult user,
+        String refreshTokenValue
+    ) {
+        RefreshToken token = refreshTokenRepository.findByToken(refreshTokenValue)
+            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 Refresh Token입니다.")
+            );
+
+        token.ensureValid();
+
+        return accessTokenProvider.generateToken(
+            user.id(),
+            user.name(),
+            user.role()
+        );
     }
 
     @Transactional

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/TokenService.java
@@ -9,6 +9,7 @@ import com.rushcrew.auth_service.auth.domain.entity.RefreshToken;
 import com.rushcrew.auth_service.auth.domain.policy.ConcurrentLoginPolicy;
 import com.rushcrew.auth_service.auth.domain.repository.RefreshTokenRepository;
 import com.rushcrew.auth_service.auth.domain.vo.UserId;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -64,8 +65,12 @@ public class TokenService {
         UserInfoResult user,
         String refreshTokenValue
     ) {
-        RefreshToken token = refreshTokenRepository.findByToken(refreshTokenValue)
-            .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 Refresh Token입니다.")
+        RefreshToken token = refreshTokenRepository
+            .findByToken(refreshTokenValue)
+            .orElseThrow(() ->
+                new IllegalArgumentException(
+                    "유효하지 않은 Refresh Token입니다."
+                )
             );
 
         token.ensureValid();
@@ -84,10 +89,16 @@ public class TokenService {
             refreshTokenRepository::deleteByToken
         );
 
-        // 2. Access Token 블랙리스트 처리
-        java.time.LocalDateTime expiryDate = accessTokenProvider.getExpiryDate(
-            accessToken
-        );
+        // 2. 만료 시간을 추출
+        LocalDateTime expiryDate;
+        try {
+            expiryDate = accessTokenProvider.getExpiryDate(accessToken);
+        } catch (Exception e) {
+            // 이미 만료되었거나 잘못된 토큰인 경우 무시
+            return;
+        }
+
+        // 3. 블랙리스트 처리
         tokenBlacklistService.blacklistAccessToken(accessToken, expiryDate);
     }
 
@@ -99,10 +110,15 @@ public class TokenService {
         // 1. 해당 유저의 모든 Refresh Token 삭제
         refreshTokenRepository.deleteAllByUserId(userId);
 
-        // 2. 현재 Access Token 및 유저 자체를 블랙리스트 처리
-        java.time.LocalDateTime expiryDate = accessTokenProvider.getExpiryDate(
-            currentAccessToken
-        );
+        // 2. 현재 Access Token 및 유저 자체를 블랙리스트 처리 (멱등성 보장)
+        LocalDateTime expiryDate;
+        try {
+            expiryDate = accessTokenProvider.getExpiryDate(currentAccessToken);
+        } catch (Exception e) {
+            // 토큰 파싱 실패 시 기본값 사용
+            expiryDate = LocalDateTime.now().plusHours(1);
+        }
+
         tokenBlacklistService.blacklistAccessToken(
             currentAccessToken,
             expiryDate

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/client/UserClient.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/client/UserClient.java
@@ -3,10 +3,13 @@ package com.rushcrew.auth_service.auth.application.client;
 import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+import com.rushcrew.auth_service.auth.application.result.UserInfoResult;
 import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 
 public interface UserClient {
     UserCreateResult createUser(SignUpCommand command);
 
     VerifyPasswordResult verifyPassword(LoginCommand command);
+
+    UserInfoResult getUserById(Long userId);
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/LogoutAllCommand.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/LogoutAllCommand.java
@@ -1,0 +1,6 @@
+package com.rushcrew.auth_service.auth.application.command;
+
+public record LogoutAllCommand(
+    Long userId,
+    String accessToken
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/LogoutCommand.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/LogoutCommand.java
@@ -1,0 +1,6 @@
+package com.rushcrew.auth_service.auth.application.command;
+
+public record LogoutCommand(
+    String accessToken,
+    String refreshToken
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/RefreshCommand.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/command/RefreshCommand.java
@@ -1,0 +1,5 @@
+package com.rushcrew.auth_service.auth.application.command;
+
+public record RefreshCommand(
+    String refreshToken
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/UserInfoResult.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/application/result/UserInfoResult.java
@@ -1,0 +1,7 @@
+package com.rushcrew.auth_service.auth.application.result;
+
+public record UserInfoResult(
+    Long id,
+    String name,
+    String role
+) {}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/entity/BlacklistedToken.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/entity/BlacklistedToken.java
@@ -1,0 +1,45 @@
+package com.rushcrew.auth_service.auth.domain.entity;
+
+import com.rushcrew.auth_service.auth.domain.vo.TokenExpiry;
+import com.rushcrew.auth_service.auth.domain.vo.TokenId;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class BlacklistedToken {
+
+    private final TokenId id;
+    private final TokenExpiry expiry;
+    private final LocalDateTime blacklistedAt;
+
+    public static BlacklistedToken create(
+        TokenId tokenId,
+        LocalDateTime expiresAt
+    ) {
+        return new BlacklistedToken(
+            tokenId,
+            TokenExpiry.create(expiresAt),
+            LocalDateTime.now()
+        );
+    }
+
+    public long remainingMillis() {
+        long expiresAtMillis = expiry
+            .getExpiresAt()
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli();
+
+        long nowMillis = System.currentTimeMillis();
+
+        return Math.max(expiresAtMillis - nowMillis, 0);
+    }
+
+    public String getTokenValue() {
+        return id.getValue();
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/entity/BlacklistedUser.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/entity/BlacklistedUser.java
@@ -1,0 +1,43 @@
+package com.rushcrew.auth_service.auth.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.rushcrew.auth_service.auth.domain.vo.TokenExpiry;
+import com.rushcrew.auth_service.auth.domain.vo.UserId;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BlacklistedUser {
+
+    private final UserId id;
+    private final TokenExpiry expiry;
+    private final LocalDateTime blacklistedAt;
+
+    public static BlacklistedUser create(UserId userId, LocalDateTime expiresAt) {
+        return new BlacklistedUser(
+            userId,
+            TokenExpiry.create(expiresAt),
+            LocalDateTime.now()
+        );
+    }
+
+    public Long getUserId() {
+        return id.getValue();
+    }
+
+    public long remainingMillis() {
+        long expiresAtMillis = expiry.getExpiresAt()
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli();
+
+        long nowMillis = System.currentTimeMillis();
+
+        return Math.max(expiresAtMillis - nowMillis, 0);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/repository/AccessTokenBlacklistRepository.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/repository/AccessTokenBlacklistRepository.java
@@ -1,0 +1,7 @@
+package com.rushcrew.auth_service.auth.domain.repository;
+
+import com.rushcrew.auth_service.auth.domain.entity.BlacklistedToken;
+
+public interface AccessTokenBlacklistRepository {
+    void addToBlacklist(BlacklistedToken token);
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/repository/UserBlacklistRepository.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/repository/UserBlacklistRepository.java
@@ -1,0 +1,10 @@
+package com.rushcrew.auth_service.auth.domain.repository;
+
+import com.rushcrew.auth_service.auth.domain.entity.BlacklistedUser;
+
+public interface UserBlacklistRepository {
+    /**
+     * 사용자를 블랙리스트에 추가 (모든 AccessToken 무효화)
+     */
+    void blacklistUser(BlacklistedUser user);
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/vo/TokenExpiry.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/domain/vo/TokenExpiry.java
@@ -1,6 +1,7 @@
 package com.rushcrew.auth_service.auth.domain.vo;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -14,21 +15,41 @@ public class TokenExpiry {
 
     private final LocalDateTime expiresAt;
 
-    public static TokenExpiry fromMilliseconds(long millis) {
-        if (millis <= 0) {
-            throw new IllegalArgumentException("만료 일수는 양수여야 합니다");
+    public static TokenExpiry create(LocalDateTime expiresAt) {
+        if (expiresAt == null) {
+            throw new IllegalArgumentException("만료 시간은 null일 수 없습니다.");
         }
 
-        return new TokenExpiry(LocalDateTime.now().plus(millis, ChronoUnit.MILLIS));
+        if (expiresAt.isBefore(LocalDateTime.now())) {
+            throw new IllegalArgumentException("만료 시간은 현재 시간 이후여야 합니다.");
+        }
+
+        return new TokenExpiry(expiresAt.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    public static TokenExpiry fromMilliseconds(long millis) {
+        if (millis <= 0) {
+            throw new IllegalArgumentException("만료 시간은 양수여야 합니다");
+        }
+
+        LocalDateTime expiresAt = LocalDateTime.now().plus(
+            millis,
+            ChronoUnit.MILLIS
+        );
+        return create(expiresAt);
     }
 
     @JsonCreator
     public static TokenExpiry fromJson(
         @JsonProperty("expiresAt") LocalDateTime expiresAt
     ) {
-        return new TokenExpiry(expiresAt);
+        if (expiresAt == null) {
+            throw new IllegalArgumentException("만료 시간은 null일 수 없습니다.");
+        }
+        return new TokenExpiry(expiresAt.truncatedTo(ChronoUnit.SECONDS));
     }
 
+    @JsonIgnore
     public boolean isExpired() {
         return LocalDateTime.now().isAfter(expiresAt);
     }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserClientImpl.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserClientImpl.java
@@ -4,9 +4,11 @@ import com.rushcrew.auth_service.auth.application.client.UserClient;
 import com.rushcrew.auth_service.auth.application.command.LoginCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.result.UserCreateResult;
+import com.rushcrew.auth_service.auth.application.result.UserInfoResult;
 import com.rushcrew.auth_service.auth.application.result.VerifyPasswordResult;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateRequest;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateResponse;
+import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserInfoResponse;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordRequest;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,13 @@ public class UserClientImpl implements UserClient {
         VerifyPasswordRequest request = VerifyPasswordRequest.fromCommand(command);
 
         VerifyPasswordResponse response = userFeignClient.verifyPassword(request);
+
+        return response.toResult();
+    }
+
+    @Override
+    public UserInfoResult getUserById(Long userId) {
+        UserInfoResponse response = userFeignClient.getUserById(userId);
 
         return response.toResult();
     }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserFeignClient.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/UserFeignClient.java
@@ -2,9 +2,12 @@ package com.rushcrew.auth_service.auth.infrastructure.external;
 
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateRequest;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserCreateResponse;
+import com.rushcrew.auth_service.auth.infrastructure.external.dto.UserInfoResponse;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordRequest;
 import com.rushcrew.auth_service.auth.infrastructure.external.dto.VerifyPasswordResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -15,4 +18,7 @@ public interface UserFeignClient {
 
     @PostMapping("/api/v1/users/verify-password")
     VerifyPasswordResponse verifyPassword(@RequestBody VerifyPasswordRequest request);
+
+    @GetMapping("/api/v1/users/internal/users/{userId}")
+    UserInfoResponse getUserById(@PathVariable Long userId);
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/UserInfoResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/external/dto/UserInfoResponse.java
@@ -1,0 +1,13 @@
+package com.rushcrew.auth_service.auth.infrastructure.external.dto;
+
+import com.rushcrew.auth_service.auth.application.result.UserInfoResult;
+
+public record UserInfoResponse(
+    Long userId,
+    String name,
+    String role
+) {
+    public UserInfoResult toResult() {
+        return new UserInfoResult(userId, name, role);
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/repository/RedisAccessTokenBlacklistRepository.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/repository/RedisAccessTokenBlacklistRepository.java
@@ -1,0 +1,44 @@
+package com.rushcrew.auth_service.auth.infrastructure.repository;
+
+import com.rushcrew.auth_service.auth.domain.entity.BlacklistedToken;
+import com.rushcrew.auth_service.auth.domain.repository.AccessTokenBlacklistRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisAccessTokenBlacklistRepository implements AccessTokenBlacklistRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String BLACKLIST_PREFIX = "blacklist:token:";
+    private static final String BLACKLIST_MARKER = "revoked";
+
+    @Override
+    public void addToBlacklist(BlacklistedToken token) {
+        try {
+            String tokenKey = BLACKLIST_PREFIX + token.getTokenValue();
+
+            long ttlMillis = token.remainingMillis();
+
+            if (ttlMillis <= 0) {
+                return;
+            }
+
+            redisTemplate
+                .opsForValue()
+                .setIfAbsent(
+                    tokenKey,
+                    BLACKLIST_MARKER,
+                    ttlMillis,
+                    TimeUnit.MILLISECONDS
+                );
+        } catch (Exception e) {
+            throw new RuntimeException("블랙리스트 저장 실패했습니다.", e);
+        }
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/repository/RedisUserBlacklistRepository.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/infrastructure/repository/RedisUserBlacklistRepository.java
@@ -1,0 +1,42 @@
+package com.rushcrew.auth_service.auth.infrastructure.repository;
+
+import com.rushcrew.auth_service.auth.domain.entity.BlacklistedUser;
+import com.rushcrew.auth_service.auth.domain.repository.UserBlacklistRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RedisUserBlacklistRepository implements UserBlacklistRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String USER_BLACKLIST_PREFIX = "blacklist:user:";
+    private static final String REVOKED_MARKER = "all_revoked";
+
+    @Override
+    public void blacklistUser(BlacklistedUser user) {
+        try {
+            String key = USER_BLACKLIST_PREFIX + user.getUserId();
+            long ttl = user.remainingMillis();
+
+            if (ttl <= 0) {
+                return;
+            }
+
+            redisTemplate.opsForValue().set(
+                key,
+                REVOKED_MARKER,
+                ttl,
+                TimeUnit.MILLISECONDS
+            );
+
+        } catch (Exception e) {
+            throw new RuntimeException("사용자 블랙리스트 저장 실패", e);
+        }
+    }
+}

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/AuthController.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/AuthController.java
@@ -59,4 +59,47 @@ public class AuthController {
 
         return ResponseEntity.ok(LoginResponse.fromResult(result));
     }
+
+    /**
+     * 로그아웃 - Access Token 블랙리스트 추가 및 Refresh Token 폐기
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logOut(
+        @RequestHeader("Authorization") String authorization,
+        HttpServletRequest request
+    ) {
+        String accessToken = tokenUtils.extractAccessToken(authorization);
+        String refreshToken = tokenUtils.extractRefreshToken(request);
+
+        LogoutCommand command = new LogoutCommand(accessToken, refreshToken);
+
+        authService.logOut(command);
+
+        ResponseCookie expiredCookie = tokenUtils.createExpiredRefreshTokenCookie();
+
+        return ResponseEntity.noContent()
+            .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
+            .build();
+    }
+
+    /**
+     * 모든 기기에서 로그아웃
+     */
+    @PostMapping("/logout/all")
+    public ResponseEntity<Void> logoutAll(
+        @RequestHeader("X-User-Id") Long userId,
+        @RequestHeader("Authorization") String authorization
+    ) {
+        String accessToken = tokenUtils.extractAccessToken(authorization);
+
+        LogoutAllCommand command = new LogoutAllCommand(userId, accessToken);
+
+        authService.logoutFromAllDevices(command);
+
+        ResponseCookie expiredCookie = tokenUtils.createExpiredRefreshTokenCookie();
+
+        return ResponseEntity.noContent()
+            .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
+            .build();
+    }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/AuthController.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/AuthController.java
@@ -2,12 +2,16 @@ package com.rushcrew.auth_service.auth.presentation;
 
 import com.rushcrew.auth_service.auth.application.AuthService;
 import com.rushcrew.auth_service.auth.application.command.LoginCommand;
+import com.rushcrew.auth_service.auth.application.command.LogoutAllCommand;
+import com.rushcrew.auth_service.auth.application.command.LogoutCommand;
+import com.rushcrew.auth_service.auth.application.command.RefreshCommand;
 import com.rushcrew.auth_service.auth.application.command.SignUpCommand;
 import com.rushcrew.auth_service.auth.application.result.LoginResult;
 import com.rushcrew.auth_service.auth.application.result.SignUpResult;
 import com.rushcrew.auth_service.auth.presentation.dto.request.LoginRequest;
 import com.rushcrew.auth_service.auth.presentation.dto.request.SignUpRequest;
 import com.rushcrew.auth_service.auth.presentation.dto.response.LoginResponse;
+import com.rushcrew.auth_service.auth.presentation.dto.response.RefreshAccessTokenResponse;
 import com.rushcrew.auth_service.auth.presentation.dto.response.SignUpResponse;
 import com.rushcrew.auth_service.auth.presentation.util.TokenUtils;
 import jakarta.servlet.http.HttpServletRequest;
@@ -20,6 +24,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -101,5 +106,21 @@ public class AuthController {
         return ResponseEntity.noContent()
             .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
             .build();
+    }
+
+    /**
+     * Access 토큰 초기화
+     */
+    @PostMapping("/token/refresh")
+    public ResponseEntity<RefreshAccessTokenResponse> refreshAccessToken(
+        HttpServletRequest request
+    ) {
+        String refreshToken = tokenUtils.extractRefreshToken(request);
+
+        RefreshCommand command = new RefreshCommand(refreshToken);
+
+        String accessToken = authService.refreshAccessToken(command);
+
+        return ResponseEntity.ok(RefreshAccessTokenResponse.of(accessToken));
     }
 }

--- a/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/RefreshAccessTokenResponse.java
+++ b/auth-service/src/main/java/com/rushcrew/auth_service/auth/presentation/dto/response/RefreshAccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.rushcrew.auth_service.auth.presentation.dto.response;
+
+public record RefreshAccessTokenResponse(
+    String accessToken
+) {
+    public static RefreshAccessTokenResponse of(String accessToken) {
+        return new RefreshAccessTokenResponse(accessToken);
+    }
+}

--- a/user-service/src/main/java/com/rushcrew/user_service/user/application/UserService.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/application/UserService.java
@@ -4,6 +4,7 @@ import com.rushcrew.user_service.user.application.command.UserCreateCommand;
 import com.rushcrew.user_service.user.application.command.UserUpdateCommand;
 import com.rushcrew.user_service.user.application.command.VerifyPasswordCommand;
 import com.rushcrew.user_service.user.application.result.UserCreateResult;
+import com.rushcrew.user_service.user.application.result.UserInfoResult;
 import com.rushcrew.user_service.user.application.result.UserResult;
 import com.rushcrew.user_service.user.application.result.VerifyPasswordResult;
 import com.rushcrew.user_service.user.domain.entity.User;
@@ -71,6 +72,16 @@ public class UserService {
             user.getUserId(),
             user.getEmail(),
             user.getName()
+        );
+    }
+
+    public UserInfoResult getUserById(Long userId) {
+        User user = userRepository.getById(userId);
+
+        return new UserInfoResult(
+            user.getUserId(),
+            user.getName(),
+            user.getRole().name()
         );
     }
 

--- a/user-service/src/main/java/com/rushcrew/user_service/user/application/result/UserInfoResult.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/application/result/UserInfoResult.java
@@ -1,0 +1,7 @@
+package com.rushcrew.user_service.user.application.result;
+
+public record UserInfoResult(
+    Long userId,
+    String name,
+    String role
+) {}

--- a/user-service/src/main/java/com/rushcrew/user_service/user/presentation/UserController.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/presentation/UserController.java
@@ -5,12 +5,14 @@ import com.rushcrew.user_service.user.application.command.UserCreateCommand;
 import com.rushcrew.user_service.user.application.command.UserUpdateCommand;
 import com.rushcrew.user_service.user.application.command.VerifyPasswordCommand;
 import com.rushcrew.user_service.user.application.result.UserCreateResult;
+import com.rushcrew.user_service.user.application.result.UserInfoResult;
 import com.rushcrew.user_service.user.application.result.UserResult;
 import com.rushcrew.user_service.user.application.result.VerifyPasswordResult;
 import com.rushcrew.user_service.user.presentation.dto.request.UserCreateRequest;
 import com.rushcrew.user_service.user.presentation.dto.request.UserUpdateRequest;
 import com.rushcrew.user_service.user.presentation.dto.request.VerifyPasswordRequest;
 import com.rushcrew.user_service.user.presentation.dto.response.UserCreateResponse;
+import com.rushcrew.user_service.user.presentation.dto.response.UserInfoResponse;
 import com.rushcrew.user_service.user.presentation.dto.response.UserResponse;
 import com.rushcrew.user_service.user.presentation.dto.response.VerifyPasswordResponse;
 import jakarta.validation.Valid;
@@ -18,6 +20,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -74,5 +77,12 @@ public class UserController {
         userService.updateUser(command);
 
         return ResponseEntity.ok().build();
+    }
+    @GetMapping("/internal/users/{userId}")
+    public ResponseEntity<UserInfoResponse> getUserById(
+        @PathVariable Long userId
+    ) {
+        UserInfoResult result = userService.getUserById(userId);
+        return ResponseEntity.ok(UserInfoResponse.fromResult(result));
     }
 }

--- a/user-service/src/main/java/com/rushcrew/user_service/user/presentation/dto/response/UserInfoResponse.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/presentation/dto/response/UserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.rushcrew.user_service.user.presentation.dto.response;
+
+import com.rushcrew.user_service.user.application.result.UserInfoResult;
+
+public record UserInfoResponse(
+    Long userId,
+    String name,
+    String role
+) {
+    public static UserInfoResponse fromResult(UserInfoResult result) {
+        return new UserInfoResponse(
+            result.userId(),
+            result.name(),
+            result.role()
+        );
+    }
+}


### PR DESCRIPTION
## 🧾 Summary

### 로그아웃
1. 클라이언트 → `POST /api/v1/auth/logout` (Access Token + Refresh Token 쿠키)
2. Refresh Token Redis 삭제 + Access Token 블랙리스트 등록 (TTL: 토큰 만료까지)
3. Refresh Token 쿠키 만료 처리

### 전체 로그아웃
1. 클라이언트 → `POST /api/v1/auth/logout/all` (User ID + Access Token)
2. 해당 유저의 모든 Refresh Token 삭제
3. 현재 Access Token + User ID 블랙리스트 등록 → 모든 토큰 무효화

### 토큰 갱신
1. 클라이언트 → `POST /api/v1/auth/token/refresh` (Refresh Token 쿠키)
2. Redis에서 Refresh Token 검증 (존재 여부 + 만료 확인)
3. User Service 호출 → 최신 사용자 정보 조회 (Feign Client)
4. 새 Access Token 발급 (최신 정보 반영) → 응답 반환

### 블랙리스트
- **Token 블랙리스트**: `blacklist:token:{token}` (단일 로그아웃)
- **User 블랙리스트**: `blacklist:user:{userId}` (전체 로그아웃)
- Redis TTL 자동 만료 (토큰 만료 시간과 동일)


### User Service 연동
- `GET /api/v1/users/internal/users/{userId}` 내부 API 추가
- Auth Service → Feign Client → User Service (사용자 정보 조회)
- 토큰 갱신 시 최신 role, name 반영

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #89 
