### PR TITLE
Feat(order): 주문 수정 기능 구현 + 서비스 단위 테스트

### DIFF
--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/UpdateOrderCommand.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/UpdateOrderCommand.java
@@ -1,0 +1,16 @@
+package com.rushcrew.order_service.application.command.dto.command;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateOrderCommand(
+	UUID orderId,
+	Long userId,
+	ShippingInfo shippingInfo,  // null 가능 (수정하지 않을 경우)
+	BigDecimal pointUsed  // null 가능 (수정하지 않을 경우, PENDING 상태에서만 가능)
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/UpdateOrderResult.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/UpdateOrderResult.java
@@ -1,0 +1,28 @@
+package com.rushcrew.order_service.application.command.dto.result;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateOrderResult(
+	UUID orderId,
+	String orderStatus,
+	ShippingInfoResult shippingInfo,
+	BigDecimal pointUsed,
+	BigDecimal totalAmount,
+	BigDecimal finalAmount,
+	Instant updatedAt
+) {
+	@Builder
+	public record ShippingInfoResult(
+		String recipientName,
+		String recipientPhone,
+		String zipCode,
+		String addressBase,
+		String addressDetail,
+		String deliveryMessage
+	) {}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCachePort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/port/out/OrderCachePort.java
@@ -1,8 +1,14 @@
 package com.rushcrew.order_service.application.command.port.out;
 
+import java.util.UUID;
+
 import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
+import com.rushcrew.order_service.application.query.dto.OrderDetailDto;
 
 public interface OrderCachePort {
 	/* 주문 생성 시, 주문 캐시 저장 */
 	void saveOrderCache(CreateOrderResult result);
+
+	/* 주문 수정 시, 캐시 업데이트 */
+	void updateOrderCache(UUID orderId, OrderDetailDto orderDetailDto);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/UpdateOrderService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/UpdateOrderService.java
@@ -1,0 +1,138 @@
+package com.rushcrew.order_service.application.command.service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.UpdateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.UpdateOrderResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCachePort;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.application.command.usecase.UpdateOrderUseCase;
+import com.rushcrew.order_service.application.query.dto.OrderDetailDto;
+import com.rushcrew.order_service.domain.enums.OrderStatus;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateOrderService implements UpdateOrderUseCase {
+
+	private final OrderCommandPort orderCommandPort;
+	private final OrderCachePort orderCachePort;
+
+	private static final int PENDING_UPDATE_MAX_MINUTES = 15; // PENDING 상태 수정 가능 시간 (15분)
+	private static final int PAID_UPDATE_MAX_DAYS = 7; // PAID 상태 수정 가능 시간 (7일)
+
+	@Override
+	@Transactional
+	public UpdateOrderResult updateOrder(UpdateOrderCommand command) {
+		log.info("주문 수정 시작: orderId={}, userId={}", command.orderId(), command.userId());
+
+		Order order = orderCommandPort.findById(command.orderId())
+			.orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+		if (!order.isOwnedBy(command.userId())) {
+			throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+		}
+
+		// 수정 가능 상태 및 시간 제한 검증
+		validateUpdateConditions(order);
+
+		// 수정 가능 항목 검증 및 수정
+		boolean updated = false;
+
+		// 배송지 정보 수정
+		if (command.shippingInfo() != null) {
+			order.updateShippingInfo(command.shippingInfo());
+			updated = true;
+			log.info("배송지 정보 수정 완료: orderId={}", order.getOrderId());
+		}
+
+		// 포인트 사용량 수정 (PENDING 상태에서만 가능)
+		if (command.pointUsed() != null) {
+			if (order.getStatus() != OrderStatus.PENDING) {
+				throw new BusinessException(OrderErrorCode.ORDER_CANNOT_UPDATE_POINT);
+			}
+			order.updatePointUsed(command.pointUsed());
+			updated = true;
+			log.info("포인트 사용량 수정 완료: orderId={}, pointUsed={}", order.getOrderId(), command.pointUsed());
+		}
+
+		if (!updated) {
+			throw new BusinessException(OrderErrorCode.ORDER_UPDATE_NO_CHANGES);
+		}
+
+		// 주문 저장
+		Order savedOrder = orderCommandPort.save(order);
+
+		// 캐시 업데이트
+		try {
+			OrderDetailDto orderDetailDto = OrderDetailDto.fromEntity(savedOrder);
+			orderCachePort.updateOrderCache(savedOrder.getOrderId(), orderDetailDto);
+			log.info("주문 캐시 업데이트 완료: orderId={}", savedOrder.getOrderId());
+		} catch (Exception e) {
+			log.error("주문 캐시 업데이트 실패: orderId={}", savedOrder.getOrderId(), e);
+			// 캐시 업데이트 실패는 치명적이지 않으므로 예외를 던지지 않음
+		}
+
+		log.info("주문 수정 완료: orderId={}", savedOrder.getOrderId());
+
+		return UpdateOrderResult.builder()
+			.orderId(savedOrder.getOrderId())
+			.orderStatus(savedOrder.getStatus().name())
+			.shippingInfo(savedOrder.getShippingInfo() != null ?
+				UpdateOrderResult.ShippingInfoResult.builder()
+					.recipientName(savedOrder.getShippingInfo().getRecipientName())
+					.recipientPhone(savedOrder.getShippingInfo().getRecipientPhone())
+					.zipCode(savedOrder.getShippingInfo().getZipCode())
+					.addressBase(savedOrder.getShippingInfo().getAddressBase())
+					.addressDetail(savedOrder.getShippingInfo().getAddressDetail())
+					.deliveryMessage(savedOrder.getShippingInfo().getDeliveryMessage())
+					.build() : null)
+			.pointUsed(savedOrder.getPointUsed())
+			.totalAmount(savedOrder.getTotalAmount())
+			.finalAmount(savedOrder.getFinalAmount())
+			.updatedAt(Instant.now())
+			.build();
+	}
+
+	/* 수정 가능 조건 및 시간 제한 검증 */
+	private void validateUpdateConditions(Order order) {
+		OrderStatus status = order.getStatus();
+		Instant now = Instant.now();
+
+		// PURCHASE_CONFIRMED, CANCELLED, REFUNDED 상태는 수정 불가
+		if (status == OrderStatus.PURCHASE_CONFIRMED
+			|| status == OrderStatus.CANCELLED
+			|| status == OrderStatus.REFUNDED) {
+			throw new BusinessException(OrderErrorCode.ORDER_CANNOT_UPDATE);
+		}
+
+		// PENDING 상태: 주문 생성 후 15분 이내만 수정 가능
+		if (status == OrderStatus.PENDING) {
+			long minutesSinceOrdered = ChronoUnit.MINUTES.between(order.getOrderedAt(), now);
+			if (minutesSinceOrdered > PENDING_UPDATE_MAX_MINUTES) {
+				throw new BusinessException(OrderErrorCode.ORDER_UPDATE_TIME_EXPIRED);
+			}
+		}
+
+		// PAID 상태: 결제 완료 후 7일 이내만 수정 가능 --> TODO: 추후 배송 상태 추가하거나 배송 기능 추가되면 이 부분 로직 변경해야 함
+		if (status == OrderStatus.PAID) {
+			if (order.getPaymentCompletedAt() == null) {
+				throw new IllegalStateException("PAID 상태인데 결제 완료 시간이 없습니다.");
+			}
+			long daysSincePayment = ChronoUnit.DAYS.between(order.getPaymentCompletedAt(), now);
+			if (daysSincePayment > PAID_UPDATE_MAX_DAYS) {
+				throw new BusinessException(OrderErrorCode.ORDER_UPDATE_TIME_EXPIRED);
+			}
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/UpdateOrderUseCase.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/UpdateOrderUseCase.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.command.usecase;
+
+import com.rushcrew.order_service.application.command.dto.command.UpdateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.UpdateOrderResult;
+
+public interface UpdateOrderUseCase {
+	UpdateOrderResult updateOrder(UpdateOrderCommand command);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/cache/OrderCacheAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/cache/OrderCacheAdapter.java
@@ -1,5 +1,6 @@
 package com.rushcrew.order_service.infrastructure.adapter.cache;
 
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -57,6 +58,25 @@ public class OrderCacheAdapter implements OrderCachePort {
 
 		} catch (JsonProcessingException e) {
 			log.error("주문 캐시 저장 실패: orderId={}", result.orderId(), e);
+		}
+	}
+
+	@Override
+	public void updateOrderCache(UUID orderId, OrderDetailDto orderDetailDto) {
+		try {
+			String key = ORDER_KEY_PREFIX + orderId;
+
+			redisTemplate.opsForValue().set(
+				key,
+				objectMapper.writeValueAsString(orderDetailDto),
+				ORDER_CACHE_TTL,
+				TimeUnit.SECONDS
+			);
+
+			log.info("주문 캐시 업데이트 완료: orderId={}", orderId);
+
+		} catch (JsonProcessingException e) {
+			log.error("주문 캐시 업데이트 실패: orderId={}", orderId, e);
 		}
 	}
 

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,17 +15,22 @@ import com.rushcrew.common.dto.ApiResponse;
 import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
 import com.rushcrew.order_service.application.command.dto.command.RequestPaymentCommand;
+import com.rushcrew.order_service.application.command.dto.command.UpdateOrderCommand;
 import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
 import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
 import com.rushcrew.order_service.application.command.dto.result.RequestPaymentResult;
+import com.rushcrew.order_service.application.command.dto.result.UpdateOrderResult;
 import com.rushcrew.order_service.application.command.usecase.ConfirmPurchaseUseCase;
 import com.rushcrew.order_service.application.command.usecase.CreateOrderUseCase;
 import com.rushcrew.order_service.application.command.usecase.RequestPaymentUseCase;
+import com.rushcrew.order_service.application.command.usecase.UpdateOrderUseCase;
 import com.rushcrew.order_service.global.util.RoleChecker;
 import com.rushcrew.order_service.presentation.dto.request.CreateOrderRequest;
+import com.rushcrew.order_service.presentation.dto.request.UpdateOrderRequest;
 import com.rushcrew.order_service.presentation.dto.response.ConfirmPurchaseResponse;
 import com.rushcrew.order_service.presentation.dto.response.CreateOrderResponse;
 import com.rushcrew.order_service.presentation.dto.response.RequestPaymentResponse;
+import com.rushcrew.order_service.presentation.dto.response.UpdateOrderResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +43,7 @@ public class OrderCommandController {
 	private final CreateOrderUseCase createOrderUseCase;
 	private final RequestPaymentUseCase requestPaymentUseCase;
 	private final ConfirmPurchaseUseCase confirmPurchaseUseCase;
+	private final UpdateOrderUseCase updateOrderUseCase;
 
 	/**
 	 * 주문 생성 API
@@ -107,6 +114,30 @@ public class OrderCommandController {
 		ConfirmPurchaseResult result = confirmPurchaseUseCase.confirmPurchase(command);
 
 		return ApiResponse.success(ConfirmPurchaseResponse.from(result));
+	}
+
+	/**
+	 * 주문 수정 API
+	 */
+	@PutMapping("/{orderId}")
+	public ApiResponse<UpdateOrderResponse> updateOrder(
+		@PathVariable UUID orderId,
+		@Valid @RequestBody UpdateOrderRequest request,
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader(value = "X-User-Role", required = false) String role
+	) {
+		RoleChecker.checkRole(role, "USER", "MASTER");
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(orderId)
+			.userId(userId)
+			.shippingInfo(request.shippingInfo() != null ? request.shippingInfo().toShippingInfo() : null)
+			.pointUsed(request.pointUsed())
+			.build();
+
+		UpdateOrderResult result = updateOrderUseCase.updateOrder(command);
+
+		return ApiResponse.success(UpdateOrderResponse.from(result));
 	}
 
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/request/UpdateOrderRequest.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/request/UpdateOrderRequest.java
@@ -1,0 +1,36 @@
+package com.rushcrew.order_service.presentation.dto.request;
+
+import java.math.BigDecimal;
+
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+
+public record UpdateOrderRequest(
+	@Valid
+	ShippingInfoRequest shippingInfo,  // null 가능 (수정하지 않을 경우)
+
+	@Min(value = 0, message = "포인트 사용량은 0 이상이어야 합니다")
+	BigDecimal pointUsed  // null 가능 (수정하지 않을 경우, PENDING 상태에서만 가능)
+) {
+	public record ShippingInfoRequest(
+		String recipientName,
+		String recipientPhone,
+		String zipCode,
+		String addressBase,
+		String addressDetail,
+		String deliveryMessage
+	) {
+		public ShippingInfo toShippingInfo() {
+			return ShippingInfo.builder()
+				.recipientName(recipientName)
+				.recipientPhone(recipientPhone)
+				.zipCode(zipCode)
+				.addressBase(addressBase)
+				.addressDetail(addressDetail)
+				.deliveryMessage(deliveryMessage)
+				.build();
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/UpdateOrderResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/UpdateOrderResponse.java
@@ -1,0 +1,48 @@
+package com.rushcrew.order_service.presentation.dto.response;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.command.dto.result.UpdateOrderResult;
+
+public record UpdateOrderResponse(
+	UUID orderId,
+	String orderStatus,
+	ShippingInfoResponse shippingInfo,
+	BigDecimal pointUsed,
+	BigDecimal totalAmount,
+	BigDecimal finalAmount,
+	Instant updatedAt,
+	String message
+) {
+	public record ShippingInfoResponse(
+		String recipientName,
+		String recipientPhone,
+		String zipCode,
+		String addressBase,
+		String addressDetail,
+		String deliveryMessage
+	) {}
+
+	public static UpdateOrderResponse from(UpdateOrderResult result) {
+		return new UpdateOrderResponse(
+			result.orderId(),
+			result.orderStatus(),
+			result.shippingInfo() != null ?
+				new ShippingInfoResponse(
+					result.shippingInfo().recipientName(),
+					result.shippingInfo().recipientPhone(),
+					result.shippingInfo().zipCode(),
+					result.shippingInfo().addressBase(),
+					result.shippingInfo().addressDetail(),
+					result.shippingInfo().deliveryMessage()
+				) : null,
+			result.pointUsed(),
+			result.totalAmount(),
+			result.finalAmount(),
+			result.updatedAt(),
+			"주문이 수정되었습니다."
+		);
+	}
+}

--- a/order-service/src/test/java/com/rushcrew/order_service/application/command/service/UpdateOrderServiceTest.java
+++ b/order-service/src/test/java/com/rushcrew/order_service/application/command/service/UpdateOrderServiceTest.java
@@ -1,0 +1,503 @@
+package com.rushcrew.order_service.application.command.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.UpdateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.UpdateOrderResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCachePort;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.domain.enums.OrderStatus;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.domain.model.order.OrderItem;
+import com.rushcrew.order_service.domain.vo.ProductSnapshot;
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("주문 수정 서비스 테스트")
+class UpdateOrderServiceTest {
+
+	@Mock
+	private OrderCommandPort orderCommandPort;
+
+	@Mock
+	private OrderCachePort orderCachePort;
+
+	@InjectMocks
+	private UpdateOrderService updateOrderService;
+
+	private Order order;
+	private Long userId;
+	private ShippingInfo newShippingInfo;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+
+		ShippingInfo originalShippingInfo = ShippingInfo.create(
+			"홍길동",
+			"01012345678",
+			"12345",
+			"서울시 강남구",
+			"101동 101호",
+			"문 앞에 놔주세요"
+		);
+
+		newShippingInfo = ShippingInfo.create(
+			"김철수",
+			"01098765432",
+			"54321",
+			"서울시 서초구",
+			"202동 202호",
+			"경비실에 맡겨주세요"
+		);
+
+		// OrderItem 생성
+		ProductSnapshot snapshot = ProductSnapshot.builder()
+			.timeDealStockId(UUID.randomUUID())
+			.productId(UUID.randomUUID())
+			.productName("테스트 상품")
+			.productDescription("테스트 설명")
+			.optionName("옵션1")
+			.timeDealId(UUID.randomUUID())
+			.timeDealTitle("타임딜 제목")
+			.discountRate(20)
+			.build();
+
+		OrderItem orderItem = OrderItem.create(
+			UUID.randomUUID(),
+			2,
+			BigDecimal.valueOf(10000),
+			BigDecimal.valueOf(8000),
+			snapshot
+		);
+
+		// Order 생성 (내부적으로 orderId가 자동 생성됨)
+		order = Order.create(
+			userId,
+			java.util.List.of(orderItem),
+			BigDecimal.valueOf(1000),
+			originalShippingInfo
+		);
+	}
+
+	@Test
+	@DisplayName("PENDING 상태 - 배송지 정보 수정 성공")
+	void testUpdateShippingInfo_PENDING_Success() {
+		// given
+		UUID actualOrderId = order.getOrderId(); // 실제 Order의 orderId 가져오기 --> Order.create에서 orderId를 생성해주고 있어서
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when
+		UpdateOrderResult result = updateOrderService.updateOrder(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(actualOrderId);
+		assertThat(result.shippingInfo()).isNotNull();
+		assertThat(result.shippingInfo().recipientName()).isEqualTo("김철수");
+		assertThat(result.shippingInfo().recipientPhone()).isEqualTo("01098765432");
+		assertThat(result.shippingInfo().zipCode()).isEqualTo("54321");
+		assertThat(result.shippingInfo().addressBase()).isEqualTo("서울시 서초구");
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort).save(any(Order.class));
+		verify(orderCachePort).updateOrderCache(eq(actualOrderId), any());
+	}
+
+	@Test
+	@DisplayName("PENDING 상태 - 포인트 사용량 수정 성공")
+	void testUpdatePointUsed_PENDING_Success() {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		BigDecimal newPointUsed = BigDecimal.valueOf(2000);
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(null)
+			.pointUsed(newPointUsed)
+			.build();
+
+		// when
+		UpdateOrderResult result = updateOrderService.updateOrder(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(actualOrderId);
+		assertThat(result.pointUsed()).isEqualByComparingTo(newPointUsed);
+		assertThat(result.finalAmount()).isEqualByComparingTo(BigDecimal.valueOf(14000)); // 16000 - 2000
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort).save(any(Order.class));
+		verify(orderCachePort).updateOrderCache(eq(actualOrderId), any());
+	}
+
+	@Test
+	@DisplayName("PENDING 상태 - 배송지 정보와 포인트 사용량 동시 수정 성공")
+	void testUpdateBoth_PENDING_Success() {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		BigDecimal newPointUsed = BigDecimal.valueOf(2000);
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(newPointUsed)
+			.build();
+
+		// when
+		UpdateOrderResult result = updateOrderService.updateOrder(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(actualOrderId);
+		assertThat(result.shippingInfo().recipientName()).isEqualTo("김철수");
+		assertThat(result.pointUsed()).isEqualByComparingTo(newPointUsed);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort).save(any(Order.class));
+		verify(orderCachePort).updateOrderCache(eq(actualOrderId), any());
+	}
+
+	@Test
+	@DisplayName("PAID 상태 - 배송지 정보 수정 성공")
+	void testUpdateShippingInfo_PAID_Success() {
+		// given
+		order.completePayment();
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when
+		UpdateOrderResult result = updateOrderService.updateOrder(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderStatus()).isEqualTo(OrderStatus.PAID.name());
+		assertThat(result.shippingInfo().recipientName()).isEqualTo("김철수");
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort).save(any(Order.class));
+		verify(orderCachePort).updateOrderCache(eq(actualOrderId), any());
+	}
+
+	@Test
+	@DisplayName("PAID 상태 - 포인트 사용량 수정 실패 (수정 불가)")
+	void testUpdatePointUsed_PAID_Failure() {
+		// given
+		order.completePayment();
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(null)
+			.pointUsed(BigDecimal.valueOf(2000))
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_CANNOT_UPDATE_POINT);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("PENDING 상태 - 15분 초과 시 수정 실패")
+	void testUpdate_PENDING_TimeExpired() {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		// orderedAt을 16분 전으로 설정
+		try {
+			java.lang.reflect.Field orderedAtField = Order.class.getDeclaredField("orderedAt");
+			orderedAtField.setAccessible(true);
+			orderedAtField.set(order, Instant.now().minus(16, ChronoUnit.MINUTES));
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_UPDATE_TIME_EXPIRED);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("PAID 상태 - 7일 초과 시 수정 실패")
+	void testUpdate_PAID_TimeExpired() {
+		// given
+		order.completePayment();
+		UUID actualOrderId = order.getOrderId();
+		// paymentCompletedAt을 8일 전으로 설정
+		try {
+			java.lang.reflect.Field paymentCompletedAtField = Order.class.getDeclaredField("paymentCompletedAt");
+			paymentCompletedAtField.setAccessible(true);
+			paymentCompletedAtField.set(order, Instant.now().minus(8, ChronoUnit.DAYS));
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_UPDATE_TIME_EXPIRED);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("PURCHASE_CONFIRMED 상태 - 수정 불가")
+	void testUpdate_PURCHASE_CONFIRMED_Failure() {
+		// given
+		order.completePayment();
+		order.confirmPurchase();
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_CANNOT_UPDATE);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("CANCELLED 상태 - 수정 불가")
+	void testUpdate_CANCELLED_Failure() {
+		// given
+		order.cancelBeforePayment("취소");
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_CANNOT_UPDATE);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("REFUNDED 상태 - 수정 불가")
+	void testUpdate_REFUNDED_Failure() {
+		// given
+		order.completePayment();
+		order.confirmPurchase();
+		order.refund("환불");
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_CANNOT_UPDATE);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("주문을 찾을 수 없음")
+	void testUpdate_OrderNotFound() {
+		// given
+		UUID nonExistentOrderId = UUID.randomUUID();
+		when(orderCommandPort.findById(nonExistentOrderId)).thenReturn(Optional.empty());
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(nonExistentOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_NOT_FOUND);
+
+		verify(orderCommandPort).findById(nonExistentOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("다른 사용자의 주문 수정 시도 - 접근 거부")
+	void testUpdate_AccessDenied() {
+		// given
+		Long otherUserId = 999L;
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(otherUserId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_ACCESS_DENIED);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("수정할 항목이 없음")
+	void testUpdate_NoChanges() {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(null)
+			.pointUsed(null)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> updateOrderService.updateOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_UPDATE_NO_CHANGES);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any(Order.class));
+		verify(orderCachePort, never()).updateOrderCache(any(), any());
+	}
+
+	@Test
+	@DisplayName("캐시 업데이트 실패해도 주문 수정은 성공")
+	void testUpdate_CacheUpdateFailure() {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		doThrow(new RuntimeException("캐시 업데이트 실패"))
+			.when(orderCachePort).updateOrderCache(any(), any());
+
+		UpdateOrderCommand command = UpdateOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.shippingInfo(newShippingInfo)
+			.pointUsed(null)
+			.build();
+
+		// when
+		UpdateOrderResult result = updateOrderService.updateOrder(command);
+
+		// then - 캐시 실패해도 주문 수정은 성공
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(actualOrderId);
+		assertThat(result.shippingInfo().recipientName()).isEqualTo("김철수");
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort).save(any(Order.class));
+		verify(orderCachePort).updateOrderCache(eq(actualOrderId), any());
+	}
+}


### PR DESCRIPTION
## 🧾 Summary
- Saga + CQRS + Outbox 패턴 적용하여 주문 수정 기능 구현

## 주문 수정 프로세스 흐름도
```mermaid
sequenceDiagram
    participant Client
    participant OrderCommandController
    participant UpdateOrderService
    participant OrderCommandPort
    participant OrderCachePort

    Client->>OrderCommandController: PUT /api/v1/orders/{orderId}
    OrderCommandController->>UpdateOrderService: UpdateOrderRequest → UpdateOrderCommand
    UpdateOrderService->>UpdateOrderService: 주문 조회 및 소유자 검증
    UpdateOrderService->>UpdateOrderService: 수정 가능 조건 검증
    UpdateOrderService->>UpdateOrderService: PENDING: 주문 생성 후 15분 이내
    UpdateOrderService->>UpdateOrderService: PAID: 결제 완료 후 7일 이내
    UpdateOrderService->>UpdateOrderService: 배송지 정보 수정 (PENDING/PAID 상태)
    UpdateOrderService->>UpdateOrderService: 포인트 사용량 수정 (PENDING 상태만)
    UpdateOrderService->>OrderCommandPort: save() (DB 저장)
    UpdateOrderService->>OrderCachePort: updateOrderCache() (Redis 캐시 업데이트)
    UpdateOrderService->>OrderCommandController: UpdateOrderResult
    OrderCommandController->>Client: UpdateOrderResponse
```

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [x] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #119 
