### PR TITLE
Feat(order) 주문 생성 기능 구현 + 단위 테스트

### DIFF
--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/CreateOrderCommand.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/CreateOrderCommand.java
@@ -1,0 +1,25 @@
+package com.rushcrew.order_service.application.command.dto.command;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+
+import lombok.Builder;
+
+@Builder
+public record CreateOrderCommand(
+	Long userId,
+	UUID timeDealId,
+	List<OrderItemCommand> orderItems,
+	BigDecimal pointUsed,
+	ShippingInfo shippingInfo
+) {
+
+	@Builder
+	public record OrderItemCommand(
+		UUID timeDealStockId,
+		Integer quantity
+	) {}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/CreateOrderResult.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/CreateOrderResult.java
@@ -1,0 +1,36 @@
+package com.rushcrew.order_service.application.command.dto.result;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record CreateOrderResult(
+	UUID orderId,
+	Long userId,
+	String orderStatus,
+	BigDecimal totalAmount,
+	BigDecimal pointUsed,
+	BigDecimal finalAmount,
+	Instant orderedAt,
+	Instant reservationExpiresAt,	// 예약 만료 시간: 15분 후
+	List<OrderItemResult> orderItems
+) {
+
+	@Builder
+	public record OrderItemResult(
+		UUID orderItemId,
+		UUID timeDealStockId,
+		UUID timeDealId,
+		UUID productId,
+		String productName,
+		String optionName,
+		Integer quantity,
+		BigDecimal unitPrice,
+		BigDecimal discountPrice,
+		BigDecimal subtotal
+	) {}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCachePort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCachePort.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.command.port.out;
+
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+
+public interface OrderCachePort {
+	/* 주문 생성 시, 주문 캐시 저장 */
+	void saveOrderCache(CreateOrderResult result);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCommandPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCommandPort.java
@@ -2,7 +2,11 @@ package com.rushcrew.order_service.application.command.port.out;
 
 import java.util.UUID;
 
+import com.rushcrew.order_service.domain.model.order.Order;
+
 public interface OrderCommandPort {
 	/* 기존 구매 수량 */
 	Integer getTotalPurchasedQuantity(Long userId, UUID timeDealId);
+
+	Order save(Order order);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCommandPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCommandPort.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.command.port.out;
+
+import java.util.UUID;
+
+public interface OrderCommandPort {
+	/* 기존 구매 수량 */
+	Integer getTotalPurchasedQuantity(Long userId, UUID timeDealId);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CreateOrderService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CreateOrderService.java
@@ -1,0 +1,32 @@
+package com.rushcrew.order_service.application.command.service;
+
+import org.springframework.stereotype.Service;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCachePort;
+import com.rushcrew.order_service.application.command.usecase.CreateOrderUseCase;
+import com.rushcrew.order_service.application.saga.orchestrator.OrderCreationSagaOrchestrator;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreateOrderService implements CreateOrderUseCase {
+
+	private final OrderCreationSagaOrchestrator sagaOrchestrator;
+	private final OrderCachePort orderCachePort;
+
+	@Override
+	public CreateOrderResult createOrder(CreateOrderCommand command) {
+		log.info("주문 생성 시작: userId={}, timeDealId={}", command.userId(), command.timeDealId());
+		// Saga 실행
+		CreateOrderResult result = sagaOrchestrator.execute(command);
+		// Redis 캐시 저장
+		orderCachePort.saveOrderCache(result);
+		log.info("주문 생성 완료: orderId={}", result.orderId());
+		return result;
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/CreateOrderUseCase.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/CreateOrderUseCase.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.command.usecase;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+
+public interface CreateOrderUseCase {
+	CreateOrderResult createOrder(CreateOrderCommand command);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/OutboxEvent.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/OutboxEvent.java
@@ -1,0 +1,21 @@
+package com.rushcrew.order_service.application.port.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record OutboxEvent(
+	UUID eventId,
+	String aggregateType,
+	UUID aggregateId,
+	String eventType,
+	String payload,
+	String status,
+	Instant createdAt,
+	Instant publishedAt,
+	Instant failedAt,
+	Integer retryCount,
+	String errorMessage
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/StockReservationResult.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/StockReservationResult.java
@@ -1,0 +1,24 @@
+package com.rushcrew.order_service.application.port.dto;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StockReservationResult {
+	private UUID timeDealStockId;
+	private Integer quantity;
+	private boolean success;
+	private Integer availableStock;
+	private String message;
+
+	public static StockReservationResult success(UUID timeDealStockId, Integer quantity) {
+		return new StockReservationResult(timeDealStockId, quantity, true, null, null);
+	}
+
+	public static StockReservationResult failure(Integer availableStock, String message) {
+		return new StockReservationResult(null, null, false, availableStock, message);
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealInfo.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealInfo.java
@@ -1,0 +1,19 @@
+package com.rushcrew.order_service.application.port.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record TimeDealInfo(
+	UUID timeDealId,
+	String title,
+	BigDecimal originalPrice,
+	BigDecimal discountPrice,
+	Integer discountRate,
+	Integer limitQuantity,
+	TimeDealStatus status,
+	boolean isActive
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStatus.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStatus.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.port.dto;
+
+public enum TimeDealStatus {
+	SCHEDULED,
+	IN_PROGRESS,
+	SOLD_OUT,
+	ENDED
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStockDetail.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStockDetail.java
@@ -1,0 +1,39 @@
+package com.rushcrew.order_service.application.port.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TimeDealStockDetail {
+	// 타임딜 재고 정보
+	private UUID timeDealStockId;
+	private UUID timeDealId;
+
+	private TimeDealStatus timeDealStatus;
+
+	private Integer availableStock;     // 주문 가능한 재고
+	private Integer reservedStock;      // 예약된 재고
+	private Integer soldStock;          // 판매 완료된 재고
+	private TimeDealStockStatus status;
+
+	// 상품 정보
+	private UUID productId;
+	private String productName;
+	private String productDescription;
+	private BigDecimal productPrice; // 원가
+	private String category;
+
+	// 옵션 정보
+	private UUID optionId;
+	private String optionName;
+
+	// 판매자 정보
+	private UUID sellerId;
+	private String sellerName;
+
+	private boolean isActive;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStockDetail.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStockDetail.java
@@ -35,5 +35,5 @@ public class TimeDealStockDetail {
 	private UUID sellerId;
 	private String sellerName;
 
-	private boolean isActive;
+	// private boolean isActive;
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStockStatus.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/dto/TimeDealStockStatus.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.port.dto;
+
+public enum TimeDealStockStatus {
+	AVAILABLE,
+	RESERVED,
+	SOLD,
+	PAUSED
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/OrderEventPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/OrderEventPort.java
@@ -1,0 +1,16 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.NonNull;
+
+public interface OrderEventPort {
+	/* 재고 소진 이벤트 발행 */
+	void publishStockDepletedEvent(
+		@NonNull UUID timeDealId,
+		@NonNull Long userId,
+		@NonNull Integer availableStock,
+		@NonNull Instant timestamp
+	);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/OutboxPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/OutboxPort.java
@@ -1,0 +1,23 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.port.dto.OutboxEvent;
+
+public interface OutboxPort {
+
+	/**
+	 * Outbox 이벤트 저장
+	 */
+	OutboxEvent save(OutboxEvent event);
+
+	/**
+	 * 이벤트 생성 및 저장 (편의 메서드)
+	 */
+	OutboxEvent createAndSave(
+		String aggregateType,
+		UUID aggregateId,
+		String eventType,
+		String payload
+	);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/PointPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/PointPort.java
@@ -13,4 +13,12 @@ public interface PointPort {
 		@NonNull UUID sagaId,
 		@NonNull String reason
 	);
+
+	/* 포인트 환불 */
+	void refundPoint(
+		@NonNull Long userId,
+		@NonNull BigDecimal amount,
+		@NonNull UUID sagaId,
+		@NonNull String reason
+	);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/PointPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/PointPort.java
@@ -1,0 +1,16 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import lombok.NonNull;
+
+public interface PointPort {
+	/* 포인트 차감 */
+	boolean deductPoint(
+		@NonNull Long userId,
+		@NonNull BigDecimal amount,
+		@NonNull UUID sagaId,
+		@NonNull String reason
+	);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/QueuePort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/QueuePort.java
@@ -1,0 +1,10 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.util.UUID;
+
+import lombok.NonNull;
+
+public interface QueuePort {
+	/* 대기열 토큰 검증 */
+	boolean validateToken(@NonNull UUID timeDealId, @NonNull Long userId);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/TimeDealStockPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/TimeDealStockPort.java
@@ -2,11 +2,22 @@ package com.rushcrew.order_service.application.port.out;
 
 import java.util.UUID;
 
+import com.rushcrew.order_service.application.port.dto.StockReservationResult;
 import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.application.port.dto.TimeDealStockDetail;
 
 import lombok.NonNull;
 
 public interface TimeDealStockPort {
-	// 타임딜 정보 조회
-	TimeDealInfo getTimeDeal(@NonNull UUID uuid);
+	/* 타임딜 정보 조회 */
+	TimeDealInfo getTimeDeal(@NonNull UUID timeDealId);
+
+	/* 타임딜 재고 상세 정보 조회 */
+	TimeDealStockDetail getTimeDealStockDetail(@NonNull UUID timeDealStockId);
+
+	/* 재고 예약 요청 */
+	StockReservationResult reserveStock(@NonNull UUID timeDealStockId, @NonNull Integer quantity, @NonNull Long userId);
+
+	/* 재고 복구 */
+	void restoreStock(@NonNull UUID timeDealStockId, @NonNull Integer quantity, @NonNull UUID sagaId, @NonNull String reason);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/TimeDealStockPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/TimeDealStockPort.java
@@ -1,0 +1,12 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+
+import lombok.NonNull;
+
+public interface TimeDealStockPort {
+	// 타임딜 정보 조회
+	TimeDealInfo getTimeDeal(@NonNull UUID uuid);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/query/dto/OrderDetailDto.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/query/dto/OrderDetailDto.java
@@ -1,0 +1,78 @@
+package com.rushcrew.order_service.application.query.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderDetailDto {
+	private UUID orderId;
+	private Long userId;
+	private String orderStatus;
+	private BigDecimal totalAmount;
+	private BigDecimal pointUsed;
+	private BigDecimal finalAmount;
+	private Instant orderedAt;
+	private Instant paymentCompletedAt;
+	private Instant purchaseConfirmedAt;
+	private Instant cancelledAt;
+	private Instant autoConfirmScheduledAt;
+	private ShippingInfo shippingInfo;
+	private List<CreateOrderResult.OrderItemResult> orderItems;
+
+	public static OrderDetailDto fromEntity(Order order) {
+		return OrderDetailDto.builder()
+			.orderId(order.getOrderId())
+			.userId(order.getUserId())
+			.orderStatus(order.getStatus().name())
+			.totalAmount(order.getTotalAmount())
+			.pointUsed(order.getPointUsed())
+			.finalAmount(order.getFinalAmount())
+			.orderedAt(order.getOrderedAt())
+			.paymentCompletedAt(order.getPaymentCompletedAt())
+			.purchaseConfirmedAt(order.getPurchaseConfirmedAt())
+			.cancelledAt(order.getCancelledAt())
+			.autoConfirmScheduledAt(order.getAutoConfirmScheduledAt())
+			.shippingInfo(order.getShippingInfo())
+			.orderItems(order.getOrderItems().stream()
+				.map(item -> CreateOrderResult.OrderItemResult.builder()
+					.orderItemId(item.getOrderItemId())
+					.productName(item.getProductName())
+					.optionName(item.getProductSnapshot().optionName())
+					.quantity(item.getQuantity())
+					.unitPrice(item.getUnitPrice())
+					.discountPrice(item.getDiscountPrice())
+					.subtotal(item.getSubtotal())
+					.build())
+				.collect(Collectors.toList()))
+			.build();
+	}
+
+	public static OrderDetailDto fromCreateOrderResult(CreateOrderResult result, Long userId, ShippingInfo shippingInfo) {
+		return OrderDetailDto.builder()
+			.orderId(result.orderId())
+			.userId(userId)
+			.orderStatus(result.orderStatus())
+			.totalAmount(result.totalAmount())
+			.pointUsed(result.pointUsed())
+			.finalAmount(result.finalAmount())
+			.orderedAt(result.orderedAt())
+			.shippingInfo(shippingInfo)
+			.orderItems(result.orderItems())
+			.build();
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/dto/OrderCreationSagaData.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/dto/OrderCreationSagaData.java
@@ -1,0 +1,28 @@
+package com.rushcrew.order_service.application.saga.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCreationSagaData {
+	private CreateOrderCommand command;
+
+	// Step 실행 결과
+	private BigDecimal totalAmount;
+	private BigDecimal finalAmount;
+	private List<CreateOrderResult.OrderItemResult> orderItems;
+
+	// 생성된 주문 ID
+	private UUID orderId;
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/dto/SagaContext.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/dto/SagaContext.java
@@ -1,0 +1,28 @@
+package com.rushcrew.order_service.application.saga.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SagaContext {
+	private UUID sagaId;
+	private Long userId;
+
+	@Builder.Default
+	private Map<String, Object> data = new HashMap<>();
+
+	public void setData(String key, Object value) {
+		this.data.put(key, value);
+	}
+
+	public Object getData(String key) {
+		return this.data.get(key);
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/dto/SagaStepResult.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/dto/SagaStepResult.java
@@ -1,0 +1,38 @@
+package com.rushcrew.order_service.application.saga.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SagaStepResult {
+	private boolean success;
+	private String errorMessage;
+
+	@Builder.Default
+	private Map<String, Object> data = new HashMap<>();
+
+	public static SagaStepResult success() {
+		return SagaStepResult.builder()
+			.success(true)
+			.build();
+	}
+
+	public static SagaStepResult success(Map<String, Object> data) {
+		return SagaStepResult.builder()
+			.success(true)
+			.data(data)
+			.build();
+	}
+
+	public static SagaStepResult failure(String errorMessage) {
+		return SagaStepResult.builder()
+			.success(false)
+			.errorMessage(errorMessage)
+			.build();
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -7,6 +7,7 @@ import com.rushcrew.order_service.application.command.dto.result.CreateOrderResu
 import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
 import com.rushcrew.order_service.application.saga.dto.SagaContext;
 import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
 import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
 import com.rushcrew.order_service.domain.enums.SagaStatus;
 import com.rushcrew.order_service.domain.model.saga.SagaInstance;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OrderCreationSagaOrchestrator {
 
 	private final ValidateStockStep validateStockStep;
+	private final ReserveStockStep reserveStockStep;
 
 	@Transactional
 	public CreateOrderResult execute(CreateOrderCommand command) {
@@ -44,7 +46,14 @@ public class OrderCreationSagaOrchestrator {
 				throw new IllegalArgumentException(validateResult.getErrorMessage());
 			}
 			sagaInstance.addStep("VALIDATE_STOCK", SagaStatus.COMPLETED);
+
 			// Step 2: 재고 예약
+			log.info("[Saga-{}] Step 2: ReserveStock 시작", context.getSagaId());
+			SagaStepResult reserveResult = reserveStockStep.execute(context, sagaData);
+			if (!reserveResult.isSuccess()) {
+				throw new IllegalArgumentException(reserveResult.getErrorMessage());
+			}
+			sagaInstance.addStep("RESERVE_STOCK", SagaStatus.COMPLETED);
 			// Step 3: 포인트 차감
 			// Step 4: 주문 생성
 

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -1,0 +1,9 @@
+package com.rushcrew.order_service.application.saga.orchestrator;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+
+public class OrderCreationSagaOrchestrator {
+	public CreateOrderResult execute(CreateOrderCommand command) {
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -7,6 +7,7 @@ import com.rushcrew.order_service.application.command.dto.result.CreateOrderResu
 import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
 import com.rushcrew.order_service.application.saga.dto.SagaContext;
 import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.saga.step.CreateOrderStep;
 import com.rushcrew.order_service.application.saga.step.DeductPointStep;
 import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
 import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
@@ -25,6 +26,7 @@ public class OrderCreationSagaOrchestrator {
 	private final ValidateStockStep validateStockStep;
 	private final ReserveStockStep reserveStockStep;
 	private final DeductPointStep deductPointStep;
+	private final CreateOrderStep createOrderStep;
 
 	@Transactional
 	public CreateOrderResult execute(CreateOrderCommand command) {
@@ -69,6 +71,15 @@ public class OrderCreationSagaOrchestrator {
 			sagaInstance.addStep("DEDUCT_POINT", SagaStatus.COMPLETED);
 
 			// Step 4: 주문 생성
+			log.info("[Saga-{}] Step 4: CreateOrder 시작", context.getSagaId());
+			SagaStepResult createResult = createOrderStep.execute(context, sagaData);
+			if (!createResult.isSuccess()) {
+				// 주문 생성 실패 → 포인트 환불 + 재고 복구
+				deductPointStep.compensate(context, sagaData);
+				reserveStockStep.compensate(context, sagaData);
+				throw new IllegalArgumentException(createResult.getErrorMessage());
+			}
+			sagaInstance.addStep("CREATE_ORDER", SagaStatus.COMPLETED);
 
 			// Saga 완료
 			sagaInstance.complete();

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -1,9 +1,57 @@
 package com.rushcrew.order_service.application.saga.orchestrator;
 
+import java.time.Instant;
+
+import org.springframework.stereotype.Component;
+
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
 import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.domain.model.saga.SagaInstance;
 
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class OrderCreationSagaOrchestrator {
+	@Transactional
 	public CreateOrderResult execute(CreateOrderCommand command) {
+		// 1. Saga 인스턴스 생성
+		SagaInstance sagaInstance = SagaInstance.create("ORDER_CREATION", command.userId());
+		// 2. Saga Context 생성
+		SagaContext context = SagaContext.builder()
+			.sagaId(sagaInstance.getSagaId())
+			.userId(command.userId())
+			.build();
+		// 3. Saga Data 생성
+		OrderCreationSagaData sagaData = OrderCreationSagaData.builder()
+			.command(command)
+			.build();
+		// 검증 시작
+		try {
+			// Step 1: 재고 검증
+			// Step 2: 재고 예약
+			// Step 3: 포인트 차감
+			// Step 4: 주문 생성
+
+			// Saga 완료
+			sagaInstance.complete();
+			log.info("[Saga-{}] 완료", context.getSagaId());
+
+			// 결과 리턴
+			return CreateOrderResult.builder()
+				.build();
+
+		} catch (Exception e) {
+			// Saga 실패 처리
+			sagaInstance.fail(e.getMessage());
+			log.error("[Saga-{}] 실패: {}", context.getSagaId(), e.getMessage(), e);
+			throw e;
+		}
+
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -1,13 +1,14 @@
 package com.rushcrew.order_service.application.saga.orchestrator;
 
-import java.time.Instant;
-
 import org.springframework.stereotype.Component;
 
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
 import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
 import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
 import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
+import com.rushcrew.order_service.domain.enums.SagaStatus;
 import com.rushcrew.order_service.domain.model.saga.SagaInstance;
 
 import jakarta.transaction.Transactional;
@@ -18,6 +19,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 public class OrderCreationSagaOrchestrator {
+
+	private final ValidateStockStep validateStockStep;
+
 	@Transactional
 	public CreateOrderResult execute(CreateOrderCommand command) {
 		// 1. Saga 인스턴스 생성
@@ -34,6 +38,12 @@ public class OrderCreationSagaOrchestrator {
 		// 검증 시작
 		try {
 			// Step 1: 재고 검증
+			log.info("[Saga-{}] Step 1: validateStock 시작", context.getSagaId());
+			SagaStepResult validateResult = validateStockStep.execute(context, sagaData);
+			if (!validateResult.isSuccess()) {
+				throw new IllegalArgumentException(validateResult.getErrorMessage());
+			}
+			sagaInstance.addStep("VALIDATE_STOCK", SagaStatus.COMPLETED);
 			// Step 2: 재고 예약
 			// Step 3: 포인트 차감
 			// Step 4: 주문 생성

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -1,5 +1,7 @@
 package com.rushcrew.order_service.application.saga.orchestrator;
 
+import java.time.Instant;
+
 import org.springframework.stereotype.Component;
 
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
@@ -86,7 +88,31 @@ public class OrderCreationSagaOrchestrator {
 			log.info("[Saga-{}] 완료", context.getSagaId());
 
 			// 결과 리턴
+			Instant reservationExpiresAt = (Instant) context.getData("reservationExpiresAt");
+			if (reservationExpiresAt == null) {
+				reservationExpiresAt = Instant.now().plus(15, java.time.temporal.ChronoUnit.MINUTES);
+			}
+
+			Instant orderedAt = (Instant) context.getData("orderedAt");
+			if (orderedAt == null) {
+				orderedAt = Instant.now();
+			}
+
+			String orderStatus = (String) context.getData("orderStatus");
+			if (orderStatus == null) {
+				orderStatus = "PENDING";
+			}
+
 			return CreateOrderResult.builder()
+				.orderId(sagaData.getOrderId())
+				.userId(command.userId())
+				.orderStatus(orderStatus)
+				.totalAmount(sagaData.getTotalAmount())
+				.pointUsed(command.pointUsed())
+				.finalAmount(sagaData.getFinalAmount())
+				.orderedAt(orderedAt)
+				.reservationExpiresAt(reservationExpiresAt)
+				.orderItems(sagaData.getOrderItems())
 				.build();
 
 		} catch (Exception e) {

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -7,6 +7,7 @@ import com.rushcrew.order_service.application.command.dto.result.CreateOrderResu
 import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
 import com.rushcrew.order_service.application.saga.dto.SagaContext;
 import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.saga.step.DeductPointStep;
 import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
 import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
 import com.rushcrew.order_service.domain.enums.SagaStatus;
@@ -23,10 +24,11 @@ public class OrderCreationSagaOrchestrator {
 
 	private final ValidateStockStep validateStockStep;
 	private final ReserveStockStep reserveStockStep;
+	private final DeductPointStep deductPointStep;
 
 	@Transactional
 	public CreateOrderResult execute(CreateOrderCommand command) {
-		// 1. Saga 인스턴스 생성
+		// 1. Saga 인스턴스 생성 - sagaId 생성
 		SagaInstance sagaInstance = SagaInstance.create("ORDER_CREATION", command.userId());
 		// 2. Saga Context 생성
 		SagaContext context = SagaContext.builder()
@@ -37,6 +39,7 @@ public class OrderCreationSagaOrchestrator {
 		OrderCreationSagaData sagaData = OrderCreationSagaData.builder()
 			.command(command)
 			.build();
+
 		// 검증 시작
 		try {
 			// Step 1: 재고 검증
@@ -54,7 +57,17 @@ public class OrderCreationSagaOrchestrator {
 				throw new IllegalArgumentException(reserveResult.getErrorMessage());
 			}
 			sagaInstance.addStep("RESERVE_STOCK", SagaStatus.COMPLETED);
+
 			// Step 3: 포인트 차감
+			log.info("[Saga-{}] Step 3: DeductPoint 시작", context.getSagaId());
+			SagaStepResult deductResult = deductPointStep.execute(context, sagaData);
+			if (!deductResult.isSuccess()) {
+				// 포인트 차감 실패 → 재고 복구
+				reserveStockStep.compensate(context, sagaData);
+				throw new IllegalArgumentException(deductResult.getErrorMessage());
+			}
+			sagaInstance.addStep("DEDUCT_POINT", SagaStatus.COMPLETED);
+
 			// Step 4: 주문 생성
 
 			// Saga 완료

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/service/SagaRecoveryService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/service/SagaRecoveryService.java
@@ -1,0 +1,116 @@
+package com.rushcrew.order_service.application.saga.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.step.CreateOrderStep;
+import com.rushcrew.order_service.application.saga.step.DeductPointStep;
+import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+import com.rushcrew.order_service.domain.model.saga.SagaInstance;
+import com.rushcrew.order_service.domain.model.saga.SagaStep;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Saga 복구 서비스
+ * 타임아웃된 Saga에 대한 보상 트랜잭션 실행
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SagaRecoveryService {
+
+	private final ReserveStockStep reserveStockStep;
+	private final DeductPointStep deductPointStep;
+
+	/* 타임아웃된 Saga에 대한 보상 트랜잭션 실행 */
+	@Transactional
+	public void compensateSaga(SagaInstance sagaInstance) {
+		log.info("Saga 보상 트랜잭션 시작: sagaId={}, sagaType={}",
+			sagaInstance.getSagaId(), sagaInstance.getSagaType());
+
+		try {
+			// ORDER_CREATION Saga만 처리
+			if (!"ORDER_CREATION".equals(sagaInstance.getSagaType())) {
+				log.warn("지원하지 않는 Saga 타입: {}", sagaInstance.getSagaType());
+				return;
+			}
+
+			// 완료된 Step들을 역순으로 보상 트랜잭션 실행
+			List<SagaStep> completedSteps = sagaInstance.getSteps().stream()
+				.filter(step -> step.getStatus() == SagaStatus.COMPLETED)
+				.sorted((s1, s2) -> s2.getExecutedAt().compareTo(s1.getExecutedAt())) // 역순 정렬
+				.toList();
+
+			if (completedSteps.isEmpty()) {
+				log.info("보상할 완료된 Step이 없음: sagaId={}", sagaInstance.getSagaId());
+				sagaInstance.fail("Saga 타임아웃 - 보상할 Step 없음");
+				return;
+			}
+
+			// SagaContext와 SagaData 재구성 (최소한의 정보만)
+			SagaContext context = SagaContext.builder()
+				.sagaId(sagaInstance.getSagaId())
+				.userId(sagaInstance.getUserId())
+				.build();
+
+			// CreateOrderCommand는 복구 시에는 최소한의 정보만 필요
+			// 실제로는 DB에서 주문 정보를 조회하여 사용해야 하지만,
+			// 타임아웃된 Saga의 경우 주문이 생성되지 않았을 수도 있음
+			OrderCreationSagaData sagaData = OrderCreationSagaData.builder()
+				.command(CreateOrderCommand.builder()
+					.userId(sagaInstance.getUserId())
+					.build())
+				.build();
+
+			// 각 Step에 대해 역순으로 보상 트랜잭션 실행
+			for (SagaStep step : completedSteps) {
+				try {
+					compensateStep(step.getStepName(), context, sagaData);
+					step.markAsCompensated();
+					log.info("Step 보상 완료: sagaId={}, stepName={}",
+						sagaInstance.getSagaId(), step.getStepName());
+				} catch (Exception e) {
+					log.error("Step 보상 실패: sagaId={}, stepName={}",
+						sagaInstance.getSagaId(), step.getStepName(), e);
+					step.markAsFailed("보상 실패: " + e.getMessage());
+					// 보상 실패해도 다음 Step 보상 시도
+				}
+			}
+
+			sagaInstance.fail("Saga 타임아웃 - 보상 트랜잭션 완료");
+			log.info("Saga 보상 트랜잭션 완료: sagaId={}", sagaInstance.getSagaId());
+
+		} catch (Exception e) {
+			log.error("Saga 보상 트랜잭션 중 오류 발생: sagaId={}", sagaInstance.getSagaId(), e);
+			sagaInstance.fail("Saga 타임아웃 - 보상 트랜잭션 실패: " + e.getMessage());
+			throw e;
+		}
+	}
+
+	/* 특정 Step에 대한 보상 트랜잭션 실행 */
+	private void compensateStep(String stepName, SagaContext context, OrderCreationSagaData sagaData) {
+		switch (stepName) {
+			case "DEDUCT_POINT":
+				deductPointStep.compensate(context, sagaData);
+				break;
+			case "RESERVE_STOCK":
+				reserveStockStep.compensate(context, sagaData);
+				break;
+			case "VALIDATE_STOCK":
+				// 조회만 수행하므로 보상 불필요
+				log.debug("VALIDATE_STOCK은 보상 불필요: sagaId={}", context.getSagaId());
+				break;
+			default:
+				log.warn("알 수 없는 Step 이름: {}, 보상 스킵", stepName);
+		}
+	}
+}
+

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/CreateOrderStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/CreateOrderStep.java
@@ -1,0 +1,149 @@
+package com.rushcrew.order_service.application.saga.step;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.application.port.out.OutboxPort;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.domain.model.order.OrderItem;
+import com.rushcrew.order_service.domain.model.order.OrderReservation;
+import com.rushcrew.order_service.domain.vo.ProductSnapshot;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CreateOrderStep {
+
+	private final OrderCommandPort orderCommandPort;
+	private final OutboxPort outboxPort;
+	private final ObjectMapper objectMapper;
+
+	/**
+	 * Forward Transaction: 주문 생성
+	 * - Order 엔티티 생성 및 저장
+	 * - Outbox에 ORDER_CREATED 이벤트 저장
+	 */
+	public SagaStepResult execute(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] CreateOrder 실행 시작", context.getSagaId());
+
+			CreateOrderCommand command = data.getCommand();
+			TimeDealInfo timeDeal = (TimeDealInfo) context.getData("timeDeal");
+
+			// 1. OrderItem 목록 생성
+			List<OrderItem> orderItems = data.getOrderItems().stream()
+				.map(itemResult -> {
+					// ProductSnapshot 생성
+					ProductSnapshot snapshot = ProductSnapshot.builder()
+						.timeDealStockId(itemResult.timeDealStockId())
+						.productId(itemResult.productId())
+						.productName(itemResult.productName())
+						.productDescription("") // stockDetail에서 가져와야 함
+						.optionName(itemResult.optionName())
+						.timeDealId(timeDeal.timeDealId())
+						.timeDealTitle(timeDeal.title())
+						.discountRate(timeDeal.discountRate())
+						.build();
+
+					return OrderItem.create(
+						itemResult.timeDealStockId(),
+						itemResult.quantity(),
+						itemResult.unitPrice(),
+						itemResult.discountPrice(),
+						snapshot
+					);
+				})
+				.collect(Collectors.toList());
+
+			// 2. Order 생성
+			Order order = Order.create(
+				command.userId(),
+				orderItems,
+				command.pointUsed(),
+				command.shippingInfo()
+			);
+
+			// 3. OrderReservation 추가
+			for (CreateOrderCommand.OrderItemCommand itemCommand : command.orderItems()) {
+				OrderReservation reservation = OrderReservation.create(
+					itemCommand.timeDealStockId(),
+					itemCommand.quantity()
+				);
+				order.addReservation(reservation);
+			}
+
+			// 4. Order 저장 --> PostgreSQL
+			Order savedOrder = orderCommandPort.save(order);
+
+			log.info("[Saga-{}] Order 저장 완료: orderId={}", context.getSagaId(), savedOrder.getOrderId());
+
+			// 5. Outbox에 ORDER_CREATED 이벤트 저장 (같은 트랜잭션)
+			Map<String, Object> eventPayload = new HashMap<>();
+			eventPayload.put("orderId", savedOrder.getOrderId());
+			eventPayload.put("userId", savedOrder.getUserId());
+			eventPayload.put("status", savedOrder.getStatus().name());
+			eventPayload.put("totalAmount", savedOrder.getTotalAmount());
+			eventPayload.put("pointUsed", savedOrder.getPointUsed());
+			eventPayload.put("finalAmount", savedOrder.getFinalAmount());
+			eventPayload.put("orderedAt", savedOrder.getOrderedAt());
+
+			outboxPort.createAndSave(
+				"ORDER",
+				savedOrder.getOrderId(),
+				"ORDER_CREATED",
+				objectMapper.writeValueAsString(eventPayload)
+			);
+
+			log.info("[Saga-{}] Outbox 이벤트 저장 완료", context.getSagaId());
+
+			// 6. SagaData에 orderId 저장
+			data.setOrderId(savedOrder.getOrderId());
+			context.setData("orderId", savedOrder.getOrderId());
+
+			// 7. 결과 데이터 생성
+			Instant reservationExpiresAt = savedOrder.getReservations().stream()
+				.map(OrderReservation::getExpiresAt)
+				.findFirst()
+				.orElse(Instant.now().plus(15, ChronoUnit.MINUTES));
+
+			// reservationExpiresAt, orderedAt, orderStatus를 context에 저장 (OrderCreationSagaOrchestrator에서 사용)
+			context.setData("reservationExpiresAt", reservationExpiresAt);
+			context.setData("orderedAt", savedOrder.getOrderedAt());
+			context.setData("orderStatus", savedOrder.getStatus().name());
+
+			Map<String, Object> resultData = new HashMap<>();
+			resultData.put("orderId", savedOrder.getOrderId());
+			resultData.put("reservationExpiresAt", reservationExpiresAt);
+
+			log.info("[Saga-{}] CreateOrder 실행 완료: orderId={}",
+				context.getSagaId(), savedOrder.getOrderId());
+
+			return SagaStepResult.success(resultData);
+
+		} catch (JsonProcessingException e) {
+			log.error("[Saga-{}] CreateOrder 실패: JSON 변환 오류", context.getSagaId(), e);
+			return SagaStepResult.failure("주문 생성 실패: JSON 변환 오류");
+		} catch (Exception e) {
+			log.error("[Saga-{}] CreateOrder 실패", context.getSagaId(), e);
+			return SagaStepResult.failure("주문 생성 실패: " + e.getMessage());
+		}
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/DeductPointStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/DeductPointStep.java
@@ -1,0 +1,80 @@
+package com.rushcrew.order_service.application.saga.step;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.port.out.PointPort;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeductPointStep {
+
+	private final PointPort pointPort;
+
+	/**
+	 * Forward Transaction: 포인트 차감
+	 */
+	public SagaStepResult execute(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] DeductPoint 실행 시작", context.getSagaId());
+
+			CreateOrderCommand command = data.getCommand();
+			BigDecimal pointUsed = command.pointUsed();
+
+			// 포인트 사용량이 0이면 스킵
+			if (pointUsed == null || pointUsed.compareTo(BigDecimal.ZERO) == 0) {
+				log.info("[Saga-{}] 포인트 사용량이 0이므로 스킵", context.getSagaId());
+				return SagaStepResult.success();
+			}
+
+			// 포인트 차감 API 호출
+			try {
+				boolean deducted = pointPort.deductPoint(
+					command.userId(),
+					pointUsed,
+					context.getSagaId(), // 주문 ID 대신 Saga ID 사용
+					"주문 결제"
+				);
+
+				if (!deducted) {
+					log.error("[Saga-{}] 포인트 차감 실패: userId={}, amount={}",
+						context.getSagaId(), command.userId(), pointUsed);
+					return SagaStepResult.failure("포인트 잔액이 부족합니다.");
+				}
+
+				// Context에 포인트 차감 정보 저장 (보상용)
+				context.setData("pointDeducted", true);
+				context.setData("pointAmount", pointUsed);
+
+				log.info("[Saga-{}] DeductPoint 실행 완료: userId={}, amount={}",
+					context.getSagaId(), command.userId(), pointUsed);
+
+				Map<String, Object> resultData = new HashMap<>();
+				resultData.put("pointDeducted", true);
+				resultData.put("pointAmount", pointUsed);
+
+				return SagaStepResult.success(resultData);
+
+			} catch (Exception e) {
+				log.error("[Saga-{}] 포인트 차감 API 호출 실패", context.getSagaId(), e);
+				return SagaStepResult.failure("포인트 차감 중 오류 발생: " + e.getMessage());
+			}
+
+		} catch (Exception e) {
+			log.error("[Saga-{}] DeductPoint 실행 중 예외 발생", context.getSagaId(), e);
+			return SagaStepResult.failure("포인트 차감 실패: " + e.getMessage());
+		}
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/DeductPointStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/DeductPointStep.java
@@ -77,4 +77,36 @@ public class DeductPointStep {
 		}
 	}
 
+	/**
+	 * Compensating Transaction: 포인트 환불
+	 */
+	public void compensate(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] DeductPoint 보상 트랜잭션 시작", context.getSagaId());
+
+			Boolean pointDeducted = (Boolean) context.getData("pointDeducted");
+			if (pointDeducted == null || !pointDeducted) {
+				log.warn("[Saga-{}] 차감된 포인트가 없어서 보상 트랜잭션 스킵", context.getSagaId());
+				return;
+			}
+
+			BigDecimal pointAmount = (BigDecimal) context.getData("pointAmount");
+			Long userId = data.getCommand().userId();
+
+			// 포인트 환불 API 호출
+			pointPort.refundPoint(
+				userId,
+				pointAmount,
+				context.getSagaId(),
+				"주문 취소로 인한 포인트 환불"
+			);
+
+			log.info("[Saga-{}] DeductPoint 보상 트랜잭션 완료: userId={}, amount={}",
+				context.getSagaId(), userId, pointAmount);
+
+		} catch (Exception e) {
+			log.error("[Saga-{}] DeductPoint 보상 트랜잭션 실패", context.getSagaId(), e);
+			// TODO: 보상 실패 시 알림 필요
+		}
+	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
@@ -124,33 +124,6 @@ public class ReserveStockStep {
 		}
 	}
 
-	/**
-	 * Compensating Transaction: 재고 복구
-	 */
-	public void compensate(SagaContext context, OrderCreationSagaData data) {
-		try {
-			log.info("[Saga-{}] ReserveStock 보상 트랜잭션 시작", context.getSagaId());
-
-			@SuppressWarnings("unchecked")
-			List<ReservedStockInfo> reservedStocks =
-				(List<ReservedStockInfo>) context.getData("reservedStocks");
-
-			if (reservedStocks == null || reservedStocks.isEmpty()) {
-				log.warn("[Saga-{}] 복구할 재고 예약 정보가 없습니다", context.getSagaId());
-				return;
-			}
-
-			rollbackReservedStocks(context, reservedStocks, data.getCommand());
-
-			log.info("[Saga-{}] ReserveStock 보상 트랜잭션 완료: {} 건 복구",
-				context.getSagaId(), reservedStocks.size());
-
-		} catch (Exception e) {
-			log.error("[Saga-{}] ReserveStock 보상 트랜잭션 실패", context.getSagaId(), e);
-			// 보상 실패 시 알림 필요 (Slack, Email 등)
-		}
-	}
-
 	private ReservedStockInfo reserveStockWithLock(
 		SagaContext context,
 		CreateOrderCommand.OrderItemCommand itemCommand,
@@ -221,7 +194,7 @@ public class ReserveStockStep {
 
 	private BigDecimal calculateTotalAmount(List<CreateOrderResult.OrderItemResult> items) {
 		return items.stream()
-			.map(CreateOrderResult.OrderItemResult::subtotal)
+			.map(CreateOrderResult.OrderItemResult::subtotal)	// 각 주문 항목에서 subtotal 값만 추출해 BigDecimal 스트림으로 변환
 			.reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
@@ -1,0 +1,235 @@
+package com.rushcrew.order_service.application.saga.step;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.port.dto.StockReservationResult;
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.application.port.dto.TimeDealStockDetail;
+import com.rushcrew.order_service.application.port.out.OrderEventPort;
+import com.rushcrew.order_service.application.port.out.TimeDealStockPort;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.validator.TimeDealStockValidator;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+import com.rushcrew.order_service.infrastructure.adapter.out.lock.DistributedLockManager;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReserveStockStep {
+
+	private final TimeDealStockPort timeDealStockPort;
+	private final OrderEventPort orderEventPort;
+	private final DistributedLockManager lockManager;
+	private final TimeDealStockValidator timeDealStockValidator;
+
+	/**
+	 * Forward Transaction: 재고 예약
+	 * - 각 상품에 대해 재고 예약 요청
+	 * - 분산 락을 사용하여 동시성 제어
+	 */
+	public SagaStepResult execute(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] ReserveStock 실행 시작", context.getSagaId());
+
+			CreateOrderCommand command = data.getCommand();
+			TimeDealInfo timeDeal = (TimeDealInfo) context.getData("timeDeal"); // Step 1에서 넘겨준 Data
+
+			List<CreateOrderResult.OrderItemResult> orderItems = new ArrayList<>();
+			List<ReservedStockInfo> reservedStocks = new ArrayList<>();
+
+			for (CreateOrderCommand.OrderItemCommand itemCommand : command.orderItems()) {
+				UUID timeDealStockId = itemCommand.timeDealStockId();
+				String lockKey = "stock:" + timeDealStockId + ":lock";
+
+				try {
+					// 분산 락으로 재고 예약
+					ReservedStockInfo reservedStock = lockManager.executeWithLock(
+						lockKey,
+						5, // 5초 대기
+						3, // 3초 TTL
+						TimeUnit.SECONDS,
+						() -> reserveStockWithLock(
+							context,
+							itemCommand,
+							timeDeal,
+							command.userId(),
+							command.timeDealId()
+						)
+					);
+
+					reservedStocks.add(reservedStock);
+
+					// OrderItemResult 생성
+					CreateOrderResult.OrderItemResult itemResult = CreateOrderResult.OrderItemResult.builder()
+						.orderItemId(UUID.randomUUID())
+						.timeDealStockId(itemCommand.timeDealStockId())
+						.timeDealId(reservedStock.getStockDetail().getTimeDealId())
+						.productId(reservedStock.getStockDetail().getProductId())
+						.productName(reservedStock.getStockDetail().getProductName())
+						.optionName(reservedStock.getStockDetail().getOptionName())
+						.quantity(itemCommand.quantity())
+						.unitPrice(reservedStock.getStockDetail().getProductPrice())
+						.discountPrice(timeDeal.discountPrice())
+						.subtotal(timeDeal.discountPrice().multiply(BigDecimal.valueOf(itemCommand.quantity())))
+						.build();
+
+					orderItems.add(itemResult);
+
+				} catch (Exception e) {
+					log.error("[Saga-{}] 재고 예약 실패: timeDealStockId={}",
+						context.getSagaId(), timeDealStockId, e);
+
+					// 이미 예약된 재고들 롤백
+					rollbackReservedStocks(context, reservedStocks, command);
+
+					return SagaStepResult.failure("재고 예약 실패: " + e.getMessage());
+				}
+			}
+
+			// SagaData에 저장
+			data.setOrderItems(orderItems);
+			data.setTotalAmount(calculateTotalAmount(orderItems));
+			data.setFinalAmount(data.getTotalAmount().subtract(command.pointUsed()));
+			context.setData("reservedStocks", reservedStocks);
+
+			log.info("[Saga-{}] ReserveStock 실행 완료: {} 건", context.getSagaId(), reservedStocks.size());
+
+			Map<String, Object> resultData = new HashMap<>();
+			resultData.put("reservedStocks", reservedStocks);
+			resultData.put("orderItems", orderItems);
+
+			return SagaStepResult.success(resultData);
+
+		} catch (Exception e) {
+			log.error("[Saga-{}] ReserveStock 실행 중 예외 발생", context.getSagaId(), e);
+			return SagaStepResult.failure("재고 예약 중 오류 발생: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Compensating Transaction: 재고 복구
+	 */
+	public void compensate(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] ReserveStock 보상 트랜잭션 시작", context.getSagaId());
+
+			@SuppressWarnings("unchecked")
+			List<ReservedStockInfo> reservedStocks =
+				(List<ReservedStockInfo>) context.getData("reservedStocks");
+
+			if (reservedStocks == null || reservedStocks.isEmpty()) {
+				log.warn("[Saga-{}] 복구할 재고 예약 정보가 없습니다", context.getSagaId());
+				return;
+			}
+
+			rollbackReservedStocks(context, reservedStocks, data.getCommand());
+
+			log.info("[Saga-{}] ReserveStock 보상 트랜잭션 완료: {} 건 복구",
+				context.getSagaId(), reservedStocks.size());
+
+		} catch (Exception e) {
+			log.error("[Saga-{}] ReserveStock 보상 트랜잭션 실패", context.getSagaId(), e);
+			// 보상 실패 시 알림 필요 (Slack, Email 등)
+		}
+	}
+
+	private ReservedStockInfo reserveStockWithLock(
+		SagaContext context,
+		CreateOrderCommand.OrderItemCommand itemCommand,
+		TimeDealInfo timeDeal,
+		Long userId,
+		UUID timeDealId
+	) {
+		// 1. 타임딜 재고 상세 정보 조회
+		TimeDealStockDetail stockDetail = timeDealStockPort
+			.getTimeDealStockDetail(itemCommand.timeDealStockId());
+
+		// 2. 상품 활성 상태 검증
+		timeDealStockValidator.validate(stockDetail);
+
+		// 3. 재고 예약 요청
+		StockReservationResult result = timeDealStockPort.reserveStock(
+			itemCommand.timeDealStockId(),
+			itemCommand.quantity(),
+			userId
+		);
+
+		if (!result.isSuccess()) {
+			// 재고 소진 이벤트 발행
+			handleStockDepletion(timeDealId, userId, result.getAvailableStock());
+			throw new BusinessException(OrderErrorCode.STOCK_DEPLETED);
+		}
+
+		log.debug("[Saga-{}] 재고 예약 성공: timeDealStockId={}, quantity={}",
+			context.getSagaId(), itemCommand.timeDealStockId(), itemCommand.quantity());
+
+		return ReservedStockInfo.builder()
+			.timeDealStockId(itemCommand.timeDealStockId())
+			.quantity(itemCommand.quantity())
+			.stockDetail(stockDetail)
+			.build();
+	}
+
+	private void rollbackReservedStocks(
+		SagaContext context,
+		List<ReservedStockInfo> reservedStocks,
+		CreateOrderCommand command
+	) {
+		for (ReservedStockInfo stock : reservedStocks) {
+			try {
+				timeDealStockPort.restoreStock(
+					stock.getTimeDealStockId(),
+					stock.getQuantity(),
+					context.getSagaId(), // orderId 대신 sagaId 사용
+					"Saga 실패로 인한 재고 복구"
+				);
+				log.info("[Saga-{}] 재고 복구 완료: timeDealStockId={}",
+					context.getSagaId(), stock.getTimeDealStockId());
+			} catch (Exception e) {
+				log.error("[Saga-{}] 재고 복구 실패: timeDealStockId={}",
+					context.getSagaId(), stock.getTimeDealStockId(), e);
+			}
+		}
+	}
+
+	private void handleStockDepletion(UUID timeDealId, Long userId, Integer availableStock) {
+		orderEventPort.publishStockDepletedEvent(
+			timeDealId,
+			userId,
+			availableStock,
+			java.time.Instant.now()
+		);
+	}
+
+	private BigDecimal calculateTotalAmount(List<CreateOrderResult.OrderItemResult> items) {
+		return items.stream()
+			.map(CreateOrderResult.OrderItemResult::subtotal)
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	@Builder
+	@Getter
+	private static class ReservedStockInfo {
+		private UUID timeDealStockId;
+		private Integer quantity;
+		private TimeDealStockDetail stockDetail;
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
@@ -198,6 +198,32 @@ public class ReserveStockStep {
 			.reduce(BigDecimal.ZERO, BigDecimal::add);
 	}
 
+	/**
+	 * Compensating Transaction: 재고 복구
+	 */
+	public void compensate(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] ReserveStock 보상 트랜잭션 시작", context.getSagaId());
+
+			@SuppressWarnings("unchecked")
+			List<ReservedStockInfo> reservedStocks =
+				(List<ReservedStockInfo>) context.getData("reservedStocks");
+
+			if (reservedStocks == null || reservedStocks.isEmpty()) {
+				log.warn("[Saga-{}] 복구할 재고 예약 정보가 없습니다", context.getSagaId());
+				return;
+			}
+
+			rollbackReservedStocks(context, reservedStocks, data.getCommand());
+
+			log.info("[Saga-{}] ReserveStock 보상 트랜잭션 완료: {} 건 복구",
+				context.getSagaId(), reservedStocks.size());
+
+		} catch (Exception e) {
+			log.error("[Saga-{}] ReserveStock 보상 트랜잭션 실패", context.getSagaId(), e);
+			// TODO: 보상 실패 시 알림 필요 (Slack)
+		}
+	}
 	@Builder
 	@Getter
 	private static class ReservedStockInfo {

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ValidateStockStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ValidateStockStep.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component;
 import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
 import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
-import com.rushcrew.order_service.application.port.out.QueuePort;
 import com.rushcrew.order_service.application.port.out.TimeDealStockPort;
 import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
 import com.rushcrew.order_service.application.saga.dto.SagaContext;
@@ -24,7 +23,6 @@ import lombok.extern.slf4j.Slf4j;
 public class ValidateStockStep {
 
 	private final TimeDealStockPort timeDealStockPort;
-	private final QueuePort queuePort;
 	private final QueueTokenValidator queueTokenValidator;
 	private final TimeDealValidator timeDealValidator;
 	private final OrderItemValidator orderItemValidator;

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ValidateStockStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ValidateStockStep.java
@@ -1,0 +1,83 @@
+package com.rushcrew.order_service.application.saga.step;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.application.port.out.QueuePort;
+import com.rushcrew.order_service.application.port.out.TimeDealStockPort;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.validator.OrderItemValidator;
+import com.rushcrew.order_service.application.validator.PurchaseLimitValidator;
+import com.rushcrew.order_service.application.validator.QueueTokenValidator;
+import com.rushcrew.order_service.application.validator.TimeDealValidator;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ValidateStockStep {
+
+	private final TimeDealStockPort timeDealStockPort;
+	private final QueuePort queuePort;
+	private final QueueTokenValidator queueTokenValidator;
+	private final TimeDealValidator timeDealValidator;
+	private final OrderItemValidator orderItemValidator;
+	private final PurchaseLimitValidator purchaseLimitValidator;
+
+	/**
+	 * Forward Transaction: 재고 검증
+	 * - 대기열 토큰 검증
+	 * - 타임딜 정보 조회 및 검증
+	 * - 중복 상품 검증
+	 * - 구매 수량 제한 검증
+	 */
+	public SagaStepResult execute(SagaContext context, OrderCreationSagaData data) {
+		try {
+			log.info("[Saga-{}] ValidateStock 실행 시작", context.getSagaId());
+
+			CreateOrderCommand command = data.getCommand();
+
+			// 1. 대기열 토큰 검증
+			queueTokenValidator.validate(command.timeDealId(), command.userId());
+			log.debug("[Saga-{}] 대기열 토큰 검증 완료", context.getSagaId());
+
+			// 2. 타임딜 정보 조회 및 검증
+			TimeDealInfo timeDeal = timeDealStockPort.getTimeDeal(command.timeDealId());
+			timeDealValidator.validate(timeDeal);
+			log.debug("[Saga-{}] 타임딜 검증 완료: {}", context.getSagaId(), timeDeal.title());
+
+			// 3. 중복 상품 검증
+			orderItemValidator.validate(command.orderItems());
+			log.debug("[Saga-{}] 주문 아이템 검증 완료", context.getSagaId());
+
+			// 4. 구매 수량 제한 검증
+			purchaseLimitValidator.validate(
+				command.userId(),
+				command.timeDealId(),
+				command.orderItems(),
+				timeDeal
+			);
+			log.debug("[Saga-{}] 구매 제한 검증 완료", context.getSagaId());
+
+			// SagaData에 TimeDealInfo 저장 (다음 Step에서 사용)
+			context.setData("timeDeal", timeDeal);
+
+			log.info("[Saga-{}] ValidateStock 실행 완료", context.getSagaId());
+			return SagaStepResult.success();
+
+		} catch (BusinessException e) {
+			log.error("[Saga-{}] ValidateStock 실행 실패: {}", context.getSagaId(), e.getMessage());
+			return SagaStepResult.failure(e.getMessage());
+		} catch (Exception e) {
+			log.error("[Saga-{}] ValidateStock 실행 중 예외 발생", context.getSagaId(), e);
+			return SagaStepResult.failure("재고 검증 실패: " + e.getMessage());
+		}
+	}
+	// 보상 트랜잭션 불필요 (조회/검증만 수행)
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/validator/OrderItemValidator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/validator/OrderItemValidator.java
@@ -1,0 +1,30 @@
+package com.rushcrew.order_service.application.validator;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+@Component
+public class OrderItemValidator {
+	public void validate(List<CreateOrderCommand.OrderItemCommand> items) {
+
+		// 중복 상품 검증
+		Set<UUID> timeDealStockIds = new HashSet<>();
+
+		for (CreateOrderCommand.OrderItemCommand item : items) {
+			if (!timeDealStockIds.add(item.timeDealStockId())) {
+				throw new BusinessException(OrderErrorCode.DUPLICATE_ORDER_ITEM);
+			}
+			if (item.quantity() <= 0) {
+				throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
+			}
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/validator/PurchaseLimitValidator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/validator/PurchaseLimitValidator.java
@@ -1,0 +1,42 @@
+package com.rushcrew.order_service.application.validator;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PurchaseLimitValidator {
+
+	private final OrderCommandPort orderCommandPort;
+
+	public void validate(
+		Long userId,
+		UUID timeDealId,
+		List<CreateOrderCommand.OrderItemCommand> items,
+		TimeDealInfo timeDeal
+	) {
+		// 요청 수량 합계
+		int requestQuantity = items.stream()
+			.mapToInt(CreateOrderCommand.OrderItemCommand::quantity).sum();
+
+		// 기존 구매 수량
+		Integer totalPurchased = orderCommandPort.getTotalPurchasedQuantity(userId, timeDealId);
+
+		// 제한 수량 확인
+		Integer limitQuantity = timeDeal.limitQuantity();
+
+		if (limitQuantity != null && (totalPurchased + requestQuantity) > limitQuantity) {
+			throw new BusinessException(OrderErrorCode.PURCHASE_LIMIT_EXCEEDED);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/validator/QueueTokenValidator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/validator/QueueTokenValidator.java
@@ -1,0 +1,23 @@
+package com.rushcrew.order_service.application.validator;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.port.out.QueuePort;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class QueueTokenValidator {
+	private final QueuePort queuePort;
+
+	public void validate(UUID timeDealId, Long userId) {
+		if (!queuePort.validateToken(timeDealId, userId)) {
+			throw new BusinessException(OrderErrorCode.INVALID_QUEUE_TOKEN);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/validator/TimeDealStockValidator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/validator/TimeDealStockValidator.java
@@ -1,0 +1,23 @@
+package com.rushcrew.order_service.application.validator;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.port.dto.TimeDealStockDetail;
+import com.rushcrew.order_service.application.port.dto.TimeDealStockStatus;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+@Component
+public class TimeDealStockValidator {
+
+	public void validate(TimeDealStockDetail stockDetail) {
+		// 상품 활성 상태 확인
+		// if (!stockDetail.isActive()) {
+		// 	throw new BusinessException(OrderErrorCode.INVALID_PRODUCT);
+		// }
+		// 재고 상태 확인
+		if (stockDetail.getStatus() == TimeDealStockStatus.PAUSED) {
+			throw new IllegalArgumentException("판매 중지된 상품입니다.");
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/validator/TimeDealValidator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/validator/TimeDealValidator.java
@@ -1,0 +1,17 @@
+package com.rushcrew.order_service.application.validator;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.application.port.dto.TimeDealStatus;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+@Component
+public class TimeDealValidator {
+	public void validate(TimeDealInfo timeDeal) {
+		if (timeDeal.status() != TimeDealStatus.IN_PROGRESS) {
+			throw new BusinessException(OrderErrorCode.INVALID_TIME_DEAL);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/cache/OrderCacheAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/cache/OrderCacheAdapter.java
@@ -1,0 +1,75 @@
+package com.rushcrew.order_service.infrastructure.adapter.cache;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCachePort;
+import com.rushcrew.order_service.application.query.dto.OrderDetailDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCacheAdapter implements OrderCachePort {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	private static final String ORDER_KEY_PREFIX = "order:";
+	private static final String USER_ORDERS_KEY_PREFIX = "user:orders:";
+	private static final long ORDER_CACHE_TTL = 3600; // 1시간
+
+	@Override
+	public void saveOrderCache(CreateOrderResult result) {
+		try {
+			// 1. 주문 상세 정보 저장 (String)
+			String orderKey = ORDER_KEY_PREFIX + result.orderId();
+			OrderDetailDto dto = convertToOrderDetailDto(result);
+
+			redisTemplate.opsForValue().set(
+				orderKey,
+				objectMapper.writeValueAsString(dto),
+				ORDER_CACHE_TTL,
+				TimeUnit.SECONDS
+			);
+
+			// 2. 사용자별 주문 목록에 추가 (Sorted Set)
+			String userOrdersKey = USER_ORDERS_KEY_PREFIX + result.userId();
+			double score = result.orderedAt().toEpochMilli(); // 타임스탬프를 score로 사용
+
+			redisTemplate.opsForZSet().add(
+				userOrdersKey,
+				result.orderId().toString(),
+				score
+			);
+
+			// 3. 사용자별 주문 목록 TTL 설정
+			redisTemplate.expire(userOrdersKey, 24, TimeUnit.HOURS);
+
+			log.info("주문 캐시 저장 완료: orderId={}", result.orderId());
+
+		} catch (JsonProcessingException e) {
+			log.error("주문 캐시 저장 실패: orderId={}", result.orderId(), e);
+		}
+	}
+
+	private OrderDetailDto convertToOrderDetailDto(CreateOrderResult result) {
+		return OrderDetailDto.builder()
+			.orderId(result.orderId())
+			.userId(result.userId())
+			.orderStatus(result.orderStatus())
+			.totalAmount(result.totalAmount())
+			.pointUsed(result.pointUsed())
+			.finalAmount(result.finalAmount())
+			.orderedAt(result.orderedAt())
+			.orderItems(result.orderItems())
+			.build();
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/PointAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/PointAdapter.java
@@ -1,0 +1,54 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.client;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.port.out.PointPort;
+import com.rushcrew.order_service.infrastructure.adapter.out.client.feign.PointFeignClient;
+import com.rushcrew.order_service.infrastructure.dto.point.PointDeductRequest;
+import com.rushcrew.order_service.infrastructure.dto.point.PointDeductResponse;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointAdapter implements PointPort {
+
+	private final PointFeignClient feignClient;
+
+	@Override
+	public boolean deductPoint(@NonNull Long userId, @NonNull BigDecimal amount, @NonNull UUID sagaId,
+		@NonNull String reason) {
+
+		try {
+			log.info("포인트 차감 요청: userId={}, amount={}, sagaId={}", userId, amount, sagaId);
+
+			PointDeductRequest request = PointDeductRequest.builder()
+				.userId(userId)
+				.amount(amount)
+				.sagaId(sagaId.toString())
+				.reason(reason)
+				.build();
+
+			PointDeductResponse response = feignClient.deductPoint(request);
+
+			if (response.isSuccess()) {
+				log.info("포인트 차감 성공: userId={}, amount={}, remainingPoint={}",
+					userId, amount, response.getRemainingPoint());
+				return true;
+			} else {
+				log.warn("포인트 차감 실패: userId={}, message={}", userId, response.getMessage());
+				return false;
+			}
+
+		} catch (Exception e) {
+			log.error("포인트 차감 중 오류 발생: userId={}, amount={}", userId, amount, e);
+			throw new RuntimeException("포인트 차감 실패", e);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/PointAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/PointAdapter.java
@@ -9,6 +9,7 @@ import com.rushcrew.order_service.application.port.out.PointPort;
 import com.rushcrew.order_service.infrastructure.adapter.out.client.feign.PointFeignClient;
 import com.rushcrew.order_service.infrastructure.dto.point.PointDeductRequest;
 import com.rushcrew.order_service.infrastructure.dto.point.PointDeductResponse;
+import com.rushcrew.order_service.infrastructure.dto.point.PointRefundRequest;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +50,31 @@ public class PointAdapter implements PointPort {
 		} catch (Exception e) {
 			log.error("포인트 차감 중 오류 발생: userId={}, amount={}", userId, amount, e);
 			throw new RuntimeException("포인트 차감 실패", e);
+		}
+	}
+
+	@Override
+	public void refundPoint(@NonNull Long userId, @NonNull BigDecimal amount, @NonNull UUID sagaId,
+		@NonNull String reason) {
+
+		try {
+			log.info("포인트 환불 요청: userId={}, amount={}, sagaId={}", userId, amount, sagaId);
+
+			PointRefundRequest request = PointRefundRequest.builder()
+				.userId(userId)
+				.amount(amount)
+				.sagaId(sagaId.toString())
+				.reason(reason)
+				.build();
+
+			feignClient.refundPoint(request);
+
+			log.info("포인트 환불 성공: userId={}, amount={}", userId, amount);
+
+		} catch (Exception e) {
+			log.error("포인트 환불 중 오류 발생: userId={}, amount={}", userId, amount, e);
+			// TODO: 환불 실패 시, 재시도 필요
+			throw new RuntimeException("포인트 환불 실패", e);
 		}
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/QueueAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/QueueAdapter.java
@@ -1,0 +1,30 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.client;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.port.out.QueuePort;
+import com.rushcrew.order_service.infrastructure.adapter.out.client.feign.QueueFeignClient;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueAdapter implements QueuePort {
+
+	private final QueueFeignClient feignClient;
+
+	@Override
+	public boolean validateToken(@NonNull UUID timeDealId, @NonNull Long userId) {
+		try {
+			return feignClient.validateToken(timeDealId.toString(), userId);
+		} catch (Exception e) {
+			log.error("대기열 토큰 검증 실패: timeDealId={}, userId={}", timeDealId, userId, e);
+			return false;
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/TimeDealStockAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/TimeDealStockAdapter.java
@@ -63,7 +63,7 @@ public class TimeDealStockAdapter implements TimeDealStockPort {
 			.optionId(UUID.fromString(response.getOptionId()))
 			.optionName(response.getOptionName())
 			.sellerId(UUID.fromString(response.getSellerId()))
-			.isActive(response.isActive())
+			// .isActive(response.isActive())
 			.build();
 	}
 

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/TimeDealStockAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/TimeDealStockAdapter.java
@@ -1,0 +1,47 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.client;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
+import com.rushcrew.order_service.application.port.dto.TimeDealStatus;
+import com.rushcrew.order_service.application.port.out.TimeDealStockPort;
+
+import com.rushcrew.order_service.infrastructure.adapter.out.client.feign.TimeDealStockFeignClient;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealResponse;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealStatusResponse;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TimeDealStockAdapter implements TimeDealStockPort {
+
+	private final TimeDealStockFeignClient feignClient;
+
+	@Override
+	public TimeDealInfo getTimeDeal(@NonNull UUID timeDealId) {
+		TimeDealResponse response = feignClient.getTimeDeal(timeDealId.toString());
+		TimeDealStatus appStatus = mapStatus(response.getStatus());
+		return TimeDealInfo.builder()
+			.timeDealId(UUID.fromString(response.getTimeDealId()))
+			.title(response.getTitle())
+			.status(appStatus)
+			.discountPrice(response.getDiscountPrice())
+			.discountRate(response.getDiscountRate())
+			.limitQuantity(response.getLimitQuantity())
+			.build();
+	}
+
+	private TimeDealStatus mapStatus(TimeDealStatusResponse infraStatus) {
+		switch (infraStatus) {
+			case SCHEDULED: return TimeDealStatus.SCHEDULED;
+			case IN_PROGRESS: return TimeDealStatus.IN_PROGRESS;
+			case SOLD_OUT: return TimeDealStatus.SOLD_OUT;
+			case ENDED: return TimeDealStatus.ENDED;
+			default: throw new IllegalArgumentException("존재하지 않는 타임딜 상태: " + infraStatus);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/TimeDealStockAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/TimeDealStockAdapter.java
@@ -4,13 +4,21 @@ import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
+import com.rushcrew.order_service.application.port.dto.StockReservationResult;
 import com.rushcrew.order_service.application.port.dto.TimeDealInfo;
 import com.rushcrew.order_service.application.port.dto.TimeDealStatus;
+import com.rushcrew.order_service.application.port.dto.TimeDealStockDetail;
+import com.rushcrew.order_service.application.port.dto.TimeDealStockStatus;
 import com.rushcrew.order_service.application.port.out.TimeDealStockPort;
 
 import com.rushcrew.order_service.infrastructure.adapter.out.client.feign.TimeDealStockFeignClient;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.StockRestoreRequest;
 import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealResponse;
 import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealStatusResponse;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealStockDetailResponse;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealStockStatusResponse;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.StockReservationRequest;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.StockReservationResponse;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +43,60 @@ public class TimeDealStockAdapter implements TimeDealStockPort {
 			.build();
 	}
 
+	@Override
+	public TimeDealStockDetail getTimeDealStockDetail(@NonNull UUID timeDealStockId) {
+		TimeDealStockDetailResponse response = feignClient.getTimeDealStockDetail(timeDealStockId.toString());
+		TimeDealStockStatus appStatus = mapStatus(response.getStatus());
+
+		return TimeDealStockDetail.builder()
+			.timeDealStockId(UUID.fromString(response.getTimeDealStockId()))
+			.timeDealId(UUID.fromString(response.getTimeDealId()))
+			.availableStock(response.getAvailableStock())
+			.reservedStock(response.getReservedStock())
+			.soldStock(response.getSoldStock())
+			.status(appStatus)
+			.productId(UUID.fromString(response.getProductId()))
+			.productName(response.getProductName())
+			.productPrice(response.getProductPrice())
+			.productDescription(response.getProductDescription())
+			.category(response.getCategory())
+			.optionId(UUID.fromString(response.getOptionId()))
+			.optionName(response.getOptionName())
+			.sellerId(UUID.fromString(response.getSellerId()))
+			.isActive(response.isActive())
+			.build();
+	}
+
+	@Override
+	public StockReservationResult reserveStock(@NonNull UUID timeDealStockId, @NonNull Integer quantity, @NonNull Long userId) {
+		StockReservationRequest request = StockReservationRequest.builder()
+			.timeDealStockId(timeDealStockId.toString())
+			.quantity(quantity)
+			.userId(userId)
+			.build();
+
+		StockReservationResponse response = feignClient.reserveStock(request);
+		if (response.isSuccess()) {
+			return StockReservationResult.success(timeDealStockId, quantity);
+		} else {
+			return StockReservationResult.failure(
+				response.getAvailableStock(), response.getMessage()
+			);
+		}
+	}
+
+	@Override
+	public void restoreStock(@NonNull UUID timeDealStockId, @NonNull Integer quantity, @NonNull UUID sagaId,
+		@NonNull String reason) {
+		StockRestoreRequest request = StockRestoreRequest.builder()
+			.timeDealStockId(timeDealStockId.toString())
+			.quantity(quantity)
+			.sagaId(sagaId.toString())
+			.reason(reason)
+			.build();
+		feignClient.restoreStock(request);
+	}
+
 	private TimeDealStatus mapStatus(TimeDealStatusResponse infraStatus) {
 		switch (infraStatus) {
 			case SCHEDULED: return TimeDealStatus.SCHEDULED;
@@ -44,4 +106,15 @@ public class TimeDealStockAdapter implements TimeDealStockPort {
 			default: throw new IllegalArgumentException("존재하지 않는 타임딜 상태: " + infraStatus);
 		}
 	}
+
+	private TimeDealStockStatus mapStatus(TimeDealStockStatusResponse infraStatus) {
+		switch (infraStatus) {
+			case AVAILABLE: return TimeDealStockStatus.AVAILABLE;
+			case RESERVED: return TimeDealStockStatus.RESERVED;
+			case SOLD: return TimeDealStockStatus.SOLD;
+			case PAUSED: return TimeDealStockStatus.PAUSED;
+			default: throw new IllegalArgumentException("존재하지 않는 타임딜 재고 상태: " + infraStatus);
+		}
+	}
 }
+

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/PointFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/PointFeignClient.java
@@ -1,0 +1,14 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.client.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import com.rushcrew.order_service.infrastructure.dto.point.PointDeductRequest;
+import com.rushcrew.order_service.infrastructure.dto.point.PointDeductResponse;
+
+@FeignClient(name = "user-service")
+public interface PointFeignClient {
+	// TODO: USER 서비스 API 확인
+	@PostMapping("/api/v1/points/deduct")
+	PointDeductResponse deductPoint(PointDeductRequest request);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/PointFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/PointFeignClient.java
@@ -2,13 +2,20 @@ package com.rushcrew.order_service.infrastructure.adapter.out.client.feign;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import com.rushcrew.order_service.infrastructure.dto.point.PointDeductRequest;
 import com.rushcrew.order_service.infrastructure.dto.point.PointDeductResponse;
+import com.rushcrew.order_service.infrastructure.dto.point.PointRefundRequest;
+
+// TODO: 영재님 API 확인 요청
 
 @FeignClient(name = "user-service")
 public interface PointFeignClient {
-	// TODO: USER 서비스 API 확인
+
 	@PostMapping("/api/v1/points/deduct")
-	PointDeductResponse deductPoint(PointDeductRequest request);
+	PointDeductResponse deductPoint(@RequestBody PointDeductRequest request);
+
+	@PostMapping("/api/v1/points/refund")
+	void refundPoint(@RequestBody PointRefundRequest request);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/QueueFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/QueueFeignClient.java
@@ -1,0 +1,13 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.client.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import lombok.NonNull;
+
+@FeignClient(name = "queue-service")
+public interface QueueFeignClient {
+	// TODO: 송경님 API 생성 요청 -> 통합 테스트 시 불필요하면 제거
+	@GetMapping("/api/v1/queue/validate")
+	boolean validateToken(String timeDealId, @NonNull Long userId);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/QueueFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/QueueFeignClient.java
@@ -5,9 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 import lombok.NonNull;
 
+// TODO: 송경님 API 생성 요청 -> 통합 테스트 시 불필요하면 제거
+
 @FeignClient(name = "queue-service")
 public interface QueueFeignClient {
-	// TODO: 송경님 API 생성 요청 -> 통합 테스트 시 불필요하면 제거
 	@GetMapping("/api/v1/queue/validate")
 	boolean validateToken(String timeDealId, @NonNull Long userId);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/QueueFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/QueueFeignClient.java
@@ -2,13 +2,15 @@ package com.rushcrew.order_service.infrastructure.adapter.out.client.feign;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import lombok.NonNull;
+import org.springframework.web.bind.annotation.RequestParam;
 
 // TODO: 송경님 API 생성 요청 -> 통합 테스트 시 불필요하면 제거
 
 @FeignClient(name = "queue-service")
 public interface QueueFeignClient {
 	@GetMapping("/api/v1/queue/validate")
-	boolean validateToken(String timeDealId, @NonNull Long userId);
+	boolean validateToken(
+		@RequestParam("timeDealId") String timeDealId,
+		@RequestParam("userId") Long userId
+	);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/TimeDealStockFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/TimeDealStockFeignClient.java
@@ -3,11 +3,29 @@ package com.rushcrew.order_service.infrastructure.adapter.out.client.feign;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
+import com.rushcrew.order_service.infrastructure.dto.timedeal.StockReservationRequest;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.StockReservationResponse;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.StockRestoreRequest;
 import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealResponse;
+import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealStockDetailResponse;
+
+// TODO: 민아님 API 확인 요청
 
 @FeignClient(name = "timedeal-service")
 public interface TimeDealStockFeignClient {
+
 	@GetMapping("/api/v1/timedeals/{timeDealId}")
 	TimeDealResponse getTimeDeal(@PathVariable("timeDealId") String timeDealId);
+
+	@GetMapping("/api/v1/timedeal-stocks/{timeDealStockId}")
+	TimeDealStockDetailResponse getTimeDealStockDetail(@PathVariable("timeDealStockId") String string);
+
+	@PostMapping("/api/v1/timedeal-stocks/reserve")
+	StockReservationResponse reserveStock(@RequestBody StockReservationRequest request);
+
+	@PostMapping("/api/v1/timedeal-stocks/restore")
+	void restoreStock(@RequestBody StockRestoreRequest request);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/TimeDealStockFeignClient.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/client/feign/TimeDealStockFeignClient.java
@@ -1,0 +1,13 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.client.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.rushcrew.order_service.infrastructure.dto.timedeal.TimeDealResponse;
+
+@FeignClient(name = "timedeal-service")
+public interface TimeDealStockFeignClient {
+	@GetMapping("/api/v1/timedeals/{timeDealId}")
+	TimeDealResponse getTimeDeal(@PathVariable("timeDealId") String timeDealId);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/lock/DistributedLockManager.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/lock/DistributedLockManager.java
@@ -1,0 +1,71 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.lock;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedLockManager {
+
+	private final RedissonClient redissonClient;
+
+	/**
+	 * 분산 락을 획득하고 비즈니스 로직 실행
+	 *
+	 * @param lockKey 락 키
+	 * @param waitTime 락 획득 대기 시간
+	 * @param leaseTime 락 보유 시간
+	 * @param timeUnit 시간 단위
+	 * @param supplier 실행할 비즈니스 로직
+	 * @return 비즈니스 로직 실행 결과
+	 */
+	public <T> T executeWithLock(
+		String lockKey,
+		long waitTime,
+		long leaseTime,
+		TimeUnit timeUnit,
+		Supplier<T> supplier
+	) {
+		RLock lock = redissonClient.getLock(lockKey);
+
+		try {
+			boolean acquired = lock.tryLock(waitTime, leaseTime, timeUnit);
+
+			if (!acquired) {
+				log.warn("Failed to acquire lock: {}", lockKey);
+				throw new LockAcquisitionException("락 획득에 실패했습니다: " + lockKey);
+			}
+
+			log.debug("Lock acquired: {}", lockKey);
+			return supplier.get();
+
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.error("Thread interrupted while acquiring lock: {}", lockKey, e);
+			throw new LockAcquisitionException("락 획득 중 인터럽트 발생", e);
+		} finally {
+			if (lock.isHeldByCurrentThread()) {
+				lock.unlock();
+				log.debug("Lock released: {}", lockKey);
+			}
+		}
+	}
+
+	public static class LockAcquisitionException extends RuntimeException {
+		public LockAcquisitionException(String message) {
+			super(message);
+		}
+
+		public LockAcquisitionException(String message, Throwable cause) {
+			super(message, cause);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/messaging/OrderEventPublisher.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/messaging/OrderEventPublisher.java
@@ -1,0 +1,23 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.messaging;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.port.out.OrderEventPort;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderEventPublisher implements OrderEventPort {
+	@Override
+	public void publishStockDepletedEvent(@NonNull UUID timeDealId, @NonNull Long userId,
+		@NonNull Integer availableStock, @NonNull Instant timestamp) {
+		// Outbox를 통해 이벤트 발행
+		// → OrderCreationService에서 Outbox에 이벤트 저장
+		// → Scheduler가 Polling하여 발행
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/outbox/OutboxAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/outbox/OutboxAdapter.java
@@ -1,0 +1,75 @@
+package com.rushcrew.order_service.infrastructure.adapter.outbox;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.port.dto.OutboxEvent;
+import com.rushcrew.order_service.application.port.out.OutboxPort;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.repository.OutboxEventJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxAdapter implements OutboxPort {
+
+	private final OutboxEventJpaRepository outboxRepository;
+
+	@Override
+	public OutboxEvent save(OutboxEvent event) {
+		OutboxEventEntity entity = toEntity(event);
+		OutboxEventEntity savedEntity = outboxRepository.save(entity);
+		return toDomain(savedEntity);
+	}
+
+	@Override
+	public OutboxEvent createAndSave(String aggregateType, UUID aggregateId, String eventType, String payload) {
+		OutboxEvent newEvent = OutboxEvent.builder()
+			.eventId(UUID.randomUUID())
+			.aggregateType(aggregateType)
+			.aggregateId(aggregateId)
+			.eventType(eventType)
+			.payload(payload)
+			.status("PENDING")
+			.createdAt(java.time.Instant.now())
+			.retryCount(0)
+			.build();
+
+		return save(newEvent);
+	}
+
+	private OutboxEventEntity toEntity(OutboxEvent event) {
+		return OutboxEventEntity.builder()
+			.eventId(event.eventId())
+			.aggregateType(event.aggregateType())
+			.aggregateId(event.aggregateId())
+			.eventType(event.eventType())
+			.payload(event.payload())
+			.status(OutboxEventEntity.OutboxStatus.valueOf(event.status()))
+			.createdAt(event.createdAt())
+			.publishedAt(event.publishedAt())
+			.failedAt(event.failedAt())
+			.retryCount(event.retryCount())
+			.errorMessage(event.errorMessage())
+			.build();
+	}
+
+	/* Mapper */
+	private OutboxEvent toDomain(OutboxEventEntity entity) {
+		return OutboxEvent.builder()
+			.eventId(entity.getEventId())
+			.aggregateType(entity.getAggregateType())
+			.aggregateId(entity.getAggregateId())
+			.eventType(entity.getEventType())
+			.payload(entity.getPayload())
+			.status(entity.getStatus().name())
+			.createdAt(entity.getCreatedAt())
+			.publishedAt(entity.getPublishedAt())
+			.failedAt(entity.getFailedAt())
+			.retryCount(entity.getRetryCount())
+			.errorMessage(entity.getErrorMessage())
+			.build();
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/persistence/OrderCommandAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/persistence/OrderCommandAdapter.java
@@ -1,0 +1,21 @@
+package com.rushcrew.order_service.infrastructure.adapter.persistence;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.infrastructure.persistence.repository.OrderJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderCommandAdapter implements OrderCommandPort {
+	private final OrderJpaRepository orderJpaRepository;
+
+	@Override
+	public Integer getTotalPurchasedQuantity(Long userId, UUID timeDealId) {
+		return orderJpaRepository.getTotalPurchasedQuantity(userId, timeDealId);
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/persistence/OrderCommandAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/persistence/OrderCommandAdapter.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.domain.model.order.Order;
 import com.rushcrew.order_service.infrastructure.persistence.repository.OrderJpaRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -17,5 +18,10 @@ public class OrderCommandAdapter implements OrderCommandPort {
 	@Override
 	public Integer getTotalPurchasedQuantity(Long userId, UUID timeDealId) {
 		return orderJpaRepository.getTotalPurchasedQuantity(userId, timeDealId);
+	}
+
+	@Override
+	public Order save(Order order) {
+		return orderJpaRepository.save(order);
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/config/FeignConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/config/FeignConfig.java
@@ -1,0 +1,7 @@
+package com.rushcrew.order_service.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/config/RedissonConfig.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/config/RedissonConfig.java
@@ -1,0 +1,17 @@
+package com.rushcrew.order_service.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Configuration
+public class RedissonConfig {
+	@Bean
+	public RedissonClient redissonClient() throws Exception {
+		Config config = Config.fromYAML(new ClassPathResource("redisson.yml").getInputStream());
+		return Redisson.create(config);
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/point/PointDeductRequest.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/point/PointDeductRequest.java
@@ -1,0 +1,19 @@
+package com.rushcrew.order_service.infrastructure.dto.point;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointDeductRequest {
+	private Long userId;
+	private BigDecimal amount;
+	private String sagaId;
+	private String reason;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/point/PointDeductResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/point/PointDeductResponse.java
@@ -1,0 +1,18 @@
+package com.rushcrew.order_service.infrastructure.dto.point;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointDeductResponse {
+	private boolean success;
+	private String message;
+	private BigDecimal remainingPoint; // 차감 후 남은 포인트
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/point/PointRefundRequest.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/point/PointRefundRequest.java
@@ -1,0 +1,19 @@
+package com.rushcrew.order_service.infrastructure.dto.point;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointRefundRequest {
+	private Long userId;
+	private BigDecimal amount;
+	private String sagaId;
+	private String reason;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockReservationRequest.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockReservationRequest.java
@@ -1,0 +1,17 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockReservationRequest {
+	@NonNull private String timeDealStockId;
+	@NonNull private Integer quantity;
+	@NonNull private Long userId;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockReservationResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockReservationResponse.java
@@ -9,7 +9,7 @@ import lombok.NonNull;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StockReservationResponse {
-	@NonNull private boolean success;
+	private boolean success;
 	@NonNull private Integer availableStock;
 	@NonNull private String message;
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockReservationResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockReservationResponse.java
@@ -1,0 +1,15 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockReservationResponse {
+	@NonNull private boolean success;
+	@NonNull private Integer availableStock;
+	@NonNull private String message;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockRestoreRequest.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/StockRestoreRequest.java
@@ -1,0 +1,18 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StockRestoreRequest {
+	@NonNull private String timeDealStockId;
+	@NonNull private Integer quantity;
+	@NonNull private String sagaId;
+	@NonNull private String reason;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealResponse.java
@@ -1,0 +1,19 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeDealResponse {
+	@NonNull private String timeDealId;
+	@NonNull private String title;
+	@NonNull private TimeDealStatusResponse status;
+	@NonNull private BigDecimal discountPrice;
+	@NonNull private Integer discountRate;
+	@NonNull private Integer limitQuantity;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStatusResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStatusResponse.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+public enum TimeDealStatusResponse {
+	SCHEDULED,
+	IN_PROGRESS,
+	SOLD_OUT,
+	ENDED
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStockDetailResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStockDetailResponse.java
@@ -1,0 +1,31 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeDealStockDetailResponse {
+	@NonNull private String timeDealStockId;
+	@NonNull private String timeDealId;
+	@NonNull private String productId;
+	@NonNull private String optionId;
+	@NonNull private Integer availableStock;     // 주문 가능한 재고
+	@NonNull private Integer reservedStock;      // 예약된 재고
+	@NonNull private Integer soldStock;          // 판매 완료된 재고
+	@NonNull private TimeDealStockStatusResponse status;
+
+	// 상품 정보 - 타임딜 서비스가 상품 서비스에서 조회해서 포함시켜줌
+	@NonNull private String productName;
+	@NonNull private String productDescription;
+	@NonNull private BigDecimal productPrice; // 원가
+	@NonNull private String category;
+	@NonNull private String optionName;
+	@NonNull private String sellerId;
+	@NonNull private String sellerName;
+	@NonNull private boolean isActive;
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStockDetailResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStockDetailResponse.java
@@ -27,5 +27,5 @@ public class TimeDealStockDetailResponse {
 	@NonNull private String optionName;
 	@NonNull private String sellerId;
 	@NonNull private String sellerName;
-	@NonNull private boolean isActive;
+	private boolean isActive;
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStockStatusResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/dto/timedeal/TimeDealStockStatusResponse.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.infrastructure.dto.timedeal;
+
+public enum TimeDealStockStatusResponse {
+	AVAILABLE,
+	RESERVED,
+	SOLD,
+	PAUSED
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/outbox/entity/OutboxEventEntity.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/outbox/entity/OutboxEventEntity.java
@@ -1,0 +1,104 @@
+package com.rushcrew.order_service.infrastructure.persistence.outbox.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+	name = "p_outbox_event",
+	schema = "order_schema",
+	indexes = {
+		@Index(name = "idx_status_created_at", columnList = "status, createdAt"),
+		@Index(name = "idx_aggregate_id", columnList = "aggregateId")
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class OutboxEventEntity {
+
+	@Id
+	private UUID eventId;
+
+	@Column(nullable = false, length = 50)
+	private String aggregateType;
+
+	@Column(nullable = false)
+	private UUID aggregateId;
+
+	@Column(nullable = false, length = 100)
+	private String eventType;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String payload;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private OutboxStatus status;
+
+	@Column(nullable = false)
+	private Instant createdAt;
+
+	private Instant publishedAt;
+
+	private Instant failedAt;
+
+	@Column(columnDefinition = "TEXT")
+	private String errorMessage;
+
+	@Column(nullable = false)
+	@Builder.Default
+	private Integer retryCount = 0;
+
+	public static OutboxEventEntity create(
+		String aggregateType,
+		UUID aggregateId,
+		String eventType,
+		String payload
+	) {
+		return OutboxEventEntity.builder()
+			.eventId(UUID.randomUUID())
+			.aggregateType(aggregateType)
+			.aggregateId(aggregateId)
+			.eventType(eventType)
+			.payload(payload)
+			.status(OutboxStatus.PENDING)
+			.createdAt(Instant.now())
+			.retryCount(0)
+			.build();
+	}
+
+	public void markAsPublished() {
+		this.status = OutboxStatus.PUBLISHED;
+		this.publishedAt = Instant.now();
+	}
+
+	public void markAsFailed(String errorMessage) {
+		this.status = OutboxStatus.FAILED;
+		this.failedAt = Instant.now();
+		this.errorMessage = errorMessage;
+		this.retryCount++;
+	}
+
+	public boolean canRetry() {
+		return this.retryCount < 3 && this.status == OutboxStatus.FAILED;
+	}
+
+	public void retry() {
+		if (!canRetry()) {
+			throw new IllegalStateException("재시도 불가능한 상태입니다.");
+		}
+		this.status = OutboxStatus.PENDING;
+		this.errorMessage = null;
+	}
+
+	public enum OutboxStatus {
+		PENDING,
+		PUBLISHED,
+		FAILED
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/outbox/repository/OutboxEventJpaRepository.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/outbox/repository/OutboxEventJpaRepository.java
@@ -1,10 +1,64 @@
 package com.rushcrew.order_service.infrastructure.persistence.outbox.repository;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity.OutboxStatus;
 
 public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventEntity, UUID> {
+
+	/**
+	 * PENDING 상태의 이벤트 조회 (Polling용)
+	 * LIMIT 100 → Pageable 사용
+	 */
+	@Query("SELECT o FROM OutboxEventEntity o " +
+		"WHERE o.status = 'PENDING' " +
+		"ORDER BY o.createdAt ASC")
+	List<OutboxEventEntity> findPendingEvents(Pageable pageable);
+
+
+	/**
+	 * 재시도 대상 FAILED 이벤트 조회
+	 * LIMIT 50 → Pageable 사용
+	 */
+	@Query("SELECT o FROM OutboxEventEntity o " +
+		"WHERE o.status = 'FAILED' " +
+		"AND o.retryCount < 3 " +
+		"AND o.failedAt < :oneHourAgo " +
+		"ORDER BY o.failedAt ASC")
+	List<OutboxEventEntity> findFailedEventsForRetry(
+		@Param("oneHourAgo") Instant oneHourAgo,
+		Pageable pageable
+	);
+
+
+	/**
+	 * 오래된 PUBLISHED 이벤트 삭제 (정리용)
+	 */
+	@Modifying
+	@Query("DELETE FROM OutboxEventEntity o " +
+		"WHERE o.status = 'PUBLISHED' " +
+		"AND o.publishedAt < :before")
+	int deletePublishedEventsBefore(@Param("before") Instant before);
+
+
+	/**
+	 * 특정 Aggregate의 이벤트 조회
+	 */
+	List<OutboxEventEntity> findByAggregateIdOrderByCreatedAtDesc(UUID aggregateId);
+
+
+	/**
+	 * 상태 카운트 메트릭용
+	 * (예: countByStatus(FAILED))
+	 */
+	long countByStatus(OutboxStatus status);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/outbox/repository/OutboxEventJpaRepository.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/outbox/repository/OutboxEventJpaRepository.java
@@ -1,0 +1,10 @@
+package com.rushcrew.order_service.infrastructure.persistence.outbox.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity;
+
+public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventEntity, UUID> {
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/repository/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/repository/OrderJpaRepository.java
@@ -1,0 +1,24 @@
+package com.rushcrew.order_service.infrastructure.persistence.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.rushcrew.order_service.domain.model.order.Order;
+
+public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
+
+	@Query(value = """
+        SELECT COALESCE(SUM(oi.quantity), 0)
+        FROM order_schema.p_order_item oi
+        JOIN order_schema.p_order o ON oi.order_id = o.order_id
+        WHERE o.user_id = :userId
+          AND oi.product_snapshot ->> 'timeDealId' = :timeDealId
+          AND o.status IN ('PAID', 'PURCHASE_CONFIRMED')
+    """, nativeQuery = true)
+	Integer getTotalPurchasedQuantity(
+		@Param("userId") Long userId,
+		@Param("timeDealId") UUID timeDealId);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/saga/repository/SagaInstanceJpaRepository.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/saga/repository/SagaInstanceJpaRepository.java
@@ -1,0 +1,15 @@
+package com.rushcrew.order_service.infrastructure.persistence.saga.repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+import com.rushcrew.order_service.domain.model.saga.SagaInstance;
+
+public interface SagaInstanceJpaRepository extends JpaRepository<SagaInstance, UUID> {
+
+	List<SagaInstance> findByStatusAndCreatedAtBefore(SagaStatus status, Instant createdAt);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/scheduler/OutboxEventScheduler.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/scheduler/OutboxEventScheduler.java
@@ -1,0 +1,177 @@
+package com.rushcrew.order_service.infrastructure.scheduler;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.repository.OutboxEventJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventScheduler {
+
+	private final OutboxEventJpaRepository outboxRepository;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	/**
+	 * 5초마다 PENDING 이벤트를 Kafka로 발행
+	 */
+	@Scheduled(fixedDelay = 5000)
+	public void publishPendingEvents() {
+		List<OutboxEventEntity> pendingEvents =
+			outboxRepository.findPendingEvents(Pageable.ofSize(100));
+
+		if (pendingEvents.isEmpty()) {
+			return;
+		}
+
+		log.info("발행 대기 중인 Outbox 이벤트 {}개 발견", pendingEvents.size());
+
+		for (OutboxEventEntity event : pendingEvents) {
+			publishEventWithTransaction(event);
+		}
+	}
+
+	/**
+	 * 이벤트를 별도 트랜잭션으로 발행하여 상태 업데이트 보장
+	 */
+	@Transactional
+	public void publishEventWithTransaction(OutboxEventEntity event) {
+		try {
+			String topic = getTopicName(event.getEventType());
+
+			// 동기 방식으로 발행하여 트랜잭션 내에서 상태 업데이트
+			try {
+				kafkaTemplate.send(topic, event.getAggregateId().toString(), event.getPayload())
+					.get(); // Future.get()으로 동기 대기
+
+				event.markAsPublished();
+				outboxRepository.save(event);
+				log.debug("Outbox 이벤트 발행 성공: eventId={}, eventType={}",
+					event.getEventId(), event.getEventType());
+
+			} catch (java.util.concurrent.ExecutionException e) {
+				Throwable cause = e.getCause() != null ? e.getCause() : e;
+				log.error("Outbox 이벤트 발행 실패: eventId={}, eventType={}",
+					event.getEventId(), event.getEventType(), cause);
+				event.markAsFailed(cause.getMessage());
+				outboxRepository.save(event);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				log.error("Outbox 이벤트 발행 중 인터럽트 발생: eventId={}, eventType={}",
+					event.getEventId(), event.getEventType(), e);
+				event.markAsFailed("이벤트 발행 중 인터럽트 발생");
+				outboxRepository.save(event);
+			} catch (Exception e) {
+				log.error("Outbox 이벤트 발행 실패: eventId={}, eventType={}",
+					event.getEventId(), event.getEventType(), e);
+				event.markAsFailed(e.getMessage());
+				outboxRepository.save(event);
+			}
+
+		} catch (Exception e) {
+			log.error("Outbox 이벤트 처리 중 오류: eventId={}", event.getEventId(), e);
+			// 트랜잭션 내에서 실패 처리
+			event.markAsFailed(e.getMessage());
+			outboxRepository.save(event);
+		}
+	}
+
+
+	/**
+	 * 10분마다 FAILED 이벤트 재시도
+	 */
+	@Scheduled(fixedDelay = 600000)
+	public void retryFailedEvents() {
+		Instant oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS);
+
+		List<OutboxEventEntity> failedEvents =
+			outboxRepository.findFailedEventsForRetry(oneHourAgo, Pageable.ofSize(50));
+
+		if (failedEvents.isEmpty()) {
+			return;
+		}
+
+		log.info("재시도 대상 Outbox 이벤트 {}개 발견", failedEvents.size());
+
+		for (OutboxEventEntity event : failedEvents) {
+			if (event.canRetry()) {
+				// 재시도 상태로 변경 후 즉시 발행 시도
+				retryEventWithTransaction(event);
+			}
+		}
+	}
+
+	/**
+	 * 이벤트 재시도를 별도 트랜잭션으로 처리
+	 */
+	@Transactional
+	public void retryEventWithTransaction(OutboxEventEntity event) {
+		try {
+			event.retry();
+			outboxRepository.save(event);
+
+			// 즉시 발행 시도
+			publishEventWithTransaction(event);
+
+		} catch (Exception e) {
+			log.error("이벤트 재시도 실패: eventId={}", event.getEventId(), e);
+		}
+	}
+
+
+	/**
+	 * 매일 자정에 7일 이상 지난 PUBLISHED 이벤트 삭제
+	 */
+	@Scheduled(cron = "0 0 0 * * ?")
+	@Transactional
+	public void cleanupOldEvents() {
+		Instant sevenDaysAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+		int deletedCount = outboxRepository.deletePublishedEventsBefore(sevenDaysAgo);
+
+		if (deletedCount > 0) {
+			log.info("오래된 Outbox 이벤트 {}개 삭제 완료", deletedCount);
+		}
+	}
+
+	private String getTopicName(String eventType) {
+		return switch (eventType) {
+			// 주문 이벤트
+			case "ORDER_CREATED" -> "order.created";
+			case "ORDER_UPDATED" -> "order.updated";
+			case "ORDER_CANCELLED" -> "order.cancelled";
+			case "ORDER_PAID" -> "order.paid";
+			case "ORDER_PURCHASE_CONFIRMED" -> "order.purchase.confirmed";
+			case "ORDER_REFUNDED" -> "order.refunded";
+
+			// 결제 이벤트
+			case "PAYMENT_COMPLETED" -> "payment.completed";
+			case "PAYMENT_CANCELLED" -> "payment.cancelled";
+			case "REFUND_REQUESTED" -> "payment.refund.requested";
+
+			// 포인트 이벤트
+			case "POINT_EARN_REQUESTED" -> "point.earn.requested";
+			case "POINT_REFUND_REQUESTED" -> "point.refund.requested";
+
+			// 재고 이벤트
+			case "STOCK_RESERVATION_CANCELLED" -> "stock.reservation.cancelled";
+			case "STOCK_ROLLBACK_REQUESTED" -> "stock.rollback.requested";
+
+			default -> {
+				log.warn("알 수 없는 이벤트 타입: {}, 기본 토픽 사용: order.events", eventType);
+				yield "order.events";
+			}
+		};
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/scheduler/SagaRecoveryScheduler.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/scheduler/SagaRecoveryScheduler.java
@@ -1,0 +1,62 @@
+package com.rushcrew.order_service.infrastructure.scheduler;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.saga.service.SagaRecoveryService;
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+import com.rushcrew.order_service.domain.model.saga.SagaInstance;
+import com.rushcrew.order_service.infrastructure.persistence.saga.repository.SagaInstanceJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SagaRecoveryScheduler {
+
+	private final SagaInstanceJpaRepository sagaRepository;
+	private final SagaRecoveryService sagaRecoveryService;
+
+	/**
+	 * 10분마다 타임아웃된 Saga 복구
+	 */
+	@Scheduled(fixedDelay = 600000)
+	public void recoverTimedOutSagas() {
+		Instant tenMinutesAgo = Instant.now().minus(10, ChronoUnit.MINUTES);
+
+		List<SagaInstance> timedOutSagas = sagaRepository
+			.findByStatusAndCreatedAtBefore(SagaStatus.RUNNING, tenMinutesAgo);
+
+		if (timedOutSagas.isEmpty()) {
+			return;
+		}
+
+		log.warn("타임아웃된 Saga {}개 발견", timedOutSagas.size());
+
+		for (SagaInstance saga : timedOutSagas) {
+			try {
+				// 보상 트랜잭션 실행
+				sagaRecoveryService.compensateSaga(saga);
+				sagaRepository.save(saga);
+
+				log.info("Saga 타임아웃 처리 완료: sagaId={}", saga.getSagaId());
+
+			} catch (Exception e) {
+				log.error("Saga 타임아웃 처리 실패: sagaId={}", saga.getSagaId(), e);
+				// 실패해도 상태는 업데이트
+				try {
+					saga.fail("Saga 타임아웃 - 복구 실패: " + e.getMessage());
+					sagaRepository.save(saga);
+				} catch (Exception saveEx) {
+					log.error("Saga 상태 저장 실패: sagaId={}", saga.getSagaId(), saveEx);
+				}
+			}
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
@@ -1,0 +1,56 @@
+package com.rushcrew.order_service.presentation.api.command;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.command.usecase.CreateOrderUseCase;
+import com.rushcrew.order_service.global.util.RoleChecker;
+import com.rushcrew.order_service.presentation.dto.request.CreateOrderRequest;
+import com.rushcrew.order_service.presentation.dto.response.CreateOrderResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderCommandController {
+
+	private final CreateOrderUseCase createOrderUseCase;
+
+	@PostMapping
+	public ApiResponse<CreateOrderResponse> createOrder(
+		@Valid @RequestBody CreateOrderRequest request,
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader(value = "X-User-Role", required = false) String role
+	) {
+		RoleChecker.checkRole(role, "USER", "MASTER", "SELLER");
+
+		CreateOrderCommand command = CreateOrderCommand.builder()
+			.userId(userId)
+			.timeDealId(UUID.fromString(request.timeDealId()))
+			.orderItems(request.orderItems().stream()
+				.map(item -> CreateOrderCommand.OrderItemCommand.builder()
+					.timeDealStockId(UUID.fromString(item.timeDealStockId()))
+					.quantity(item.quantity())
+					.build())
+				.collect(Collectors.toList()))
+			.pointUsed(request.pointUsed())
+			.shippingInfo(request.shippingInfo().toShippingInfo())
+			.build();
+
+		CreateOrderResult result = createOrderUseCase.createOrder(command);
+
+		return ApiResponse.success(CreateOrderResponse.from(result));
+	}
+
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/request/CreateOrderRequest.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/request/CreateOrderRequest.java
@@ -1,0 +1,80 @@
+package com.rushcrew.order_service.presentation.dto.request;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateOrderRequest(
+
+	@NotBlank(message = "타임딜 ID는 필수입니다")
+	String timeDealId,
+
+	@NotNull(message = "주문 아이템은 필수입니다")
+	@Size(min = 1, message = "최소 1개 이상의 상품이 필요합니다")
+	@Valid
+	List<OrderItemRequest> orderItems,
+
+	@NotNull(message = "포인트 사용량은 필수입니다")
+	@Min(value = 0, message = "포인트 사용량은 0 이상이어야 합니다")
+	BigDecimal pointUsed,
+
+	@NotNull(message = "배송 정보는 필수입니다")
+	@Valid
+	ShippingInfoRequest shippingInfo
+) {
+
+	public record OrderItemRequest(
+
+		@NotBlank(message = "타임딜 재고 ID는 필수입니다")
+		String timeDealStockId,
+
+		@NotNull(message = "수량은 필수입니다")
+		@Min(value = 1, message = "수량은 1개 이상이어야 합니다")
+		Integer quantity
+	) {}
+
+	public record ShippingInfoRequest(
+
+		@NotBlank(message = "수령인 이름은 필수입니다")
+		@Size(max = 50, message = "수령인 이름은 50자 이내여야 합니다")
+		String recipientName,
+
+		@NotBlank(message = "수령인 연락처는 필수입니다")
+		@Pattern(regexp = "^01[0-9]{8,9}$", message = "올바른 휴대폰 번호 형식이 아닙니다")
+		String recipientPhone,
+
+		@NotBlank(message = "우편번호는 필수입니다")
+		@Pattern(regexp = "^[0-9]{5}$", message = "우편번호는 5자리 숫자여야 합니다")
+		String zipCode,
+
+		@NotBlank(message = "기본 주소는 필수입니다")
+		@Size(max = 255, message = "기본 주소는 255자 이내여야 합니다")
+		String addressBase,
+
+		@NotBlank(message = "상세 주소는 필수입니다")
+		@Size(max = 255, message = "상세 주소는 255자 이내여야 합니다")
+		String addressDetail,
+
+		@Size(max = 100, message = "배송 메시지는 100자 이내여야 합니다")
+		String deliveryMessage
+	) {
+		public ShippingInfo toShippingInfo() {
+			return ShippingInfo.builder()
+				.recipientName(recipientName)
+				.recipientPhone(recipientPhone)
+				.zipCode(zipCode)
+				.addressBase(addressBase)
+				.addressDetail(addressDetail)
+				.deliveryMessage(deliveryMessage)
+				.build();
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/CreateOrderResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/CreateOrderResponse.java
@@ -1,0 +1,63 @@
+package com.rushcrew.order_service.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateOrderResponse {
+	private UUID orderId;
+	private String orderStatus;
+	private BigDecimal totalAmount;
+	private BigDecimal pointUsed;
+	private BigDecimal finalAmount;
+	private Instant orderedAt;
+	private Instant reservationExpiresAt;
+	private String message;
+	private List<OrderItemResponse> orderItems;
+
+	@Getter
+	@AllArgsConstructor
+	public static class OrderItemResponse {
+		private UUID orderItemId;
+		private String productName;
+		private String optionName;
+		private Integer quantity;
+		private BigDecimal unitPrice;
+		private BigDecimal discountPrice;
+		private BigDecimal subtotal;
+	}
+
+	public static CreateOrderResponse from(CreateOrderResult result) {
+		List<OrderItemResponse> items = result.orderItems().stream()
+			.map(item -> new OrderItemResponse(
+				item.orderItemId(),
+				item.productName(),
+				item.optionName(),
+				item.quantity(),
+				item.unitPrice(),
+				item.discountPrice(),
+				item.subtotal()
+			))
+			.toList();
+
+		return new CreateOrderResponse(
+			result.orderId(),
+			result.orderStatus(),
+			result.totalAmount(),
+			result.pointUsed(),
+			result.finalAmount(),
+			result.orderedAt(),
+			result.reservationExpiresAt(),
+			"주문이 성공적으로 생성되었습니다. 15분 내에 결제를 완료해주세요.",
+			items
+		);
+	}
+}

--- a/order-service/src/main/resources/application.yaml
+++ b/order-service/src/main/resources/application.yaml
@@ -1,4 +1,7 @@
 spring:
+  application:
+    name: order-service
+
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration

--- a/order-service/src/test/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestratorTest.java
+++ b/order-service/src/test/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestratorTest.java
@@ -1,0 +1,294 @@
+package com.rushcrew.order_service.application.saga.orchestrator;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.saga.dto.OrderCreationSagaData;
+import com.rushcrew.order_service.application.saga.dto.SagaContext;
+import com.rushcrew.order_service.application.saga.dto.SagaStepResult;
+import com.rushcrew.order_service.application.saga.step.CreateOrderStep;
+import com.rushcrew.order_service.application.saga.step.DeductPointStep;
+import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
+import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderCreationSagaOrchestrator 테스트")
+class OrderCreationSagaOrchestratorTest {
+
+	@Mock
+	private ValidateStockStep validateStockStep;
+
+	@Mock
+	private ReserveStockStep reserveStockStep;
+
+	@Mock
+	private DeductPointStep deductPointStep;
+
+	@Mock
+	private CreateOrderStep createOrderStep;
+
+	@InjectMocks
+	private OrderCreationSagaOrchestrator orchestrator;
+
+	private CreateOrderCommand command;
+	private UUID orderId;
+
+	@BeforeEach
+	void setUp() {
+		orderId = UUID.randomUUID();
+
+		ShippingInfo shippingInfo = ShippingInfo.create(
+			"홍길동",
+			"01012345678",
+			"12345",
+			"서울시 강남구",
+			"101동 101호",
+			"문 앞에 놔주세요"
+		);
+
+		command = CreateOrderCommand.builder()
+			.userId(1L)
+			.timeDealId(UUID.randomUUID())
+			.orderItems(List.of(
+				CreateOrderCommand.OrderItemCommand.builder()
+					.timeDealStockId(UUID.randomUUID())
+					.quantity(2)
+					.build()
+			))
+			.pointUsed(BigDecimal.valueOf(1000))
+			.shippingInfo(shippingInfo)
+			.build();
+	}
+
+	@Test
+	@DisplayName("주문 생성 성공 - 모든 Step이 성공적으로 완료")
+	void testCreateOrder_Success() {
+		// given
+		// Step 1: ValidateStock
+		when(validateStockStep.execute(any(SagaContext.class), any(OrderCreationSagaData.class)))
+			.thenReturn(SagaStepResult.success());
+
+		// Step 2: ReserveStock - OrderItems 설정 후 성공 반환
+		doAnswer(invocation -> {
+			OrderCreationSagaData data = invocation.getArgument(1);
+
+			// OrderItems 설정
+			data.setOrderItems(List.of(
+				CreateOrderResult.OrderItemResult.builder()
+					.orderItemId(UUID.randomUUID())
+					.timeDealStockId(UUID.randomUUID())
+					.productId(UUID.randomUUID())
+					.productName("테스트 상품")
+					.optionName("옵션1")
+					.quantity(2)
+					.unitPrice(BigDecimal.valueOf(10000))
+					.discountPrice(BigDecimal.valueOf(8000))
+					.subtotal(BigDecimal.valueOf(16000))
+					.build()
+			));
+			data.setTotalAmount(BigDecimal.valueOf(16000));
+			data.setFinalAmount(BigDecimal.valueOf(15000));
+
+			return SagaStepResult.success(); // SagaStepResult 반환 * --> execute()에서 반드시 SagaStepResult를 return 해야 함
+		}).when(reserveStockStep).execute(any(SagaContext.class), any(OrderCreationSagaData.class));
+
+		// Step 3: DeductPoint
+		when(deductPointStep.execute(any(SagaContext.class), any(OrderCreationSagaData.class)))
+			.thenReturn(SagaStepResult.success());
+
+		// Step 4: CreateOrder - orderId와 시간 정보 설정 후 성공 반환
+		doAnswer(invocation -> {
+			SagaContext ctx = invocation.getArgument(0);
+			OrderCreationSagaData data = invocation.getArgument(1);
+
+			// Context에 데이터 저장
+			ctx.setData("orderId", orderId);
+			ctx.setData("reservationExpiresAt", Instant.now().plusSeconds(900));
+			ctx.setData("orderedAt", Instant.now());
+			ctx.setData("orderStatus", "PENDING");
+
+			// SagaData에 orderId 설정
+			data.setOrderId(orderId);
+
+			return SagaStepResult.success(); // SagaStepResult 반환 * --> execute()에서 반드시 SagaStepResult를 return 해야 함
+		}).when(createOrderStep).execute(any(SagaContext.class), any(OrderCreationSagaData.class));
+
+		// when
+		CreateOrderResult result = orchestrator.execute(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(orderId);
+		assertThat(result.userId()).isEqualTo(1L);
+		assertThat(result.orderStatus()).isEqualTo("PENDING");
+		assertThat(result.totalAmount()).isEqualByComparingTo(BigDecimal.valueOf(16000));
+		assertThat(result.pointUsed()).isEqualByComparingTo(BigDecimal.valueOf(1000));
+		assertThat(result.finalAmount()).isEqualByComparingTo(BigDecimal.valueOf(15000));
+		assertThat(result.orderItems()).isNotEmpty();
+		assertThat(result.orderItems()).hasSize(1);
+		assertThat(result.orderItems().get(0).productName()).isEqualTo("테스트 상품");
+
+		// verify - 각 Step이 정확히 1번씩 호출되었는지 확인
+		verify(validateStockStep, times(1)).execute(any(SagaContext.class), any(OrderCreationSagaData.class));
+		verify(reserveStockStep, times(1)).execute(any(SagaContext.class), any(OrderCreationSagaData.class));
+		verify(deductPointStep, times(1)).execute(any(SagaContext.class), any(OrderCreationSagaData.class));
+		verify(createOrderStep, times(1)).execute(any(SagaContext.class), any(OrderCreationSagaData.class));
+
+		// 보상 트랜잭션이 호출되지 않았는지 확인
+		verify(reserveStockStep, never()).compensate(any(), any());
+		verify(deductPointStep, never()).compensate(any(), any());
+	}
+
+	@Test
+	@DisplayName("Step 2 실패 - ReserveStock 실패 시 보상 트랜잭션 없음")
+	void testCreateOrder_ReserveStockFails() {
+		// given
+		when(validateStockStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.success());
+
+		when(reserveStockStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.failure("재고 부족"));
+
+		// when & then
+		assertThatThrownBy(() -> orchestrator.execute(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("재고 부족");
+
+		// verify
+		verify(validateStockStep, times(1)).execute(any(), any());
+		verify(reserveStockStep, times(1)).execute(any(), any());
+		verify(deductPointStep, never()).execute(any(), any());
+		verify(createOrderStep, never()).execute(any(), any());
+
+		// Step 1은 조회만 하므로 보상 불필요
+		verify(reserveStockStep, never()).compensate(any(), any());
+	}
+
+	@Test
+	@DisplayName("Step 3 실패 - DeductPoint 실패 시 재고 복구")
+	void testCreateOrder_DeductPointFails() {
+		// given
+		when(validateStockStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.success());
+
+		doAnswer(invocation -> {
+			OrderCreationSagaData data = invocation.getArgument(1);
+			data.setOrderItems(List.of(
+				CreateOrderResult.OrderItemResult.builder()
+					.orderItemId(UUID.randomUUID())
+					.productName("테스트 상품")
+					.quantity(2)
+					.unitPrice(BigDecimal.valueOf(10000))
+					.discountPrice(BigDecimal.valueOf(8000))
+					.subtotal(BigDecimal.valueOf(16000))
+					.build()
+			));
+			data.setTotalAmount(BigDecimal.valueOf(16000));
+			data.setFinalAmount(BigDecimal.valueOf(15000));
+			return SagaStepResult.success();
+		}).when(reserveStockStep).execute(any(), any());
+
+		when(deductPointStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.failure("포인트 부족"));
+
+		// when & then
+		assertThatThrownBy(() -> orchestrator.execute(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("포인트 부족");
+
+		// verify
+		verify(validateStockStep, times(1)).execute(any(), any());
+		verify(reserveStockStep, times(1)).execute(any(), any());
+		verify(deductPointStep, times(1)).execute(any(), any());
+		verify(createOrderStep, never()).execute(any(), any());
+
+		// 보상 트랜잭션: ReserveStock만 복구
+		verify(reserveStockStep, times(1)).compensate(any(), any());
+		verify(deductPointStep, never()).compensate(any(), any());
+	}
+
+	@Test
+	@DisplayName("Step 4 실패 - CreateOrder 실패 시 포인트 환불 + 재고 복구")
+	void testCreateOrder_CreateOrderFails() {
+		// given
+		when(validateStockStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.success());
+
+		doAnswer(invocation -> {
+			OrderCreationSagaData data = invocation.getArgument(1);
+			data.setOrderItems(List.of(
+				CreateOrderResult.OrderItemResult.builder()
+					.orderItemId(UUID.randomUUID())
+					.productName("테스트 상품")
+					.quantity(2)
+					.unitPrice(BigDecimal.valueOf(10000))
+					.discountPrice(BigDecimal.valueOf(8000))
+					.subtotal(BigDecimal.valueOf(16000))
+					.build()
+			));
+			data.setTotalAmount(BigDecimal.valueOf(16000));
+			data.setFinalAmount(BigDecimal.valueOf(15000));
+			return SagaStepResult.success();
+		}).when(reserveStockStep).execute(any(), any());
+
+		when(deductPointStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.success());
+
+		when(createOrderStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.failure("DB 저장 실패"));
+
+		// when & then
+		assertThatThrownBy(() -> orchestrator.execute(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("DB 저장 실패");
+
+		// verify
+		verify(validateStockStep, times(1)).execute(any(), any());
+		verify(reserveStockStep, times(1)).execute(any(), any());
+		verify(deductPointStep, times(1)).execute(any(), any());
+		verify(createOrderStep, times(1)).execute(any(), any());
+
+		// 보상 트랜잭션: DeductPoint + ReserveStock 순서대로 복구
+		verify(deductPointStep, times(1)).compensate(any(), any());
+		verify(reserveStockStep, times(1)).compensate(any(), any());
+	}
+
+	@Test
+	@DisplayName("Step 1 실패 - ValidateStock 실패 시 보상 트랜잭션 없음")
+	void testCreateOrder_ValidateStockFails() {
+		// given
+		when(validateStockStep.execute(any(), any()))
+			.thenReturn(SagaStepResult.failure("대기열 토큰 없음"));
+
+		// when & then
+		assertThatThrownBy(() -> orchestrator.execute(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("대기열 토큰 없음");
+
+		// verify
+		verify(validateStockStep, times(1)).execute(any(), any());
+		verify(reserveStockStep, never()).execute(any(), any());
+		verify(deductPointStep, never()).execute(any(), any());
+		verify(createOrderStep, never()).execute(any(), any());
+
+		// Step 1은 조회만 하므로 보상 불필요
+		verify(reserveStockStep, never()).compensate(any(), any());
+		verify(deductPointStep, never()).compensate(any(), any());
+	}
+}


### PR DESCRIPTION
## 🧾 Summary
- 주문 생성은 로직이 많아서 커밋을 신경써서 나누려고 노력했습니다.
- Saga + CQRS + Outbox 패턴 적용하여 주문 생성 기능 구현


## 주문 생성 프로세스 흐름도
```mermaid
flowchart TD

A[Client] -->|POST /api/v1/orders| B[OrderCommandController]
B -->|CreateOrderRequest → CreateOrderCommand| C[CreateOrderService]

C --> D["OrderCreationSagaOrchestrator
(Saga Pattern)"]

D --> E["Step 1: ValidateStockStep
- QueueTokenValidator
- TimeDealValidator
- OrderItemValidator
- PurchaseLimitValidator"]

D --> F["Step 2: ReserveStockStep
- DistributedLockManager
- reserveStock()
- publishStockDepletedEvent()"]

D --> G["Step 3: DeductPointStep
- deductPoint()"]

D --> H["Step 4: CreateOrderStep
- Order.create()
- save()
- createAndSave(OutboxEvent)"]

H --> I["OrderCachePort.saveOrderCache() (Redis)"]
I --> J["CreateOrderResult → CreateOrderResponse"]
J --> A
```

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [x] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #113 
