### PR TITLE
Feat(order): 주문 서비스 도메인 계층 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     container_name: rushdeal_kafka_ui
     platform: linux/amd64
     ports:
-      - "8080:8080"
+      - "18080:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/enums/OrderEventType.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/enums/OrderEventType.java
@@ -1,0 +1,21 @@
+package com.rushcrew.order_service.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderEventType {
+	ORDER_CREATED("주문 생성"),
+	SHIPPING_INFO_UPDATED("배송지 정보 수정"),
+	PAYMENT_COMPLETED("결제 완료"),
+	PURCHASE_CONFIRMED("구매 확정"),
+	CANCELLED_BEFORE_PAYMENT("결제 전 취소"),
+	CANCELLED_AFTER_PAYMENT("결제 후 취소"),
+	REFUNDED("구매확정 후 환불"),
+	POINT_USAGE_UPDATED("포인트 사용량 수정"),
+	POINT_DEDUCTION_FAILED("포인트 차감 실"),
+	PAYMENT_FAILED("결제 실패");
+
+	private final String description;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/enums/OrderStatus.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/enums/OrderStatus.java
@@ -1,0 +1,129 @@
+package com.rushcrew.order_service.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum OrderStatus {
+	PENDING("결제 대기"),
+	PAID("결제 완료"),
+	PURCHASE_CONFIRMED("구매 확정"),
+	CANCELLED("취소"),
+	REFUNDED("환불");
+
+	private final String description;
+
+	OrderStatus(String description) {
+		this.description = description;
+	}
+
+	// ============================================
+	//              상태 전이 검증 로직
+	// ============================================
+
+	public void validateCanPay() {
+		if (this != PENDING) {
+			throw new IllegalStateException(
+				"결제는 PENDING 상태에서만 가능합니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateCanCancelBeforePayment() {
+		if (this != PENDING) {
+			throw new IllegalStateException(
+				"결제 전 주문 취소는 PENDING 상태에서만 가능합니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateCanCancelAfterPayment() {
+		if (this != PAID) {
+			throw new IllegalStateException(
+				"결제 후 주문 취소는 PAID 상태에서만 가능합니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateCanRefund() {
+		if (this != PURCHASE_CONFIRMED) {
+			throw new IllegalStateException(
+				"환불은 PURCHASE_CONFIRMED 상태에서만 가능합니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateCanConfirmPurchase() {
+		if (this != PAID) {
+			throw new IllegalStateException(
+				"구매확정은 PAID 상태에서만 가능합니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateCanUpdateShippingInfo() {
+		if (this != PENDING && this != PAID) {
+			throw new IllegalStateException(
+				"배송지 정보는 PENDING 또는 PAID 상태에서만 수정할 수 있습니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateCanUpdatePointUsed() {
+		if (this != PENDING) {
+			throw new IllegalStateException(
+				"포인트 사용량은 PENDING 상태에서만 수정할 수 있습니다. (현재 상태: %s)".formatted(this)
+			);
+		}
+	}
+
+	public void validateTransition(OrderStatus targetStatus) {
+		if (!isValidTransition(targetStatus)) {
+			throw new IllegalStateException(
+				"상태 전이 불가: %s → %s".formatted(this, targetStatus)
+			);
+		}
+	}
+
+
+	// ============================================
+	//               상태 검증 boolean
+	// ============================================
+
+	public boolean canPay() {
+		return this == PENDING;
+	}
+
+	public boolean canCancelBeforePayment() {
+		return this == PENDING;
+	}
+
+	public boolean canCancelAfterPayment() {
+		return this == PAID;
+	}
+
+	public boolean canRefund() {
+		return this == PURCHASE_CONFIRMED;
+	}
+
+	public boolean canConfirmPurchase() {
+		return this == PAID;
+	}
+
+	public boolean canUpdateShippingInfo() {
+		return this == PENDING || this == PAID;
+	}
+
+	public boolean canUpdatePointUsed() {
+		return this == PENDING;
+	}
+
+	private boolean isValidTransition(OrderStatus targetStatus) {
+		return switch (this) {
+			case PENDING -> targetStatus == PAID || targetStatus == CANCELLED;
+			case PAID -> targetStatus == PURCHASE_CONFIRMED || targetStatus == CANCELLED;
+			case PURCHASE_CONFIRMED -> targetStatus == REFUNDED;
+			case CANCELLED, REFUNDED -> false;
+		};
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/enums/ReservationStatus.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/enums/ReservationStatus.java
@@ -1,0 +1,15 @@
+package com.rushcrew.order_service.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReservationStatus {
+	RESERVED("예약됨"),
+	CONFIRMED("확정됨"),
+	EXPIRED("만료됨"),
+	CANCELLED("취소됨");
+
+	private final String description;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/enums/SagaStatus.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/enums/SagaStatus.java
@@ -1,0 +1,9 @@
+package com.rushcrew.order_service.domain.enums;
+
+public enum SagaStatus {
+	RUNNING,        // 실행 중
+	COMPLETED,      // 완료
+	FAILED,         // 실패
+	COMPENSATING,   // 보상 트랜잭션 실행 중
+	COMPENSATED     // 보상 완료
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/Order.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/Order.java
@@ -1,0 +1,309 @@
+package com.rushcrew.order_service.domain.model.order;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.order_service.domain.enums.OrderEventType;
+import com.rushcrew.order_service.domain.enums.OrderStatus;
+import com.rushcrew.order_service.domain.vo.OrderAmount;
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_order", schema = "order_schema")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class Order extends BaseEntity {
+
+	@Id
+	private UUID orderId;
+
+	@Column(nullable = false)
+	private Long userId;
+
+	@Embedded
+	private OrderAmount amount;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private OrderStatus status;
+
+	@Embedded
+	private ShippingInfo shippingInfo; // 현재 배송 서비스가 없어서 Embeddable 사용 --> 추후 배송 서비스를 독립적으로 개발하게 되면, 그때 ShippingInfo 테이블 분리 + Order에서 deliveryId 참조로 리팩토링
+
+	@Column(nullable = false)
+	private Instant orderedAt;
+
+	private Instant paymentCompletedAt;
+
+	private Instant purchaseConfirmedAt;
+
+	private Instant autoConfirmScheduledAt;
+
+	private Instant cancelledAt;
+
+	private Instant refundedAt;
+
+	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<OrderItem> orderItems = new ArrayList<>();
+
+	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<OrderReservation> reservations = new ArrayList<>();
+
+	@OneToMany(mappedBy = "order", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+	@Builder.Default
+	private List<OrderHistory> histories = new ArrayList<>();
+
+
+
+	// ============================================
+	//                 도메인 로직
+	// ============================================
+
+	public static Order create(
+		Long userId,
+		List<OrderItem> orderItems,
+		BigDecimal pointUsed,
+		ShippingInfo shippingInfo
+	) {
+		BigDecimal totalAmount = orderItems.stream()
+			.map(OrderItem::getSubtotal)
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+
+		OrderAmount amount = OrderAmount.create(totalAmount, pointUsed);
+
+		Order order = Order.builder()
+			.orderId(UUID.randomUUID())
+			.userId(userId)
+			.amount(amount)
+			.status(OrderStatus.PENDING)
+			.shippingInfo(shippingInfo)
+			.orderedAt(Instant.now())
+			.build();
+
+		orderItems.forEach(order::addOrderItem);
+		order.addHistory(
+			OrderEventType.ORDER_CREATED,
+			null,
+			OrderStatus.PENDING,
+			OrderStatus.PENDING.getDescription());
+
+		return order;
+	}
+
+	public void updateShippingInfo(ShippingInfo newShippingInfo) {
+		this.status.validateCanUpdateShippingInfo();
+		newShippingInfo.validate();
+		this.shippingInfo = newShippingInfo;
+		addHistory(
+			OrderEventType.SHIPPING_INFO_UPDATED,
+			status,
+			status,
+			OrderEventType.SHIPPING_INFO_UPDATED.getDescription()
+		);
+	}
+
+	// 포인트 사용량 수정 (PENDING 상태에서만 가능 - 결제 전)
+	public void updatePointUsed(BigDecimal newPointUsed) {
+		this.status.validateCanUpdatePointUsed();
+		BigDecimal oldPointUsed = this.amount.getPointUsed();
+		this.amount = this.amount.updatePointUsed(newPointUsed);
+		addHistory(
+			OrderEventType.POINT_USAGE_UPDATED,
+			status,
+			status,
+			"포인트 사용량 변경: %s --> %s".formatted(oldPointUsed, newPointUsed)
+		);
+	}
+
+	// 포인트 차감 실패 이력 기록
+	public void recordPointDeductionFailed(String reason) {
+		addHistory(
+			OrderEventType.POINT_DEDUCTION_FAILED,
+			this.status,
+			this.status,  // 상태는 PENDING 유지
+			reason
+		);
+	}
+
+	// 결제 전 주문 취소
+	public void cancelBeforePayment(String reason) {
+		this.status.validateCanCancelBeforePayment();
+		this.status.validateTransition(OrderStatus.CANCELLED);
+		OrderStatus previousStatus = this.status;
+		this.status = OrderStatus.CANCELLED;
+		this.cancelledAt = Instant.now();
+		addHistory(
+			OrderEventType.CANCELLED_BEFORE_PAYMENT,
+			previousStatus,
+			OrderStatus.CANCELLED,
+			reason != null ? reason : OrderStatus.CANCELLED.getDescription()
+		);
+	}
+
+	// 결제 후 주문 취소 (구매확정 전)
+	public void cancelAfterPayment(String reason) {
+		this.status.validateCanCancelAfterPayment();
+		this.status.validateTransition(OrderStatus.CANCELLED);
+		OrderStatus previousStatus = this.status;
+		this.status = OrderStatus.CANCELLED;
+		this.cancelledAt = Instant.now();
+		addHistory(
+			OrderEventType.CANCELLED_AFTER_PAYMENT,
+			previousStatus,
+			OrderStatus.CANCELLED,
+			reason != null ? reason : OrderStatus.CANCELLED.getDescription()
+		);
+	}
+
+	// 환불 (구매확정 후)
+	public void refund(String reason) {
+		this.status.validateCanRefund();
+		this.status.validateTransition(OrderStatus.REFUNDED);
+		OrderStatus previousStatus = this.status;
+		this.status = OrderStatus.REFUNDED;
+		this.refundedAt = Instant.now();
+		addHistory(
+			OrderEventType.REFUNDED,
+			previousStatus,
+			OrderStatus.REFUNDED,
+			reason != null ? reason : OrderStatus.REFUNDED.getDescription()
+		);
+	}
+
+	public void completePayment() {
+		this.status.validateCanPay();
+		this.status.validateTransition(OrderStatus.PAID);
+		OrderStatus previousStatus = this.status;
+		this.status = OrderStatus.PAID;
+		this.paymentCompletedAt = Instant.now();
+		// 7일 후 자동 구매확정 예약
+		this.autoConfirmScheduledAt = this.paymentCompletedAt.plus(7, ChronoUnit.DAYS);
+		addHistory(
+			OrderEventType.PAYMENT_COMPLETED,
+			previousStatus,
+			OrderStatus.PAID,
+			OrderStatus.PAID.getDescription()
+		);
+	}
+
+	public void confirmPurchase() {
+		confirmPurchase(OrderStatus.PURCHASE_CONFIRMED.getDescription());
+	}
+
+	/**
+	 * 구매확정 (이유 지정 가능 - 자동 구매확정용)
+	 */
+	public void confirmPurchase(String reason) {
+		this.status.validateCanConfirmPurchase();
+		this.status.validateTransition(OrderStatus.PURCHASE_CONFIRMED);
+		OrderStatus previousStatus = this.status;
+		this.status = OrderStatus.PURCHASE_CONFIRMED;
+		this.purchaseConfirmedAt = Instant.now();
+		addHistory(
+			OrderEventType.PURCHASE_CONFIRMED,
+			previousStatus,
+			OrderStatus.PURCHASE_CONFIRMED,
+			reason != null ? reason : OrderStatus.PURCHASE_CONFIRMED.getDescription()
+		);
+	}
+
+	private void addOrderItem(OrderItem orderItem) {
+		this.orderItems.add(orderItem);
+		orderItem.assignOrder(this);
+	}
+
+	public void addReservation(OrderReservation reservation) {
+		this.reservations.add(reservation);
+		reservation.assignOrder(this);
+	}
+
+	private void addHistory(OrderEventType eventType, OrderStatus previousStatus, OrderStatus newStatus, String reason) {
+		OrderHistory history = OrderHistory.create(
+			this,
+			eventType,
+			previousStatus,
+			newStatus,
+			reason
+		);
+		this.histories.add(history);
+	}
+
+	public boolean isOwnedBy(Long userId) {
+		return this.userId.equals(userId);
+	}
+
+
+	// ============================================
+	//       주문 상태 검증 (행위 가능 여부 판단)
+	// ============================================
+
+	public boolean canPay() {
+		return this.status.canPay();
+	}
+
+	public boolean canCancelBeforePayment() {
+		return this.status.canCancelBeforePayment();
+	}
+
+	public boolean canCancelAfterPayment() {
+		return this.status.canCancelAfterPayment();
+	}
+
+	public boolean canRefund() {
+		return this.status.canRefund();
+	}
+
+	public boolean canConfirmPurchase() {
+		return this.status.canConfirmPurchase();
+	}
+
+	public boolean canUpdateShippingInfo() {
+		return this.status.canUpdateShippingInfo();
+	}
+
+	public boolean canUpdatePointUsed() {
+		return this.status.canUpdatePointUsed();
+	}
+
+
+	// ============================================
+	//         편의 메서드 (OrderAmount 위임)
+	// ============================================
+
+	public BigDecimal getTotalAmount() {
+		return amount.getTotalAmount();
+	}
+
+	public BigDecimal getPointUsed() {
+		return amount.getPointUsed();
+	}
+
+	public BigDecimal getFinalAmount() {
+		return amount.getFinalAmount();
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/OrderHistory.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/OrderHistory.java
@@ -1,0 +1,107 @@
+package com.rushcrew.order_service.domain.model.order;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.hibernate.annotations.Type;
+
+import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.order_service.domain.enums.OrderEventType;
+import com.rushcrew.order_service.domain.enums.OrderStatus;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_order_history", schema = "order_schema")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class OrderHistory extends BaseEntity {
+
+	@Id
+	private UUID orderHistoryId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 50)
+	private OrderEventType eventType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 20)
+	private OrderStatus previousStatus;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private OrderStatus newStatus;
+
+	@Column(columnDefinition = "TEXT")
+	private String reason;
+
+	@Type(JsonBinaryType.class)
+	@Column(columnDefinition = "jsonb")
+	private Map<String, Object> metadata;
+
+	// ============================================
+	//                 도메인 로직
+	// ============================================
+
+	public static OrderHistory create(
+		Order order,
+		OrderEventType eventType,
+		OrderStatus previousStatus,
+		OrderStatus newStatus,
+		String reason
+	) {
+		if (order == null) {
+			throw new IllegalArgumentException("주문 정보는 필수입니다.");
+		}
+		if (eventType == null) {
+			throw new IllegalArgumentException("이벤트 타입은 필수입니다.");
+		}
+		if (newStatus == null) {
+			throw new IllegalArgumentException("새 상태는 필수입니다.");
+		}
+
+		return OrderHistory.builder()
+			.orderHistoryId(UUID.randomUUID())
+			.order(order)
+			.eventType(eventType)
+			.previousStatus(previousStatus)
+			.newStatus(newStatus)
+			.reason(reason)
+			.build();
+	}
+
+	// 메타데이터를 포함하는 주문 이력 생성
+	public static OrderHistory createWithMetadata(
+		Order order,
+		OrderEventType eventType,
+		OrderStatus previousStatus,
+		OrderStatus newStatus,
+		String reason,
+		Map<String, Object> metadata
+	) {
+		OrderHistory history = create(order, eventType, previousStatus, newStatus, reason);
+		history.metadata = metadata;
+		return history;
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/OrderItem.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/OrderItem.java
@@ -1,0 +1,136 @@
+package com.rushcrew.order_service.domain.model.order;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+
+import org.hibernate.annotations.Type;
+
+import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.order_service.domain.vo.ProductSnapshot;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_order_item", schema = "order_schema")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class OrderItem extends BaseEntity {
+
+	@Id
+	private UUID orderItemId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@Column(nullable = false)
+	private UUID timeDealStockId;
+
+	@Column(nullable = false)
+	private Integer quantity;
+
+	@Column(nullable = false, precision = 12, scale = 2)
+	private BigDecimal unitPrice; // 상품 원가
+
+	@Column(nullable = false, precision = 12, scale = 2)
+	private BigDecimal discountPrice; // 타임딜 할인가 (실제 판매가)
+
+	@Column(nullable = false, precision = 12, scale = 2)
+	private BigDecimal subtotal;
+
+	// ★ 새로 추가되는 필드 (쿼리용)
+	@Column(nullable = false)
+	private UUID timeDealId;
+
+	@Type(JsonBinaryType.class)
+	@Column(columnDefinition = "jsonb", nullable = false)
+	private ProductSnapshot productSnapshot;
+
+
+	// ============================================
+	//                 도메인 로직
+	// ============================================
+
+	public static OrderItem create(
+		UUID timeDealStockId,
+		Integer quantity,
+		BigDecimal unitPrice,
+		BigDecimal discountPrice,
+		ProductSnapshot productSnapshot
+	) {
+		if (quantity == null || quantity <= 0) {
+			throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
+		}
+		if (unitPrice == null || unitPrice.compareTo(BigDecimal.ZERO) <= 0) {
+			throw new IllegalArgumentException("상품 가격은 0보다 커야 합니다.");
+		}
+		if (discountPrice == null || discountPrice.compareTo(BigDecimal.ZERO) < 0) {
+			throw new IllegalArgumentException("할인가는 0 이상이어야 합니다.");
+		}
+		if (discountPrice.compareTo(unitPrice) > 0) {
+			throw new IllegalArgumentException(
+				"할인가[%S] 는 원가[%s] 보다 클 수 없습니다.".formatted(discountPrice, unitPrice)
+			);
+		}
+
+		BigDecimal subtotal = discountPrice.multiply(BigDecimal.valueOf(quantity));
+
+		return OrderItem.builder()
+			.orderItemId(UUID.randomUUID())
+			.timeDealStockId(timeDealStockId)
+			.quantity(quantity)
+			.unitPrice(unitPrice)
+			.discountPrice(discountPrice)
+			.subtotal(subtotal)
+			.timeDealId(productSnapshot.timeDealId())
+			.productSnapshot(productSnapshot)
+			.build();
+	}
+
+	// 주문 연관 관계 설정
+	void assignOrder(Order order) {
+		this.order = order;
+	}
+
+	public String getProductName() {
+		return productSnapshot != null ? productSnapshot.productName() : null;
+	}
+
+	public String getProductDescription() {
+		return productSnapshot != null ? productSnapshot.productDescription() : null;
+	}
+
+	// 할인율
+	public BigDecimal getDiscountRate() {
+		if (unitPrice.compareTo(BigDecimal.ZERO) == 0) {
+			return BigDecimal.ZERO;
+		}
+		// (원가 - 할인가) / 원가 x 100
+		BigDecimal discount = unitPrice.subtract(discountPrice);
+		return discount
+			.divide(unitPrice, 2, RoundingMode.HALF_UP)
+			.multiply(BigDecimal.valueOf(100));
+	}
+
+	// 할인 금액
+	public BigDecimal getTotalDiscount() {
+		// (원가 - 할인가) x 수량
+		return unitPrice.subtract(discountPrice).multiply(BigDecimal.valueOf(quantity));
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/OrderReservation.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/model/order/OrderReservation.java
@@ -1,0 +1,114 @@
+package com.rushcrew.order_service.domain.model.order;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.order_service.domain.enums.ReservationStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_order_reservation", schema = "order_schema")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class OrderReservation extends BaseEntity {
+
+	@Id
+	private UUID orderReservationId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "order_id", nullable = false)
+	private Order order;
+
+	@Column(name = "time_deal_stock_id", nullable = false)
+	private UUID timeDealStockId;
+
+	@Column(nullable = false)
+	private Integer quantity;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private ReservationStatus status;
+
+	@Column(nullable = false)
+	private Instant reservedAt;
+
+	@Column(nullable = false)
+	private Instant expiresAt;
+
+	private Instant confirmedAt;
+
+	private Instant releasedAt;
+
+
+	// ============================================
+	//                 도메인 로직
+	// ============================================
+
+	// 예약 생성 (15분 TTL)
+	public static OrderReservation create(UUID timeDealStockId, Integer quantity) {
+		return OrderReservation.builder()
+			.orderReservationId(UUID.randomUUID())
+			.timeDealStockId(timeDealStockId)
+			.quantity(quantity)
+			.status(ReservationStatus.RESERVED)
+			.reservedAt(Instant.now())
+			.expiresAt(Instant.now().plus(15, ChronoUnit.MINUTES)) // 15분 TTL
+			.build();
+	}
+
+	// 결제 완료 시 예약 확정
+	public void confirm() {
+		if (this.status != ReservationStatus.RESERVED) {
+			throw new IllegalStateException("RESERVED 상태에서만 확정할 수 있습니다.");
+		}
+		this.status = ReservationStatus.CONFIRMED;
+		this.confirmedAt = Instant.now();
+	}
+
+	// 15분 경과 시 예약 만료
+	public void expire() {
+		if (this.status != ReservationStatus.RESERVED) {
+			throw new IllegalStateException("RESERVED 상태에서만 만료 처리할 수 있습니다.");
+		}
+		this.status = ReservationStatus.EXPIRED;
+		this.releasedAt = Instant.now();
+	}
+
+	// 주문 취소 시 예약 취소
+	public void cancel() {
+		if (this.status != ReservationStatus.RESERVED) {
+			throw new IllegalStateException("RESERVED 상태에서만 취소할 수 있습니다.");
+		}
+		this.status = ReservationStatus.CANCELLED;
+		this.releasedAt = Instant.now();
+	}
+
+	// 예약 만료 여부 확인
+	public boolean isExpired() {
+		return Instant.now().isAfter(expiresAt);
+	}
+
+	// 주문 연관 관계 설정
+	public void assignOrder(Order order) {
+		this.order = order;
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/model/saga/SagaInstance.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/model/saga/SagaInstance.java
@@ -1,0 +1,77 @@
+package com.rushcrew.order_service.domain.model.saga;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "p_saga_instance", schema = "order_schema")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SagaInstance {
+
+	@Id
+	private UUID sagaId;
+
+	@Column(nullable = false, length = 50)
+	private String sagaType;
+
+	@Column(nullable = false)
+	private Long userId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private SagaStatus status;
+
+	@Column(nullable = false)
+	private Instant createdAt;
+
+	private Instant completedAt;
+
+	private Instant failedAt;
+
+	@Column(columnDefinition = "TEXT")
+	private String errorMessage;
+
+	@OneToMany(mappedBy = "sagaInstance", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<SagaStep> steps = new ArrayList<>();
+
+	public static SagaInstance create(String sagaType, Long userId) {
+		return SagaInstance.builder()
+			.sagaId(UUID.randomUUID())
+			.sagaType(sagaType)
+			.userId(userId)
+			.status(SagaStatus.RUNNING)
+			.createdAt(Instant.now())
+			.build();
+	}
+
+	public void addStep(String stepName, SagaStatus status) {
+		SagaStep step = SagaStep.create(this, stepName, status);
+		this.steps.add(step);
+	}
+
+	public void complete() {
+		this.status = SagaStatus.COMPLETED;
+		this.completedAt = Instant.now();
+	}
+
+	public void fail(String errorMessage) {
+		this.status = SagaStatus.FAILED;
+		this.failedAt = Instant.now();
+		this.errorMessage = errorMessage;
+	}
+
+	public void startCompensation() {
+		this.status = SagaStatus.COMPENSATING;
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/model/saga/SagaStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/model/saga/SagaStep.java
@@ -1,0 +1,59 @@
+package com.rushcrew.order_service.domain.model.saga;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "p_saga_step", schema = "order_schema")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SagaStep {
+
+	@Id
+	private UUID sagaStepId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "saga_id", nullable = false)
+	private SagaInstance sagaInstance;
+
+	@Column(nullable = false, length = 50)
+	private String stepName;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private SagaStatus status;
+
+	private Instant executedAt;
+
+	private Instant compensatedAt;
+
+	@Column(columnDefinition = "TEXT")
+	private String errorMessage;
+
+	public static SagaStep create(SagaInstance sagaInstance, String stepName, SagaStatus status) {
+		return SagaStep.builder()
+			.sagaStepId(UUID.randomUUID())
+			.sagaInstance(sagaInstance)
+			.stepName(stepName)
+			.status(status)
+			.executedAt(Instant.now())
+			.build();
+	}
+
+	public void markAsCompensated() {
+		this.status = SagaStatus.COMPENSATED;
+		this.compensatedAt = Instant.now();
+	}
+
+	public void markAsFailed(String errorMessage) {
+		this.status = SagaStatus.FAILED;
+		this.errorMessage = errorMessage;
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/vo/OrderAmount.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/vo/OrderAmount.java
@@ -1,0 +1,80 @@
+package com.rushcrew.order_service.domain.vo;
+
+import java.math.BigDecimal;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * OrderAmount.class: 금액 관련 로직 (추후 할인, 쿠폰 등 금액 정책 생성 시 여기에 추가
+ * totalAmount: 총 주문 금액
+ * pointUsed: 사용한 포인트
+ * finalAmount: 최종 결제 금액
+ */
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderAmount {
+
+	@Column(nullable = false, precision = 12, scale = 2)
+	private BigDecimal totalAmount;
+
+	@Column(nullable = false, precision = 12, scale = 2)
+	private BigDecimal pointUsed;
+
+	@Column(nullable = false, precision = 12, scale = 2)
+	private BigDecimal finalAmount;
+
+
+	// ============================================
+	//                 도메인 로직
+	// ============================================
+
+	public static OrderAmount create(BigDecimal totalAmount, BigDecimal pointUsed) {
+		validate(totalAmount, pointUsed);
+		if (pointUsed.compareTo(totalAmount) > 0) {
+			throw new IllegalArgumentException(
+				"포인트 사용량은 주문 금액을 초과할 수 없습니다. (포인트: %s, 주문금액: %s)"
+					.formatted(pointUsed, totalAmount)
+			);
+		}
+		BigDecimal finalAmount = totalAmount.subtract(pointUsed);
+		if (finalAmount.compareTo(BigDecimal.ZERO) < 0) {
+			throw new IllegalArgumentException("최종 결제 금액은 0보다 작을 수 없습니다.");
+		}
+		return new OrderAmount(totalAmount, pointUsed, finalAmount);
+	}
+
+	public OrderAmount updatePointUsed(BigDecimal newPointUsed) {
+		if (newPointUsed == null || newPointUsed.compareTo(BigDecimal.ZERO) < 0) {
+			throw new IllegalArgumentException("포인트 사용량은 0 이상이어야 합니다.");
+		}
+		if (newPointUsed.compareTo(this.totalAmount) > 0) {
+			throw new IllegalArgumentException(
+				"포인트 사용량은 주문 금액을 초과할 수 없습니다. (포인트: %s, 주문금액: %s)"
+					.formatted(newPointUsed, this.totalAmount)
+			);
+		}
+		return create(this.totalAmount, newPointUsed);
+	}
+
+	private static void validate(BigDecimal totalAmount, BigDecimal pointUsed) {
+		if (totalAmount == null || totalAmount.compareTo(BigDecimal.ZERO) < 0) {
+			throw new IllegalArgumentException("주문 금액은 0 이상이어야 합니다.");
+		}
+		if (pointUsed == null || pointUsed.compareTo(BigDecimal.ZERO) < 0) {
+			throw new IllegalArgumentException("포인트 사용량은 0 이상이어야 합니다.");
+		}
+	}
+
+	// 포인트 사용 X
+	public static OrderAmount withoutPoint(BigDecimal totalAmount) {
+		return create(totalAmount, BigDecimal.ZERO);
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/vo/ProductSnapshot.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/vo/ProductSnapshot.java
@@ -1,0 +1,24 @@
+package com.rushcrew.order_service.domain.vo;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record ProductSnapshot(
+	UUID timeDealStockId,
+	UUID productId,
+	String productName,
+	String productDescription,
+	UUID optionId,
+	String optionName,
+	UUID sellerId,
+	String sellerName,
+	BigDecimal originalPrice,
+	UUID timeDealId,
+	String timeDealTitle,
+	Integer discountRate,
+	String category
+) implements Serializable {}

--- a/order-service/src/main/java/com/rushcrew/order_service/domain/vo/ShippingInfo.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/domain/vo/ShippingInfo.java
@@ -1,0 +1,69 @@
+package com.rushcrew.order_service.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ShippingInfo {
+
+	@Column(nullable = false, length = 50)
+	private String recipientName;
+
+	@Column(nullable = false, length = 20)
+	private String recipientPhone;
+
+	@Column(nullable = false, length = 10)
+	private String zipCode;
+
+	@Column(nullable = false, length = 255)
+	private String addressBase;
+
+	@Column(nullable = false, length = 255)
+	private String addressDetail;
+
+	@Column(length = 100)
+	private String deliveryMessage;
+
+	public static ShippingInfo create(String recipientName,
+		String recipientPhone,
+		String zipCode,
+		String addressBase,
+		String addressDetail,
+		String deliveryMessage) {
+		ShippingInfo info = new ShippingInfo(recipientName, recipientPhone, zipCode, addressBase, addressDetail, deliveryMessage);
+		info.validate(); // 생성 시 검증 수행
+		return info;
+	}
+
+	public void validate() {
+		if (recipientName == null || recipientName.isBlank()) {
+			throw new IllegalArgumentException("수령인 이름은 필수입니다.");
+		}
+
+		if (recipientPhone == null || !recipientPhone.matches("^01[0-9]{8,9}$")) {
+			throw new IllegalArgumentException("올바른 휴대폰 번호 형식이 아닙니다.");
+		}
+
+		if (zipCode == null || !zipCode.matches("^[0-9]{5}$")) {
+			throw new IllegalArgumentException("우편번호는 5자리 숫자여야 합니다.");
+		}
+
+		if (addressBase == null || addressBase.isBlank()) {
+			throw new IllegalArgumentException("기본 주소는 필수입니다.");
+		}
+
+		if (addressDetail == null || addressDetail.isBlank()) {
+			throw new IllegalArgumentException("상세 주소는 필수입니다.");
+		}
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/global/config/RedisConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/global/config/RedisConfig.java
@@ -1,0 +1,65 @@
+package com.rushcrew.order_service.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		// ObjectMapper 설정
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		// Key Serializer
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+
+		// Value Serializer
+		GenericJackson2JsonRedisSerializer serializer =
+			new GenericJackson2JsonRedisSerializer(objectMapper);
+		template.setValueSerializer(serializer);
+		template.setHashValueSerializer(serializer);
+
+		template.afterPropertiesSet();
+		return template;
+	}
+
+	@Bean
+	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofHours(1)) // 1시간 TTL
+			.serializeKeysWith(
+				RedisSerializationContext.SerializationPair
+					.fromSerializer(new StringRedisSerializer())
+			)
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair
+					.fromSerializer(new GenericJackson2JsonRedisSerializer())
+			);
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(config)
+			.build();
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/global/error/OrderErrorCode.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/global/error/OrderErrorCode.java
@@ -1,0 +1,56 @@
+package com.rushcrew.order_service.global.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.rushcrew.common.global.error.ErrorCode;
+
+public enum OrderErrorCode implements ErrorCode {
+
+	INVALID_QUEUE_TOKEN(HttpStatus.BAD_REQUEST, "INVALID_QUEUE_TOKEN", "유효한 대기열 토큰이 없습니다."),
+	INVALID_TIME_DEAL(HttpStatus.BAD_REQUEST, "INVALID_TIME_DEAL", "타임딜이 진행 중이 아닙니다."),
+	INVALID_PRODUCT(HttpStatus.BAD_REQUEST, "INVALID_PRODUCT", "존재하지 않거나 판매 중단된 상품입니다."),
+	DUPLICATE_ORDER_ITEM(HttpStatus.BAD_REQUEST, "DUPLICATE_ORDER_ITEM", "이미 장바구니에 담긴 상품입니다."),
+	PURCHASE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PURCHASE_LIMIT_EXCEEDED", "1인당 최대 구매 가능 수량을 초과했습니다."),
+	STOCK_DEPLETED(HttpStatus.CONFLICT, "STOCK_DEPLETED", "재고가 부족합니다."),
+	NOT_ENOUGH_POINTS(HttpStatus.BAD_REQUEST, "NOT_ENOUGH_POINTS", "포인트 잔액이 부족합니다."),
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORDER_NOT_FOUND", "주문을 찾을 수 없습니다."),
+	ORDER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ORDER_ACCESS_DENIED", "본인의 주문만 접근할 수 있습니다."),
+	ORDER_CANNOT_PAY(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_PAY", "결제 가능한 주문 상태가 아닙니다."),
+	ORDER_CANNOT_CONFIRM_PURCHASE(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_CONFIRM_PURCHASE", "구매확정 가능한 주문 상태가 아닙니다."),
+	ORDER_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_CANCEL", "취소 가능한 주문 상태가 아닙니다."),
+	ORDER_CANNOT_REFUND(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_REFUND", "환불 가능한 주문 상태가 아닙니다."),
+	PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_FAILED", "결제에 실패했습니다."),
+	INVALID_ORDER_STATE(HttpStatus.BAD_REQUEST, "INVALID_ORDER_STATE", "결제 가능한 주문 상태가 아닙니다."),
+	UNAUTHORIZED(HttpStatus.FORBIDDEN, "UNAUTHORIZED", "본인의 주문만 결제할 수 있습니다."),
+	RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "RESERVATION_EXPIRED", "재고 예약이 만료되었습니다. 주문을 다시 생성해주세요."),
+	SOLD_OUT_PRODUCT(HttpStatus.BAD_REQUEST, "SOLD_OUT_PRODUCT", "품절된 상품입니다."),
+	ORDER_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_UPDATE", "수정 가능한 주문 상태가 아닙니다."),
+	ORDER_CANNOT_UPDATE_POINT(HttpStatus.BAD_REQUEST, "ORDER_CANNOT_UPDATE_POINT", "포인트 사용량은 결제 전(PENDING 상태)에서만 수정할 수 있습니다."),
+	ORDER_UPDATE_TIME_EXPIRED(HttpStatus.BAD_REQUEST, "ORDER_UPDATE_TIME_EXPIRED", "주문 수정 가능 시간이 지났습니다."),
+	ORDER_UPDATE_NO_CHANGES(HttpStatus.BAD_REQUEST, "ORDER_UPDATE_NO_CHANGES", "수정할 항목이 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String name;
+	private final String message;
+
+	OrderErrorCode(HttpStatus httpStatus, String name, String message) {
+		this.httpStatus = httpStatus;
+		this.name = name;
+		this.message = message;
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+}


### PR DESCRIPTION
## 🧾 Summary
- model 구현
  - Order
  - OrderItem
  - OrderReservation
  - OrderHistory
  - SagaInstance     * 추가
  - SagaStep     * 추가
- enum 정의
  - OrderStatus
  - OrderEventType
  - ReservationStatus
  - SagaStatus     * 추가
- vo 구현
  - OrderAmount
  - ShippingInfo
  - ProductSnapshot 
- global 패키지
  -  config > RedisConfig
  - error > OrderErrorCode
 
## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #111 
