### PR TITLE
Feat(order): 주문 구매확정 및 포인트 적립 요청 기능 구현 + 서비스 단위 테스트

### DIFF
--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/ConfirmPurchaseCommand.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/ConfirmPurchaseCommand.java
@@ -1,0 +1,11 @@
+package com.rushcrew.order_service.application.command.dto.command;
+
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record ConfirmPurchaseCommand(
+	UUID orderId,
+	Long userId
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/ConfirmPurchaseResult.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/ConfirmPurchaseResult.java
@@ -1,0 +1,13 @@
+package com.rushcrew.order_service.application.command.dto.result;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record ConfirmPurchaseResult(
+	UUID orderId,
+	String orderStatus,
+	Instant purchaseConfirmedAt
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/ConfirmPurchaseService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/ConfirmPurchaseService.java
@@ -1,0 +1,18 @@
+package com.rushcrew.order_service.application.command.service;
+
+import org.springframework.stereotype.Service;
+
+import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
+import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
+import com.rushcrew.order_service.application.command.usecase.ConfirmPurchaseUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ConfirmPurchaseService implements ConfirmPurchaseUseCase {
+	@Override
+	public ConfirmPurchaseResult confirmPurchase(ConfirmPurchaseCommand command) {
+		return null;
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/ConfirmPurchaseService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/ConfirmPurchaseService.java
@@ -1,18 +1,89 @@
 package com.rushcrew.order_service.application.command.service;
 
-import org.springframework.stereotype.Service;
+import java.time.Instant;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
 import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
 import com.rushcrew.order_service.application.command.usecase.ConfirmPurchaseUseCase;
+import com.rushcrew.order_service.application.port.out.OutboxPort;
+import com.rushcrew.order_service.application.port.out.PointEventPort;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ConfirmPurchaseService implements ConfirmPurchaseUseCase {
+
+	private final OrderCommandPort orderCommandPort;
+	private final PointEventPort pointEventPort;
+	private final OutboxPort outboxPort;
+	private final ObjectMapper objectMapper;
+
 	@Override
+	@Transactional
 	public ConfirmPurchaseResult confirmPurchase(ConfirmPurchaseCommand command) {
-		return null;
+		log.info("구매확정 처리 시작: orderId={}, userId={}", command.orderId(), command.userId());
+
+		Order order = orderCommandPort.findById(command.orderId())
+			.orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+		if (!order.isOwnedBy(command.userId())) {
+			throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+		}
+
+		// 구매확정 가능 상태 검증
+		if (!order.canConfirmPurchase()) {
+			throw new BusinessException(OrderErrorCode.ORDER_CANNOT_CONFIRM_PURCHASE);
+		}
+
+		// 주문 상태 변경 PAID -> PURCHASE_CONFIRMED
+		order.confirmPurchase();
+		Order savedOrder = orderCommandPort.save(order);	// DB 저장
+
+		log.info("구매확정 완료: orderId={}", savedOrder.getOrderId());
+
+		// 포인트 적립 요청 이벤트 발행 (kafka 비동기 통신 - outbox 패턴)
+		pointEventPort.publishPointEarnRequested(
+			savedOrder.getUserId(),
+			savedOrder.getOrderId(),
+			savedOrder.getFinalAmount(),
+			"구매확정",
+			Instant.now()
+		);
+
+		// ORDER_PURCHASE_CONFIRMED 이벤트를 outbox에 저장
+		try {
+			java.util.Map<String, Object> eventPayload = new java.util.HashMap<>();
+			eventPayload.put("orderId", savedOrder.getOrderId());
+			eventPayload.put("userId", savedOrder.getUserId());
+			eventPayload.put("status", savedOrder.getStatus().name());
+			eventPayload.put("finalAmount", savedOrder.getFinalAmount());
+			eventPayload.put("purchaseConfirmedAt", savedOrder.getPurchaseConfirmedAt());
+
+			outboxPort.createAndSave(
+				"ORDER",
+				savedOrder.getOrderId(),
+				"ORDER_PURCHASE_CONFIRMED",
+				objectMapper.writeValueAsString(eventPayload)
+			);
+		} catch (Exception e) {
+			log.error("ORDER_PURCHASE_CONFIRMED 이벤트 저장 실패: orderId={}", savedOrder.getOrderId(), e);
+		}
+
+		return ConfirmPurchaseResult.builder()
+			.orderId(savedOrder.getOrderId())
+			.orderStatus(savedOrder.getStatus().name())
+			.purchaseConfirmedAt(savedOrder.getPurchaseConfirmedAt())
+			.build();
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/ConfirmPurchaseUseCase.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/ConfirmPurchaseUseCase.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.command.usecase;
+
+import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
+import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
+
+public interface ConfirmPurchaseUseCase {
+	ConfirmPurchaseResult confirmPurchase(ConfirmPurchaseCommand command);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/PointEventPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/PointEventPort.java
@@ -1,0 +1,10 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public interface PointEventPort {
+	/* 포인트 적립 요청 이벤트 발행 */
+	void publishPointEarnRequested(Long userId, UUID orderId, BigDecimal finalAmount, String reason, Instant timestamp);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/messaging/PointEventPublisher.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/messaging/PointEventPublisher.java
@@ -1,0 +1,56 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.messaging;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.order_service.application.port.out.PointEventPort;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.repository.OutboxEventJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointEventPublisher implements PointEventPort {
+
+	private final OutboxEventJpaRepository outboxRepository;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void publishPointEarnRequested(Long userId, UUID orderId, BigDecimal finalAmount, String reason, Instant timestamp) {
+		try {
+			log.info("포인트 적립 요청 이벤트 발행: userId={}, orderId={}, finalAmount={}", userId, orderId, finalAmount);
+
+			Map<String, Object> event = new HashMap<>();
+			event.put("userId", userId);
+			event.put("orderId", orderId.toString());
+			event.put("finalAmount", finalAmount);
+			event.put("reason", reason);
+			event.put("timestamp", timestamp.toString());
+
+			String payload = objectMapper.writeValueAsString(event);
+
+			OutboxEventEntity outbox = OutboxEventEntity.create(
+				"ORDER",       // aggregateType
+				orderId,                     // aggregateId
+				"POINT_EARN_REQUESTED",      // eventType
+				payload                      // json
+			);
+
+			outboxRepository.save(outbox);
+			log.info("포인트 적립 요청 이벤트 Outbox 저장 완료: orderId={}", orderId);
+
+		} catch (Exception e) {
+			log.error("포인트 적립 요청 이벤트 발행 실패: orderId={}", orderId, e);
+			throw new RuntimeException("포인트 적립 요청 이벤트 발행 실패", e);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
@@ -11,14 +11,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
 import com.rushcrew.order_service.application.command.dto.command.RequestPaymentCommand;
+import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
 import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
 import com.rushcrew.order_service.application.command.dto.result.RequestPaymentResult;
+import com.rushcrew.order_service.application.command.usecase.ConfirmPurchaseUseCase;
 import com.rushcrew.order_service.application.command.usecase.CreateOrderUseCase;
 import com.rushcrew.order_service.application.command.usecase.RequestPaymentUseCase;
 import com.rushcrew.order_service.global.util.RoleChecker;
 import com.rushcrew.order_service.presentation.dto.request.CreateOrderRequest;
+import com.rushcrew.order_service.presentation.dto.response.ConfirmPurchaseResponse;
 import com.rushcrew.order_service.presentation.dto.response.CreateOrderResponse;
 import com.rushcrew.order_service.presentation.dto.response.RequestPaymentResponse;
 
@@ -32,6 +36,7 @@ public class OrderCommandController {
 
 	private final CreateOrderUseCase createOrderUseCase;
 	private final RequestPaymentUseCase requestPaymentUseCase;
+	private final ConfirmPurchaseUseCase confirmPurchaseUseCase;
 
 	/**
 	 * 주문 생성 API
@@ -62,6 +67,9 @@ public class OrderCommandController {
 		return ApiResponse.success(CreateOrderResponse.from(result));
 	}
 
+	/**
+	 * 결제 요청 API
+	 */
 	@PostMapping("/{orderId}/payment")
 	public ApiResponse<RequestPaymentResponse> requestPayment(
 		@PathVariable UUID orderId,
@@ -78,6 +86,27 @@ public class OrderCommandController {
 		RequestPaymentResult result = requestPaymentUseCase.requestPayment(command);
 
 		return ApiResponse.success(RequestPaymentResponse.from(result));
+	}
+
+	/**
+	 * 구매확정 API
+	 */
+	@PostMapping("/{orderId}/confirm")
+	public ApiResponse<ConfirmPurchaseResponse> confirmPurchase(
+		@PathVariable UUID orderId,
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader(value = "X-User-Role", required = false) String role
+	) {
+		RoleChecker.checkRole(role, "USER", "MASTER");
+
+		ConfirmPurchaseCommand command = ConfirmPurchaseCommand.builder()
+			.orderId(orderId)
+			.userId(userId)
+			.build();
+
+		ConfirmPurchaseResult result = confirmPurchaseUseCase.confirmPurchase(command);
+
+		return ApiResponse.success(ConfirmPurchaseResponse.from(result));
 	}
 
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/ConfirmPurchaseResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/ConfirmPurchaseResponse.java
@@ -1,0 +1,23 @@
+package com.rushcrew.order_service.presentation.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
+
+public record ConfirmPurchaseResponse(
+	UUID orderId,
+	String orderStatus,
+	Instant purchaseConfirmedAt,
+	String message
+) {
+
+	public static ConfirmPurchaseResponse from(ConfirmPurchaseResult result) {
+		return new ConfirmPurchaseResponse(
+			result.orderId(),
+			result.orderStatus(),
+			result.purchaseConfirmedAt(),
+			"구매가 확정되었습니다."
+		);
+	}
+}

--- a/order-service/src/test/java/com/rushcrew/order_service/application/command/service/ConfirmPurchaseServiceTest.java
+++ b/order-service/src/test/java/com/rushcrew/order_service/application/command/service/ConfirmPurchaseServiceTest.java
@@ -1,0 +1,204 @@
+package com.rushcrew.order_service.application.command.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
+import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.application.port.out.OutboxPort;
+import com.rushcrew.order_service.application.port.out.PointEventPort;
+import com.rushcrew.order_service.domain.enums.OrderStatus;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("구매확정 서비스 테스트")
+class ConfirmPurchaseServiceTest {
+
+	@Mock
+	private OrderCommandPort orderCommandPort;
+
+	@Mock
+	private PointEventPort pointEventPort;
+
+	@Mock
+	private OutboxPort outboxPort;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@InjectMocks
+	private ConfirmPurchaseService confirmPurchaseService;
+
+	private Order order;
+	private ConfirmPurchaseCommand command;
+	private UUID orderId;
+
+	@BeforeEach
+	void setUp() {
+		orderId = UUID.randomUUID();
+		command = ConfirmPurchaseCommand.builder()
+			.orderId(orderId)
+			.userId(1L)
+			.build();
+
+		order = mock(Order.class);
+	}
+
+	@Test
+	@DisplayName("구매확정 성공")
+	void testConfirmPurchase_Success() throws Exception {
+		// given
+		Instant now = Instant.now();
+		when(orderCommandPort.findById(orderId)).thenReturn(Optional.of(order));
+		when(order.isOwnedBy(1L)).thenReturn(true);
+		when(order.canConfirmPurchase()).thenReturn(true);
+		when(order.getOrderId()).thenReturn(orderId);
+		when(order.getUserId()).thenReturn(1L);
+		when(order.getFinalAmount()).thenReturn(BigDecimal.valueOf(9000));
+		when(order.getStatus()).thenReturn(OrderStatus.PURCHASE_CONFIRMED);
+		when(order.getPurchaseConfirmedAt()).thenReturn(now);
+		when(orderCommandPort.save(order)).thenReturn(order);
+		when(objectMapper.writeValueAsString(any())).thenReturn("{\"orderId\":\"" + orderId + "\"}");
+
+		// when
+		ConfirmPurchaseResult result = confirmPurchaseService.confirmPurchase(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(orderId);
+		assertThat(result.orderStatus()).isEqualTo("PURCHASE_CONFIRMED");
+		assertThat(result.purchaseConfirmedAt()).isNotNull();
+
+		// verify
+		verify(orderCommandPort).findById(orderId);
+		verify(order).isOwnedBy(1L);
+		verify(order).canConfirmPurchase();
+		verify(order).confirmPurchase();
+		verify(orderCommandPort).save(order);
+		verify(pointEventPort).publishPointEarnRequested(
+			eq(1L),
+			eq(orderId),
+			eq(BigDecimal.valueOf(9000)),
+			eq("구매확정"),
+			any(Instant.class)
+		);
+		verify(outboxPort).createAndSave(
+			eq("ORDER"),
+			eq(orderId),
+			eq("ORDER_PURCHASE_CONFIRMED"),
+			anyString()
+		);
+	}
+
+	@Test
+	@DisplayName("구매확정 실패 - 주문을 찾을 수 없음")
+	void testConfirmPurchase_OrderNotFound() {
+		// given
+		when(orderCommandPort.findById(orderId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> confirmPurchaseService.confirmPurchase(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_NOT_FOUND);
+
+		// verify
+		verify(orderCommandPort).findById(orderId);
+		verify(order, never()).isOwnedBy(anyLong());
+		verify(orderCommandPort, never()).save(any());
+		verify(pointEventPort, never()).publishPointEarnRequested(any(), any(), any(), any(), any());
+		verify(outboxPort, never()).createAndSave(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("구매확정 실패 - 주문 소유자 불일치")
+	void testConfirmPurchase_AccessDenied() {
+		// given
+		when(orderCommandPort.findById(orderId)).thenReturn(Optional.of(order));
+		when(order.isOwnedBy(1L)).thenReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> confirmPurchaseService.confirmPurchase(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_ACCESS_DENIED);
+
+		// verify
+		verify(orderCommandPort).findById(orderId);
+		verify(order).isOwnedBy(1L);
+		verify(order, never()).canConfirmPurchase();
+		verify(order, never()).confirmPurchase();
+		verify(orderCommandPort, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("구매확정 실패 - 구매확정 불가능한 상태")
+	void testConfirmPurchase_CannotConfirm() {
+		// given
+		when(orderCommandPort.findById(orderId)).thenReturn(Optional.of(order));
+		when(order.isOwnedBy(1L)).thenReturn(true);
+		when(order.canConfirmPurchase()).thenReturn(false);
+
+		// when & then
+		assertThatThrownBy(() -> confirmPurchaseService.confirmPurchase(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_CANNOT_CONFIRM_PURCHASE);
+
+		// verify
+		verify(orderCommandPort).findById(orderId);
+		verify(order).isOwnedBy(1L);
+		verify(order).canConfirmPurchase();
+		verify(order, never()).confirmPurchase();
+		verify(orderCommandPort, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("구매확정 성공 - Outbox 저장 실패해도 트랜잭션 롤백되지 않음")
+	void testConfirmPurchase_OutboxFailureDoesNotRollback() throws Exception {
+		// given
+		Instant now = Instant.now();
+		when(orderCommandPort.findById(orderId)).thenReturn(Optional.of(order));
+		when(order.isOwnedBy(1L)).thenReturn(true);
+		when(order.canConfirmPurchase()).thenReturn(true);
+		when(order.getOrderId()).thenReturn(orderId);
+		when(order.getUserId()).thenReturn(1L);
+		when(order.getFinalAmount()).thenReturn(BigDecimal.valueOf(9000));
+		when(order.getStatus()).thenReturn(OrderStatus.PURCHASE_CONFIRMED);
+		when(order.getPurchaseConfirmedAt()).thenReturn(now);
+		when(orderCommandPort.save(order)).thenReturn(order);
+		when(objectMapper.writeValueAsString(any())).thenThrow(new RuntimeException("JSON 직렬화 실패"));
+
+		// when
+		ConfirmPurchaseResult result = confirmPurchaseService.confirmPurchase(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(orderId);
+		assertThat(result.orderStatus()).isEqualTo("PURCHASE_CONFIRMED");
+
+		// verify
+		verify(order).confirmPurchase();
+		verify(orderCommandPort).save(order);
+		verify(pointEventPort).publishPointEarnRequested(any(), any(), any(), any(), any());
+		verify(outboxPort, never()).createAndSave(any(), any(), any(), any());
+	}
+}


### PR DESCRIPTION
## 🧾 Summary
- Saga + CQRS + Outbox 패턴 적용하여 구매확정 기능 구현

## 구매확정 프로세스 흐름도
```mermaid
sequenceDiagram
    participant Client
    participant OrderCommandController
    participant ConfirmPurchaseService
    participant Order
    participant OrderCommandPort
    participant PointEventPort
    participant OutboxPort

    Client->>OrderCommandController: POST /api/v1/orders/{orderId}/confirm
    OrderCommandController->>ConfirmPurchaseService: ConfirmPurchaseCommand
    ConfirmPurchaseService->>ConfirmPurchaseService: 주문 조회 및 소유자 검증
    ConfirmPurchaseService->>ConfirmPurchaseService: 구매확정 가능 상태 검증 (PAID)
    ConfirmPurchaseService->>Order: confirmPurchase() (PAID -> PURCHASE_CONFIRMED)
    ConfirmPurchaseService->>OrderCommandPort: save()
    ConfirmPurchaseService->>PointEventPort: publishPointEarnRequested()
    ConfirmPurchaseService->>OutboxPort: createAndSave() (ORDER_PURCHASE_CONFIRMED 이벤트)
    ConfirmPurchaseService->>OrderCommandController: ConfirmPurchaseResult
    OrderCommandController->>Client: ConfirmPurchaseResponse
```

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [x] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #117 
