### PR TITLE
Feat(order): 주문 취소 기능 구현 + 서비스 단위 테스트

### DIFF
--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/CancelOrderCommand.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/command/CancelOrderCommand.java
@@ -1,0 +1,11 @@
+package com.rushcrew.order_service.application.command.dto.command;
+
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record CancelOrderCommand(
+	UUID orderId,
+	Long userId
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/CancelOrderResult.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/dto/result/CancelOrderResult.java
@@ -1,0 +1,13 @@
+package com.rushcrew.order_service.application.command.dto.result;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import lombok.Builder;
+
+@Builder
+public record CancelOrderResult(
+	UUID orderId,
+	String orderStatus,
+	Instant cancelledAt
+) {}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CancelOrderService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CancelOrderService.java
@@ -1,0 +1,18 @@
+package com.rushcrew.order_service.application.command.service;
+
+import org.springframework.stereotype.Service;
+
+import com.rushcrew.order_service.application.command.dto.command.CancelOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CancelOrderResult;
+import com.rushcrew.order_service.application.command.usecase.CancelOrderUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CancelOrderService implements CancelOrderUseCase {
+	@Override
+	public CancelOrderResult cancelOrder(CancelOrderCommand command) {
+		return null;
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CancelOrderService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CancelOrderService.java
@@ -1,18 +1,99 @@
 package com.rushcrew.order_service.application.command.service;
 
-import org.springframework.stereotype.Service;
+import java.time.Instant;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.order_service.application.command.dto.command.CancelOrderCommand;
 import com.rushcrew.order_service.application.command.dto.result.CancelOrderResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
 import com.rushcrew.order_service.application.command.usecase.CancelOrderUseCase;
+import com.rushcrew.order_service.application.port.out.OutboxPort;
+import com.rushcrew.order_service.application.port.out.StockEventPort;
+import com.rushcrew.order_service.domain.enums.ReservationStatus;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.domain.model.order.OrderReservation;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CancelOrderService implements CancelOrderUseCase {
+
+	private final OrderCommandPort orderCommandPort;
+	private final StockEventPort stockEventPort;
+	private final OutboxPort outboxPort;
+	private final ObjectMapper objectMapper;
+
 	@Override
+	@Transactional
 	public CancelOrderResult cancelOrder(CancelOrderCommand command) {
-		return null;
+		log.info("주문 취소 처리 시작: orderId={}, userId={}", command.orderId(), command.userId());
+
+		Order order = orderCommandPort.findById(command.orderId())
+			.orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+		if (!order.isOwnedBy(command.userId())) {
+			throw new BusinessException(OrderErrorCode.ORDER_ACCESS_DENIED);
+		}
+
+		// 취소 가능 상태 검증 (PENDING 상태만 가능)
+		if (!order.canCancelBeforePayment()) {
+			throw new BusinessException(OrderErrorCode.ORDER_CANNOT_CANCEL);
+		}
+
+		// 주문 상태 변경 (PENDING → CANCELLED)
+		order.cancelBeforePayment("사용자 요청에 의한 주문 취소");
+		Order savedOrder = orderCommandPort.save(order);
+
+		log.info("주문 취소 완료: orderId={}", savedOrder.getOrderId());
+
+		// 각 예약된 재고에 대해 예약 해제 이벤트 발행 (kafka 비동기 통신 - outbox 패턴)
+		for (OrderReservation reservation : savedOrder.getReservations()) {
+			if (reservation.getStatus() == ReservationStatus.RESERVED) {
+				// 예약 상태를 CANCELLED로 변경
+				reservation.cancel();
+
+				// 재고 예약 취소 이벤트 발행
+				stockEventPort.publishStockReservationCancelled(
+					savedOrder.getOrderId(),
+					reservation.getTimeDealStockId(),
+					reservation.getQuantity(),
+					"주문 취소에 의한 재고 예약 해제",
+					Instant.now()
+				);
+			}
+		}
+
+		// outbox에 ORDER_CANCELLED 이벤트 저장
+		try {
+			java.util.Map<String, Object> eventPayload = new java.util.HashMap<>();
+			eventPayload.put("orderId", savedOrder.getOrderId());
+			eventPayload.put("userId", savedOrder.getUserId());
+			eventPayload.put("status", savedOrder.getStatus().name());
+			eventPayload.put("cancelledAt", savedOrder.getCancelledAt());
+
+			outboxPort.createAndSave(
+				"ORDER",
+				savedOrder.getOrderId(),
+				"ORDER_CANCELLED",
+				objectMapper.writeValueAsString(eventPayload)
+			);
+		} catch (Exception e) {
+			log.error("ORDER_CANCELLED 이벤트 저장 실패: orderId={}", savedOrder.getOrderId(), e);
+		}
+
+		// 7. 결과 반환
+		return CancelOrderResult.builder()
+			.orderId(savedOrder.getOrderId())
+			.orderStatus(savedOrder.getStatus().name())
+			.cancelledAt(savedOrder.getCancelledAt())
+			.build();
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/CancelOrderUseCase.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/usecase/CancelOrderUseCase.java
@@ -1,0 +1,8 @@
+package com.rushcrew.order_service.application.command.usecase;
+
+import com.rushcrew.order_service.application.command.dto.result.CancelOrderResult;
+import com.rushcrew.order_service.application.command.dto.command.CancelOrderCommand;
+
+public interface CancelOrderUseCase {
+	CancelOrderResult cancelOrder(CancelOrderCommand command);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/StockEventPort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/StockEventPort.java
@@ -1,0 +1,9 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public interface StockEventPort {
+	/* 재고 예약 취소 이벤트 발행 */
+	void publishStockReservationCancelled(UUID orderId, UUID timeDealStockId, Integer quantity, String reason, Instant timestamp);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/messaging/StockEventPublisher.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/adapter/out/messaging/StockEventPublisher.java
@@ -1,0 +1,59 @@
+package com.rushcrew.order_service.infrastructure.adapter.out.messaging;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.order_service.application.port.out.StockEventPort;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.entity.OutboxEventEntity;
+import com.rushcrew.order_service.infrastructure.persistence.outbox.repository.OutboxEventJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockEventPublisher implements StockEventPort {
+
+	private final OutboxEventJpaRepository outboxRepository;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void publishStockReservationCancelled(UUID orderId, UUID timeDealStockId, Integer quantity, String reason,
+		Instant timestamp) {
+		try {
+			log.info("재고 예약 취소 이벤트 발행: orderId={}, timeDealStockId={}, quantity={}",
+				orderId, timeDealStockId, quantity);
+
+			Map<String, Object> event = new HashMap<>();
+			event.put("orderId", orderId.toString());
+			event.put("timeDealStockId", timeDealStockId.toString());
+			event.put("quantity", quantity);
+			event.put("reason", reason);
+			event.put("timestamp", timestamp.toString());
+
+			String payload = objectMapper.writeValueAsString(event);
+
+			OutboxEventEntity outbox = OutboxEventEntity.create(
+				"ORDER",         // aggregateType
+				orderId,                       // aggregateId
+				"STOCK_RESERVATION_CANCELLED", // eventType
+				payload                        // json
+			);
+
+			outboxRepository.save(outbox);
+			log.info("재고 예약 취소 이벤트 Outbox 저장 완료: orderId={}, timeDealStockId={}",
+				orderId, timeDealStockId);
+
+		} catch (Exception e) {
+			log.error("재고 예약 취소 이벤트 발행 실패: orderId={}, timeDealStockId={}",
+				orderId, timeDealStockId, e);
+			throw new RuntimeException("재고 예약 취소 이벤트 발행 실패", e);
+		}
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/api/command/OrderCommandController.java
@@ -12,14 +12,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.order_service.application.command.dto.command.CancelOrderCommand;
 import com.rushcrew.order_service.application.command.dto.command.ConfirmPurchaseCommand;
 import com.rushcrew.order_service.application.command.dto.command.CreateOrderCommand;
 import com.rushcrew.order_service.application.command.dto.command.RequestPaymentCommand;
 import com.rushcrew.order_service.application.command.dto.command.UpdateOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CancelOrderResult;
 import com.rushcrew.order_service.application.command.dto.result.ConfirmPurchaseResult;
 import com.rushcrew.order_service.application.command.dto.result.CreateOrderResult;
 import com.rushcrew.order_service.application.command.dto.result.RequestPaymentResult;
 import com.rushcrew.order_service.application.command.dto.result.UpdateOrderResult;
+import com.rushcrew.order_service.application.command.usecase.CancelOrderUseCase;
 import com.rushcrew.order_service.application.command.usecase.ConfirmPurchaseUseCase;
 import com.rushcrew.order_service.application.command.usecase.CreateOrderUseCase;
 import com.rushcrew.order_service.application.command.usecase.RequestPaymentUseCase;
@@ -27,6 +30,7 @@ import com.rushcrew.order_service.application.command.usecase.UpdateOrderUseCase
 import com.rushcrew.order_service.global.util.RoleChecker;
 import com.rushcrew.order_service.presentation.dto.request.CreateOrderRequest;
 import com.rushcrew.order_service.presentation.dto.request.UpdateOrderRequest;
+import com.rushcrew.order_service.presentation.dto.response.CancelOrderResponse;
 import com.rushcrew.order_service.presentation.dto.response.ConfirmPurchaseResponse;
 import com.rushcrew.order_service.presentation.dto.response.CreateOrderResponse;
 import com.rushcrew.order_service.presentation.dto.response.RequestPaymentResponse;
@@ -44,6 +48,7 @@ public class OrderCommandController {
 	private final RequestPaymentUseCase requestPaymentUseCase;
 	private final ConfirmPurchaseUseCase confirmPurchaseUseCase;
 	private final UpdateOrderUseCase updateOrderUseCase;
+	private final CancelOrderUseCase cancelOrderUseCase;
 
 	/**
 	 * 주문 생성 API
@@ -138,6 +143,27 @@ public class OrderCommandController {
 		UpdateOrderResult result = updateOrderUseCase.updateOrder(command);
 
 		return ApiResponse.success(UpdateOrderResponse.from(result));
+	}
+
+	/**
+	 * 주문 취소 API
+	 */
+	@PostMapping("/{orderId}/cancel")
+	public ApiResponse<CancelOrderResponse> cancelOrder(
+		@PathVariable UUID orderId,
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader(value = "X-User-Role", required = false) String role
+	) {
+		RoleChecker.checkRole(role, "USER", "MASTER");
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(orderId)
+			.userId(userId)
+			.build();
+
+		CancelOrderResult result = cancelOrderUseCase.cancelOrder(command);
+
+		return ApiResponse.success(CancelOrderResponse.from(result));
 	}
 
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/CancelOrderResponse.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/presentation/dto/response/CancelOrderResponse.java
@@ -1,0 +1,23 @@
+package com.rushcrew.order_service.presentation.dto.response;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.rushcrew.order_service.application.command.dto.result.CancelOrderResult;
+
+public record CancelOrderResponse(
+	UUID orderId,
+	String orderStatus,
+	Instant cancelledAt,
+	String message
+) {
+
+	public static CancelOrderResponse from(CancelOrderResult result) {
+		return new CancelOrderResponse(
+			result.orderId(),
+			result.orderStatus(),
+			result.cancelledAt(),
+			"주문이 취소되었습니다."
+		);
+	}
+}

--- a/order-service/src/test/java/com/rushcrew/order_service/application/command/service/CancelOrderServiceTest.java
+++ b/order-service/src/test/java/com/rushcrew/order_service/application/command/service/CancelOrderServiceTest.java
@@ -1,0 +1,304 @@
+package com.rushcrew.order_service.application.command.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.order_service.application.command.dto.command.CancelOrderCommand;
+import com.rushcrew.order_service.application.command.dto.result.CancelOrderResult;
+import com.rushcrew.order_service.application.command.port.out.OrderCommandPort;
+import com.rushcrew.order_service.application.port.out.OutboxPort;
+import com.rushcrew.order_service.application.port.out.StockEventPort;
+import com.rushcrew.order_service.domain.enums.OrderStatus;
+import com.rushcrew.order_service.domain.enums.ReservationStatus;
+import com.rushcrew.order_service.domain.model.order.Order;
+import com.rushcrew.order_service.domain.model.order.OrderItem;
+import com.rushcrew.order_service.domain.model.order.OrderReservation;
+import com.rushcrew.order_service.domain.vo.ProductSnapshot;
+import com.rushcrew.order_service.domain.vo.ShippingInfo;
+import com.rushcrew.order_service.global.error.OrderErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("주문 취소 서비스 테스트")
+class CancelOrderServiceTest {
+
+	@Mock
+	private OrderCommandPort orderCommandPort;
+
+	@Mock
+	private StockEventPort stockEventPort;
+
+	@Mock
+	private OutboxPort outboxPort;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@InjectMocks
+	private CancelOrderService cancelOrderService;
+
+	private Order order;
+	private Long userId;
+	private UUID timeDealStockId;
+
+	@BeforeEach
+	void setUp() {
+		userId = 1L;
+		timeDealStockId = UUID.randomUUID();
+
+		ShippingInfo shippingInfo = ShippingInfo.create(
+			"홍길동",
+			"01012345678",
+			"12345",
+			"서울시 강남구",
+			"101동 101호",
+			"문 앞에 놔주세요"
+		);
+
+		ProductSnapshot snapshot = ProductSnapshot.builder()
+			.timeDealStockId(timeDealStockId)
+			.productId(UUID.randomUUID())
+			.productName("테스트 상품")
+			.productDescription("테스트 설명")
+			.optionName("옵션1")
+			.timeDealId(UUID.randomUUID())
+			.timeDealTitle("타임딜 제목")
+			.discountRate(20)
+			.build();
+
+		OrderItem orderItem = OrderItem.create(
+			timeDealStockId,
+			2,
+			BigDecimal.valueOf(10000),
+			BigDecimal.valueOf(8000),
+			snapshot
+		);
+
+		order = Order.create(
+			userId,
+			List.of(orderItem),
+			BigDecimal.valueOf(1000),
+			shippingInfo
+		);
+
+		// OrderReservation 수동으로 추가
+		addReservationToOrder(order, timeDealStockId, 2);
+	}
+
+	private void addReservationToOrder(Order order, UUID timeDealStockId, int quantity) {
+		try {
+			// OrderReservation 생성
+			OrderReservation reservation = OrderReservation.create(
+				timeDealStockId,
+				quantity
+			);
+
+			// Order와의 양방향 연관관계 설정
+			reservation.assignOrder(order);
+
+			// Reflection을 사용하여 Order의 reservations 필드에 접근 **
+			Field reservationsField = Order.class.getDeclaredField("reservations");
+			reservationsField.setAccessible(true);
+
+			@SuppressWarnings("unchecked")
+			List<OrderReservation> reservations = (List<OrderReservation>) reservationsField.get(order);
+			if (reservations == null) {
+				reservations = new ArrayList<>();
+				reservationsField.set(order, reservations);
+			}
+			reservations.add(reservation);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to add reservation to order", e);
+		}
+	}
+
+	@Test
+	@DisplayName("주문 취소 성공")
+	void testCancelOrder_Success() throws Exception {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(objectMapper.writeValueAsString(any())).thenReturn("{\"orderId\":\"" + actualOrderId + "\"}");
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.build();
+
+		// when
+		CancelOrderResult result = cancelOrderService.cancelOrder(command);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(actualOrderId);
+		assertThat(result.orderStatus()).isEqualTo("CANCELLED");
+		assertThat(result.cancelledAt()).isNotNull();
+		assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+
+		// verify
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort).save(order);
+		verify(stockEventPort).publishStockReservationCancelled(
+			eq(actualOrderId),
+			eq(timeDealStockId),
+			eq(2),
+			eq("주문 취소에 의한 재고 예약 해제"),
+			any(Instant.class)
+		);
+		verify(outboxPort).createAndSave(
+			eq("ORDER"),
+			eq(actualOrderId),
+			eq("ORDER_CANCELLED"),
+			anyString()
+		);
+	}
+
+	@Test
+	@DisplayName("주문 취소 실패 - 주문을 찾을 수 없음")
+	void testCancelOrder_OrderNotFound() {
+		// given
+		UUID nonExistentOrderId = UUID.randomUUID();
+		when(orderCommandPort.findById(nonExistentOrderId)).thenReturn(Optional.empty());
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(nonExistentOrderId)
+			.userId(userId)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_NOT_FOUND);
+
+		verify(orderCommandPort).findById(nonExistentOrderId);
+		verify(orderCommandPort, never()).save(any());
+		verify(stockEventPort, never()).publishStockReservationCancelled(any(), any(), any(), any(), any());
+		verify(outboxPort, never()).createAndSave(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("주문 취소 실패 - 주문 소유자 불일치")
+	void testCancelOrder_AccessDenied() {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		Long otherUserId = 999L;
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(otherUserId)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_ACCESS_DENIED);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any());
+		verify(stockEventPort, never()).publishStockReservationCancelled(any(), any(), any(), any(), any());
+		verify(outboxPort, never()).createAndSave(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("주문 취소 실패 - PENDING 상태가 아님")
+	void testCancelOrder_CannotCancel() {
+		// given
+		order.completePayment(); // PAID 상태로 변경
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.build();
+
+		// when & then
+		assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(OrderErrorCode.ORDER_CANNOT_CANCEL);
+
+		verify(orderCommandPort).findById(actualOrderId);
+		verify(orderCommandPort, never()).save(any());
+		verify(stockEventPort, never()).publishStockReservationCancelled(any(), any(), any(), any(), any());
+		verify(outboxPort, never()).createAndSave(any(), any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("주문 취소 성공 - 예약 상태가 CANCELLED로 변경됨")
+	void testCancelOrder_ReservationCancelled() throws Exception {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(objectMapper.writeValueAsString(any())).thenReturn("{\"orderId\":\"" + actualOrderId + "\"}");
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.build();
+
+		// when
+		cancelOrderService.cancelOrder(command);
+
+		// then - 예약 상태가 CANCELLED로 변경되었는지 확인
+		List<OrderReservation> reservations = order.getReservations();
+		assertThat(reservations).isNotEmpty();
+		assertThat(reservations.get(0).getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+	}
+
+	@Test
+	@DisplayName("주문 취소 성공 - Outbox 저장 실패해도 취소는 성공")
+	void testCancelOrder_OutboxFailure() throws Exception {
+		// given
+		UUID actualOrderId = order.getOrderId();
+		when(orderCommandPort.findById(actualOrderId)).thenReturn(Optional.of(order));
+		when(orderCommandPort.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		when(objectMapper.writeValueAsString(any())).thenThrow(new RuntimeException("JSON 직렬화 실패"));
+
+		CancelOrderCommand command = CancelOrderCommand.builder()
+			.orderId(actualOrderId)
+			.userId(userId)
+			.build();
+
+		// when
+		CancelOrderResult result = cancelOrderService.cancelOrder(command);
+
+		// then - Outbox 실패해도 취소는 성공
+		assertThat(result).isNotNull();
+		assertThat(result.orderId()).isEqualTo(actualOrderId);
+		assertThat(result.orderStatus()).isEqualTo("CANCELLED");
+
+		verify(orderCommandPort).save(order);
+		verify(stockEventPort).publishStockReservationCancelled(
+			eq(actualOrderId),
+			eq(timeDealStockId),
+			eq(2),
+			eq("주문 취소에 의한 재고 예약 해제"),
+			any(Instant.class)
+		);
+		verify(outboxPort, never()).createAndSave(any(), any(), any(), any());
+	}
+}


### PR DESCRIPTION
## 🧾 Summary
- Saga + CQRS + Outbox 패턴 적용하여 주문 취소 기능 구현

## 주문 취소 프로세스 흐름도
```mermaid
sequenceDiagram
    participant Client
    participant OrderCommandController
    participant CancelOrderService
    participant OrderCommandPort
    participant StockEventPort
    participant OutboxPort

    Client->>OrderCommandController: POST /api/v1/orders/{orderId}/cancel
    OrderCommandController->>CancelOrderService: CancelOrderCommand
    CancelOrderService->>CancelOrderService: 주문 조회 및 소유자 검증
    CancelOrderService->>CancelOrderService: 취소 가능 상태 검증
    CancelOrderService->>CancelOrderService: PENDING → cancelBeforePayment()
    CancelOrderService->>CancelOrderService: PAID → cancelAfterPayment()
    CancelOrderService->>OrderCommandPort: save() (DB 저장)
    CancelOrderService->>StockEventPort: publishStockReservationCancelled()
    CancelOrderService->>OutboxPort: createAndSave() (ORDER_CANCELLED 이벤트)
    CancelOrderService->>OrderCommandController: CancelOrderResult
    OrderCommandController->>Client: CancelOrderResponse
```

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [x] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [x] Unit test passed

## 📌 Related Issues
Closes #62 
