### PR TITLE
Feat(user): API Gateway 인증 연동 및 SecurityContext 적용

### DIFF
--- a/user-service/src/main/java/com/rushcrew/user_service/global/security/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/global/security/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.rushcrew.user_service.global.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -9,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
     @Bean

--- a/user-service/src/main/java/com/rushcrew/user_service/global/security/filter/AuthorizationFilter.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/global/security/filter/AuthorizationFilter.java
@@ -1,0 +1,67 @@
+package com.rushcrew.user_service.global.security.filter;
+
+import com.rushcrew.user_service.global.security.model.UserDetailsImpl;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+// Spring Security 필터 체인에 자동으로 추가됨
+@Slf4j
+@Component
+// OncePerRequestFilter를 상속받아 하나의 요청당 한 번만 필터가 실행되도록 보장
+public class AuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_NAME_HEADER = "X-User-Email";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    // 실제 필터링 로직을 구현하는 메서드
+    @Override
+    protected void doFilterInternal(
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        String userId = request.getHeader(USER_ID_HEADER);
+        String userName = request.getHeader(USER_NAME_HEADER);
+        String role = request.getHeader(USER_ROLE_HEADER);
+
+        if (userId == null || userName == null || role == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 헤더에서 추출한 정보로 Spring Security의 UserDetails 객체 생성
+        UserDetailsImpl userDetails = new UserDetailsImpl(
+            Long.valueOf(userId),
+            userName,
+            role
+        );
+
+        // UserDetails를 Spring Security의 인증 객체로 변환
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+            );
+
+        // 인증 객체에 HTTP 요청의 세부 정보(IP, 세션 ID 등)를 추가
+        authentication.setDetails(
+            new WebAuthenticationDetailsSource().buildDetails(request)
+        );
+        // 현재 스레드의 SecurityContext에 인증 정보를 저장
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/user-service/src/main/java/com/rushcrew/user_service/global/security/model/UserDetailsImpl.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/global/security/model/UserDetailsImpl.java
@@ -1,0 +1,28 @@
+package com.rushcrew.user_service.global.security.model;
+
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public record UserDetailsImpl(
+    Long userId,
+    String email,
+    String role
+) implements UserDetails {
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "ROLE_" + role);
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return "";
+    }
+}

--- a/user-service/src/main/java/com/rushcrew/user_service/user/application/UserService.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/application/UserService.java
@@ -3,6 +3,7 @@ package com.rushcrew.user_service.user.application;
 import com.rushcrew.user_service.user.application.command.UserCreateCommand;
 import com.rushcrew.user_service.user.application.command.UserUpdateCommand;
 import com.rushcrew.user_service.user.application.command.VerifyPasswordCommand;
+import com.rushcrew.user_service.user.application.result.UserAllResult;
 import com.rushcrew.user_service.user.application.result.UserCreateResult;
 import com.rushcrew.user_service.user.application.result.UserInfoResult;
 import com.rushcrew.user_service.user.application.result.UserResult;
@@ -11,6 +12,7 @@ import com.rushcrew.user_service.user.domain.entity.User;
 import com.rushcrew.user_service.user.domain.enums.UserRole;
 import com.rushcrew.user_service.user.domain.repository.UserRepository;
 import com.rushcrew.user_service.user.domain.service.UserValidator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -92,5 +94,12 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(command.password());
 
         user.updateUser(encodedPassword, command.name());
+    }
+
+    public List<UserAllResult> getAllUsers() {
+        return userRepository.getAll()
+            .stream()
+            .map(UserAllResult::fromDomain)
+            .toList();
     }
 }

--- a/user-service/src/main/java/com/rushcrew/user_service/user/application/result/UserAllResult.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/application/result/UserAllResult.java
@@ -1,0 +1,19 @@
+package com.rushcrew.user_service.user.application.result;
+
+import com.rushcrew.user_service.user.domain.entity.User;
+
+public record UserAllResult(
+    Long userId,
+    String email,
+    String name,
+    String role
+) {
+    public static UserAllResult fromDomain(User user) {
+        return new UserAllResult(
+            user.getUserId(),
+            user.getEmail(),
+            user.getName(),
+            user.getRole().name()
+        );
+    }
+}

--- a/user-service/src/main/java/com/rushcrew/user_service/user/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/domain/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.rushcrew.user_service.user.domain.repository;
 
 import com.rushcrew.user_service.user.domain.entity.User;
+import java.util.List;
 
 public interface UserRepository {
 
@@ -11,4 +12,6 @@ public interface UserRepository {
     User getByEmail(String email);
 
     User save(User user);
+
+    List<User> getAll();
 }

--- a/user-service/src/main/java/com/rushcrew/user_service/user/infrastructure/repository/UserRepositoryImpl.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/infrastructure/repository/UserRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.rushcrew.user_service.user.infrastructure.repository;
 
 import com.rushcrew.user_service.user.domain.entity.User;
 import com.rushcrew.user_service.user.domain.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -31,5 +32,10 @@ public class UserRepositoryImpl implements UserRepository {
     public User getById(Long id) {
         return userJpaRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("해당하는 유저가 존재하지 않습니다"));
+    }
+
+    @Override
+    public List<User> getAll() {
+        return userJpaRepository.findAll();
     }
 }

--- a/user-service/src/main/java/com/rushcrew/user_service/user/presentation/UserController.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/presentation/UserController.java
@@ -11,14 +11,17 @@ import com.rushcrew.user_service.user.application.result.VerifyPasswordResult;
 import com.rushcrew.user_service.user.presentation.dto.request.UserCreateRequest;
 import com.rushcrew.user_service.user.presentation.dto.request.UserUpdateRequest;
 import com.rushcrew.user_service.user.presentation.dto.request.VerifyPasswordRequest;
+import com.rushcrew.user_service.user.presentation.dto.response.UserAllResponse;
 import com.rushcrew.user_service.user.presentation.dto.response.UserCreateResponse;
 import com.rushcrew.user_service.user.presentation.dto.response.UserInfoResponse;
 import com.rushcrew.user_service.user.presentation.dto.response.UserResponse;
 import com.rushcrew.user_service.user.presentation.dto.response.VerifyPasswordResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -78,11 +81,24 @@ public class UserController {
 
         return ResponseEntity.ok().build();
     }
+
     @GetMapping("/internal/users/{userId}")
     public ResponseEntity<UserInfoResponse> getUserById(
         @PathVariable Long userId
     ) {
         UserInfoResult result = userService.getUserById(userId);
         return ResponseEntity.ok(UserInfoResponse.fromResult(result));
+    }
+
+    @GetMapping("/all")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<List<UserAllResponse>> getAllUsers(
+    ) {
+        List<UserAllResponse> response = userService.getAllUsers()
+            .stream()
+            .map(UserAllResponse::fromResult)
+            .toList();
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/user-service/src/main/java/com/rushcrew/user_service/user/presentation/dto/response/UserAllResponse.java
+++ b/user-service/src/main/java/com/rushcrew/user_service/user/presentation/dto/response/UserAllResponse.java
@@ -1,0 +1,19 @@
+package com.rushcrew.user_service.user.presentation.dto.response;
+
+import com.rushcrew.user_service.user.application.result.UserAllResult;
+
+public record UserAllResponse(
+    Long userId,
+    String email,
+    String name,
+    String role
+) {
+    public static UserAllResponse fromResult(UserAllResult result) {
+        return new UserAllResponse(
+            result.userId(),
+            result.email(),
+            result.name(),
+            result.role()
+        );
+    }
+}


### PR DESCRIPTION
## 🧾 Summary
- Gateway로부터 전달되는 사용자 헤더를 기반으로 인증 객체를 구성하는 AuthorizationFilter를 추가
- Spring Security에서 사용할 사용자 정보를 표현하기 위해 UserDetailsImpl을 도입

## 구현 내용
### 1. UserDetailsImpl 추가
- getAuthorities()에서 role에 ROLE_ prefix 자동 적용

### 2. AuthorizationFilter 구현
- OncePerRequestFilter 상속으로 요청당 1회 실행 보장
- 아래 헤더 값을 기반으로 인증 객체 생성
  - X-User-Id
  - X-User-Email
  - X-User-Role
- SecurityContextHolder에 인증 정보 저장

### 3. API 추가
- Spring Security 인증 컨텍스트 기반 user 정보 조회 API 구현

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #104 

