### PR TITLE
Feature(queue): 대기열 활성 스케줄러 관련 예외 및 토큰 삭제 처리

### DIFF
--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -21,7 +21,7 @@ public interface QueuePort {
     /**
      * 토큰 형식 검증
      */
-    TokenId validateQueueToken(String token);
+    TokenId extractValidQueueTokenId(String token);
 
     /**
      * 토큰 형식 검증 + 유저 토큰 활성화 여부

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -35,7 +35,10 @@ public interface QueuePort {
     boolean activateTokens(UUID productId, TrafficSetting trafficSetting);
 
     /**
+     * [명시적 대기열 퇴장/취소]
      * 토큰 만료 (삭제) 처리
+     * 대기 중 취소하거나, 주문 완료 후 호출
+     * UserId를 넘겨서 USER_INDEX_KEY까지 확실하게 지움 -> 이후에 즉시 재진입 가능하도록
      */
-    void expireToken(UUID productId, String token);
+    void exitQueue(UUID productId, String token, Long userId);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -33,4 +33,9 @@ public interface QueuePort {
      * 스케줄러가 호출: 대기 -> 활성 전환
      */
     boolean activateTokens(UUID productId, TrafficSetting trafficSetting);
+
+    /**
+     * 토큰 만료 (삭제) 처리
+     */
+    void expireToken(UUID productId, String token);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -32,5 +32,5 @@ public interface QueuePort {
      * 토큰 활성화
      * 스케줄러가 호출: 대기 -> 활성 전환
      */
-    void activateTokens(UUID productId, TrafficSetting trafficSetting);
+    boolean activateTokens(UUID productId, TrafficSetting trafficSetting);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueuePolicyService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueuePolicyService.java
@@ -1,6 +1,7 @@
 package com.rushcrew.queue.application.service;
 
 import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.queue.application.command.policy.CreatePolicyCommand;
 import com.rushcrew.queue.application.command.policy.SearchPolicyCommand;
 import com.rushcrew.queue.application.command.policy.UpdatePolicyCommand;
 import com.rushcrew.queue.application.dto.PageQuery;
@@ -35,8 +36,7 @@ public class QueuePolicyService implements QueuePolicyPort {
      */
     @Override
     @Transactional
-    public QueuePolicyQueryResponse createQueuePolicy(
-        com.rushcrew.queue.application.command.policy.CreatePolicyCommand command, Long userId, String role) {
+    public QueuePolicyQueryResponse createQueuePolicy(CreatePolicyCommand command, Long userId, String role) {
         // 권한 유효성 검사
         queuePolicyValidator.validateMasterRole(userId, role);
 

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -82,7 +82,7 @@ public class QueueService implements QueuePort {
             throw new BusinessException(QueueErrorCode.TOKEN_OWNER_NOT_MATCH);
         }
 
-        TokenId tokenId = validateQueueToken(token);
+        TokenId tokenId = extractValidQueueTokenId(token);
 
         // 활성 상태 여부 확인
         if (queueRepository.isActivatedToken(productId, tokenId)) {
@@ -119,7 +119,7 @@ public class QueueService implements QueuePort {
     }
 
     @Override
-    public TokenId validateQueueToken(String token) {
+    public TokenId extractValidQueueTokenId(String token) {
         TokenId tokenId;
         try {
             tokenId = TokenId.of(UUID.fromString(token));
@@ -172,7 +172,7 @@ public class QueueService implements QueuePort {
      */
     @Override
     public void exitQueue(UUID productId, String token, Long userId) {
-        TokenId tokenId = validateQueueToken(token);
+        TokenId tokenId = extractValidQueueTokenId(token);
         // RedisQueueRepository로 캐스팅
         if (queueRepository instanceof RedisQueueRepository) {
             queueRepository.removeTokenWithUserIdxKey(productId, tokenId, userId);
@@ -186,7 +186,7 @@ public class QueueService implements QueuePort {
      */
     @Override
     public boolean validateActivatedQueueToken(UUID productId, String token) {
-        TokenId tokenId = validateQueueToken(token);
+        TokenId tokenId = extractValidQueueTokenId(token);
         return queueRepository.isActivatedToken(productId, tokenId);
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -54,7 +54,7 @@ public class QueueService implements QueuePort {
             policy.getTrafficSetting().getTtl());
         if (!isSuccess) {
             // 이미 대기열에 있는 경우 예외 처리
-            throw new IllegalStateException("이미 대기열에 등록된 사용자입니다.");
+            throw new BusinessException(QueueErrorCode.USER_ALREADY_IN_WAITING_QUEUE);
         }
 
         // 현재 순번 조회
@@ -80,7 +80,7 @@ public class QueueService implements QueuePort {
         boolean isOwner = queueRepository.verifyTokenOwner(productId, userId, token);
         if (!isOwner) {
             log.warn("[QUEUE:ERROR] 토큰 도용 시도 감지: User {}, Token {}", userId, token);
-            throw new SecurityException("토큰 소유자가 일치하지 않습니다.");
+            throw new BusinessException(QueueErrorCode.TOKEN_OWNER_NOT_MATCH);
         }
 
         TokenId tokenId = validateQueueToken(token);
@@ -100,8 +100,10 @@ public class QueueService implements QueuePort {
         // rank는 0부터 시작 (내 앞의 대기 인원 수 (0이면 내가 1빠))
         Long waitingRank = queueRepository.getWaitingRank(productId, tokenId);
         if (waitingRank == null) {
-            // Redis에 없으면 만료되었거나 잘못된 토큰
-            throw new IllegalArgumentException("대기열에 존재하지 않는 토큰입니다.");
+            // User Index Key는 있는데 Redis에 ZSet에 없는 경우 (만료됨)
+            // => 에러를 던지면 클라이언트가 다시 enterQueue를 호출하게 되고,
+            // 그때 QueueRepository의 register 메서드에서 Index Key 삭제하고 재진입 처리
+            throw new BusinessException(QueueErrorCode.QUEUE_TOKEN_NOT_AVAILABLE);
         }
 
         // 요청시간 LocalDateTime 타입으로 변환

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -165,6 +165,16 @@ public class QueueService implements QueuePort {
     }
 
     /**
+     * 토큰 만료 처리
+     */
+    @Override
+    public void expireToken(UUID productId, String token) {
+        TokenId tokenId = validateQueueToken(token);
+        queueRepository.removeToken(productId, tokenId);
+        log.info("[QUEUE] 토큰 만료 처리 완료 (Product: {}, Token: {})", productId, token);
+    }
+
+    /**
      * 토큰 유효성 검증 (활성화 여부)
      */
     @Override

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -129,7 +129,7 @@ public class QueueService implements QueuePort {
     }
 
     @Override
-    public void activateTokens(UUID productId, TrafficSetting trafficSetting) {
+    public boolean activateTokens(UUID productId, TrafficSetting trafficSetting) {
         // 현재 활성 인원 조회
         Long currActiveCount = queueRepository.countActiveTokens(productId);
 
@@ -139,7 +139,7 @@ public class QueueService implements QueuePort {
 
         if (currActiveCount >= maxCapacity) {
             log.warn("[QUEUE] 활성열이 꽉 찼습니다. (Current: {}, Max: {})", currActiveCount, maxCapacity);
-            throw new BusinessException(QueueErrorCode.ACTIVE_QUEUE_FULL);
+            return false;
         }
 
         // 활성 토큰 N개 계산 => (N = min(배치사이즈, 남은자리))
@@ -148,7 +148,7 @@ public class QueueService implements QueuePort {
         long tokenCountToActivate = Math.min(limitSize, availableCount);
 
         if (tokenCountToActivate <= 0) {
-            throw new BusinessException(QueueErrorCode.NO_TOKEN_TO_ACTIVATE);
+            return false;
         }
 
         // 대기열에서 상위 N개 토큰 조회 (Waiting -> Active 대상) : 요청 시점(Score)이 낮은 것
@@ -156,11 +156,12 @@ public class QueueService implements QueuePort {
 
         if (waitingTokensToActivate.isEmpty()) {
             log.debug("[QUEUE] 대기열이 비어있습니다.");
-            throw new BusinessException(QueueErrorCode.NO_TOKEN_TO_ACTIVATE);
+            return false;
         }
 
         // 활성 상태로 전환
         queueRepository.activateTokens(productId, waitingTokensToActivate, trafficSetting);
+        return true;
     }
 
     /**

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -167,13 +167,19 @@ public class QueueService implements QueuePort {
     }
 
     /**
-     * 토큰 만료 처리
+     * 대기열 퇴장/취소 (토큰 삭제 처리)
+     * 대기 중 취소하거나, 주문 완료 후 호출
+     * UserId를 넘겨서 USER_INDEX_KEY까지 확실하게 지움 -> 즉시 재진입 가능
      */
     @Override
-    public void expireToken(UUID productId, String token) {
+    public void exitQueue(UUID productId, String token, Long userId) {
         TokenId tokenId = validateQueueToken(token);
-        queueRepository.removeToken(productId, tokenId);
-        log.info("[QUEUE] 토큰 만료 처리 완료 (Product: {}, Token: {})", productId, token);
+        // RedisQueueRepository로 캐스팅
+        if (queueRepository instanceof RedisQueueRepository) {
+            queueRepository.removeTokenWithUserIdxKey(productId, tokenId, userId);
+        } else {
+            queueRepository.removeToken(productId, tokenId);
+        }
     }
 
     /**

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.engine.internal.ManagedTypeHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -139,7 +139,7 @@ public class QueueService implements QueuePort {
 
         if (currActiveCount >= maxCapacity) {
             log.warn("[QUEUE] 활성열이 꽉 찼습니다. (Current: {}, Max: {})", currActiveCount, maxCapacity);
-            return;
+            throw new BusinessException(QueueErrorCode.ACTIVE_QUEUE_FULL);
         }
 
         // 활성 토큰 N개 계산 => (N = min(배치사이즈, 남은자리))
@@ -148,7 +148,7 @@ public class QueueService implements QueuePort {
         long tokenCountToActivate = Math.min(limitSize, availableCount);
 
         if (tokenCountToActivate <= 0) {
-            return;
+            throw new BusinessException(QueueErrorCode.NO_TOKEN_TO_ACTIVATE);
         }
 
         // 대기열에서 상위 N개 토큰 조회 (Waiting -> Active 대상) : 요청 시점(Score)이 낮은 것
@@ -156,7 +156,7 @@ public class QueueService implements QueuePort {
 
         if (waitingTokensToActivate.isEmpty()) {
             log.debug("[QUEUE] 대기열이 비어있습니다.");
-            return;
+            throw new BusinessException(QueueErrorCode.NO_TOKEN_TO_ACTIVATE);
         }
 
         // 활성 상태로 전환

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -160,15 +160,16 @@ public class QueueScheduler {
      * 토큰 활성화 실패 시 마지막 실행 시간(lastExecutionTime) 롤백
      */
     private void activateTokens(UUID productId, long executionTime, TrafficSetting setting) {
-        try {
-            queueService.activateTokens(productId, setting);
-            log.info("[Scheduler] 상품({}) 활성화 완료", productId);
-        } catch (BusinessException e) {
+        boolean success = queueService.activateTokens(productId, setting);
+
+        if (!success) {
             // activateTokens 실패 시 실행 시간 롤백
-            log.error("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId, e);
+            log.warn("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId);
             // 예외를 다시 던지지 않음 (다음 스케줄에서 재시도하도록)
             rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
+            return;
         }
+        log.info("[Scheduler] 상품({}) 활성화 완료", productId);
     }
 
     /**

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -1,9 +1,11 @@
 package com.rushcrew.queue.application.util;
 
+import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.domain.entity.QueuePolicy;
 import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
 import com.rushcrew.queue.domain.vo.TrafficSetting;
+import java.lang.reflect.Executable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -99,6 +101,7 @@ public class QueueScheduler {
     /**
      * 각 정책별로 활성화 로직 수행 (병렬 처리 가능)
      * 각 상품별로 락을 걸고 실행 (다중 서버 돌리는 상황에서 중복 실행 방지)
+     * 락 획득 실패 시 즉시 반환 (다음 스케줄에서 재시도)
      */
     private void processPolicyWithLock(QueuePolicy queuePolicy) {
         UUID productId = queuePolicy.getProductId();
@@ -133,10 +136,11 @@ public class QueueScheduler {
             }
 
             // 실행 시간 먼저 갱신 (중복 실행 방지)
-            updateLastExecutionTime(productId);
+            long executionTime = System.currentTimeMillis();
+            updateLastExecutionTime(productId, executionTime);
+
             // 대기열 -> 활성열 이동 요청
-            queueService.activateTokens(productId, setting);
-            log.info("[Scheduler] 상품({}) 활성화 완료", productId);
+            activateTokens(productId, executionTime, setting);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("[Scheduler] 락 획득 중 인터럽트 발생", e);
@@ -152,12 +156,48 @@ public class QueueScheduler {
     }
 
     /**
+     * 대기열 토큰 활성열 이동 처리 (토큰 활성화)
+     * 토큰 활성화 실패 시 마지막 실행 시간(lastExecutionTime) 롤백
+     */
+    private void activateTokens(UUID productId, long executionTime, TrafficSetting setting) {
+        try {
+            queueService.activateTokens(productId, setting);
+            log.info("[Scheduler] 상품({}) 활성화 완료", productId);
+        } catch (BusinessException e) {
+            // activateTokens 실패 시 실행 시간 롤백
+            log.error("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId, e);
+            // 예외를 다시 던지지 않음 (다음 스케줄에서 재시도하도록)
+            rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
+        }
+    }
+
+    /**
+     * activateTokens 실패 시 실행 시간 롤백
+     * queueGap 시간만큼 이전으로 되돌려 다음 스케줄에서 재시도 가능하도록 함
+     */
+    private void rollbackLastExecutionTime(UUID productId, long executionTime, Integer queueGap) {
+        try {
+            String lastRunKey = getLastRunKey(productId);
+            // queueGap 시간만큼 되돌려서 다음 스케줄에서 재시도 가능하도록
+            long rollbackTime = executionTime - (queueGap * 1000L);
+            redisTemplate.opsForValue().set(
+                lastRunKey,
+                String.valueOf(rollbackTime)
+            );
+            log.info("[Scheduler] 상품({}) 실행 시간 롤백 완료", productId);
+        } catch (BusinessException e) {
+            log.error("[Scheduler] 상품({}) 실행 시간 롤백 실패 - 수동 개입 필요", productId, e);
+            // TODO: 추후 따로 알림 보내는 형식으로의 조치가 필요
+        }
+    }
+
+    /**
      * 해당 상품의 스케줄러 실행 자격이 있는지 검사
      * 조건: (현재시간 - 마지막실행시간) >= queueGap
      */
     private boolean canExecute(UUID productId, int queueGap) {
         try {
-            String lastRunKey = String.format(LAST_RUN_KEY, productId);
+            String lastRunKey = getLastRunKey(productId);
             String lastRunTimeStr = redisTemplate.opsForValue().get(lastRunKey);
 
             // 첫 시작에는 true
@@ -179,9 +219,13 @@ public class QueueScheduler {
     /**
      * 마지막 실행 시간 갱신
      */
-    private void updateLastExecutionTime(UUID productId) {
-        String lastRunKey = String.format(LAST_RUN_KEY, productId);
-        redisTemplate.opsForValue().set(lastRunKey, String.valueOf(System.currentTimeMillis()));
+    private void updateLastExecutionTime(UUID productId, long executionTime) {
+        String lastRunKey = getLastRunKey(productId);
+        redisTemplate.opsForValue().set(lastRunKey, String.valueOf(executionTime));
+    }
+
+    private String getLastRunKey(UUID productId) {
+        return String.format(LAST_RUN_KEY, productId);
     }
 
     private String getLockKey(UUID productId) {

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -128,11 +128,15 @@ public class QueueScheduler {
             int queueGap = setting.getQueueGap();
 
             // Redis에 기록된 마지막 실행 시간 체크 (실행 가능 여부 검사)
-            if (canExecute(productId, queueGap)) {
-                // 대기열 -> 활성열 이동 요청
-                queueService.activateTokens(productId, setting);
-                updateLastExecutionTime(productId);
+            if (!canExecute(productId, queueGap)) {
+                return;
             }
+
+            // 실행 시간 먼저 갱신 (중복 실행 방지)
+            updateLastExecutionTime(productId);
+            // 대기열 -> 활성열 이동 요청
+            queueService.activateTokens(productId, setting);
+            log.info("[Scheduler] 상품({}) 활성화 완료", productId);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("[Scheduler] 락 획득 중 인터럽트 발생", e);
@@ -142,6 +146,7 @@ public class QueueScheduler {
             // 내가 건 락인 경우에만 해제
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
+                log.info("[Scheduler] 락 해제 완료");
             }
         }
     }
@@ -165,8 +170,8 @@ public class QueueScheduler {
             // 밀리초 단위로 비교 (초 단위보다 정밀)
             return diffMillis >= (queueGap * 1000L);
         } catch (Exception e) {
-            log.error("[Scheduler] Redis 조회 실패 (상품: {})", productId, e);
-            // Redis 실패 시 false 반환 (다음 스케줄에서 재시도)
+            log.error("[Scheduler] Redis 조회 실패 (상품: {}) - 다음 스케줄링에서 재시도", productId, e);
+            // Redis 조회 실패 시 false 반환 (다음 스케줄에서 재시도)
             return false;
         }
     }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -79,21 +79,18 @@ public class QueueScheduler {
 
         LocalDateTime now = LocalDateTime.now();
 
-        for (QueuePolicy policy : cachedPolicies) {
-            // "곧 시작(1분 내)할" 정책도 refreshPolicies 메서드에서 미리 가져왔으므로,
-            // 실제로 지금 시간이 시작 시간을 지났는지 메모리 상에서 체크
-            if (!isWithinRunningTime(policy, now)) {
-                continue;
-            }
-            processPolicyWithLock(policy);
-        }
-
+        // 병렬 처리로 성능 개선 (상품별 독립 락이므로 안전)
+        cachedPolicies.parallelStream()
+            .filter(policy -> isWithinRunningTime(policy, now))
+            .forEach(this::processPolicyWithLock);
     }
 
     /**
      * 대기열 정책에서 대기열 진입 시간 확인 로직
      */
     private boolean isWithinRunningTime(QueuePolicy policy, LocalDateTime now) {
+        // "곧 시작(1분 내)할" 정책도 refreshPolicies 메서드에서 미리 가져왔으므로,
+        // 실제로 지금 시간이 시작 시간을 지났는지 메모리 상에서 체크
         LocalDateTime startTime = policy.getTimePeriod().getStartTime();
         LocalDateTime endTime = policy.getTimePeriod().getEndTime();
         return (now.isEqual(startTime) || now.isAfter(startTime)) && now.isBefore(endTime);

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -49,21 +49,26 @@ public class QueueScheduler {
      */
     @Scheduled(fixedRate = 60000)
     public void refreshPolicies() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime oneMinuteLater = now.plusMinutes(1);
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime oneMinuteLater = now.plusMinutes(1);
 
-        // 현재 유효한(진행 중인) 타임딜 정책 조회
-        // TODO: RDB 부하가 걱정된다면 이 목록을 Redis에 캐싱
-        List<QueuePolicy> allActivePolicies = queuePolicyRepository.findAllActivePolicies(now,
-            oneMinuteLater);
+            // 현재 유효한(진행 중인) 타임딜 정책 조회
+            // TODO: RDB 부하가 걱정된다면 이 목록을 Redis에 캐싱
+            List<QueuePolicy> allActivePolicies = queuePolicyRepository.findAllActivePolicies(now,
+                oneMinuteLater);
 
-        // 새 리스트로 교체 (원자적 작업)
-        List<QueuePolicy> newPolicies = new CopyOnWriteArrayList<>(allActivePolicies);
+            // 새 리스트로 교체 (원자적 작업)
+            List<QueuePolicy> newPolicies = new CopyOnWriteArrayList<>(allActivePolicies);
 
-        // 캐시 교체 (CopyOnWriteArrayList는 참조 교체 시 스레드 세이프)
-        cachedPolicies.clear();
-        cachedPolicies.addAll(newPolicies);
-        log.info("[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: {})", allActivePolicies.size());
+            // 캐시 교체 (CopyOnWriteArrayList는 참조 교체 시 스레드 세이프)
+            cachedPolicies.clear();
+            cachedPolicies.addAll(newPolicies);
+            log.info("[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: {})", allActivePolicies.size());
+        } catch (Exception e) {
+            // 기존 캐시로 계속 운영 (장애 시에도 서비스 유지. 스케줄러 영구 중단 방지)
+            log.error("[Scheduler:Refresher] 정책 캐시 갱신 실패 - 기존 캐시 유지", e);
+        }
     }
 
     /**
@@ -150,7 +155,6 @@ public class QueueScheduler {
             // 내가 건 락인 경우에만 해제
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
-                log.info("[Scheduler] 락 해제 완료");
             }
         }
     }
@@ -158,6 +162,7 @@ public class QueueScheduler {
     /**
      * 대기열 토큰 활성열 이동 처리 (토큰 활성화)
      * 토큰 활성화 실패 시 마지막 실행 시간(lastExecutionTime) 롤백
+     * TODO: 추후 모니터링 추가 필요
      */
     private void activateTokens(UUID productId, long executionTime, TrafficSetting setting) {
         try {

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -160,16 +160,22 @@ public class QueueScheduler {
      * 토큰 활성화 실패 시 마지막 실행 시간(lastExecutionTime) 롤백
      */
     private void activateTokens(UUID productId, long executionTime, TrafficSetting setting) {
-        boolean success = queueService.activateTokens(productId, setting);
+        try {
+            boolean success = queueService.activateTokens(productId, setting);
 
-        if (!success) {
-            // activateTokens 실패 시 실행 시간 롤백
-            log.warn("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId);
-            // 예외를 다시 던지지 않음 (다음 스케줄에서 재시도하도록)
+            if (!success) {
+                // activateTokens 실패 시 실행 시간 롤백
+                log.warn("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId);
+                // 예외를 다시 던지지 않음 (다음 스케줄에서 재시도하도록)
+                rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
+                return;
+            }
+            log.info("[Scheduler] 상품({}) 활성화 완료", productId);
+        } catch (Exception e) {
+            // 실제 에러 (Redis 장애, DB 장애 등)
+            log.error("[Scheduler] 상품({}) 활성화 중 예외 발생 - 실행 시간 롤백", productId, e);
             rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
-            return;
         }
-        log.info("[Scheduler] 상품({}) 활성화 완료", productId);
     }
 
     /**

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -7,7 +7,10 @@ import com.rushcrew.queue.domain.vo.TrafficSetting;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -19,18 +22,22 @@ public class QueueScheduler {
     private final QueuePolicyRepository queuePolicyRepository;
     private final QueuePort queueService;
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedissonClient redissonClient;
 
     // DB 부하를 줄이기 위한 인메모리 캐시 (스레드 세이프)
     private final List<QueuePolicy> cachedPolicies = new CopyOnWriteArrayList<>();
 
     // 마지막 실행 시간 기록 Redis 키
     private static final String LAST_RUN_KEY = "queue:scheduler:last_run:%s";
+    // 락 키
+    private static final String LOCK_KEY = "lock:scheduler:product:%s";
 
     public QueueScheduler(QueuePolicyRepository queuePolicyRepository, QueuePort queueService,
-        RedisTemplate<String, String> redisTemplate) {
+        RedisTemplate<String, String> redisTemplate, RedissonClient redissonClient) {
         this.queuePolicyRepository = queuePolicyRepository;
         this.queueService = queueService;
         this.redisTemplate = redisTemplate;
+        this.redissonClient = redissonClient;
     }
 
     /**
@@ -48,9 +55,12 @@ public class QueueScheduler {
         List<QueuePolicy> allActivePolicies = queuePolicyRepository.findAllActivePolicies(now,
             oneMinuteLater);
 
+        // 새 리스트로 교체 (원자적 작업)
+        List<QueuePolicy> newPolicies = new CopyOnWriteArrayList<>(allActivePolicies);
+
         // 캐시 교체 (CopyOnWriteArrayList는 참조 교체 시 스레드 세이프)
         cachedPolicies.clear();
-        cachedPolicies.addAll(allActivePolicies);
+        cachedPolicies.addAll(newPolicies);
         log.info("[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: {})", allActivePolicies.size());
     }
 
@@ -75,7 +85,7 @@ public class QueueScheduler {
             if (!isWithinRunningTime(policy, now)) {
                 continue;
             }
-            processPolicy(policy);
+            processPolicyWithLock(policy);
         }
 
     }
@@ -91,22 +101,50 @@ public class QueueScheduler {
 
     /**
      * 각 정책별로 활성화 로직 수행 (병렬 처리 가능)
+     * 각 상품별로 락을 걸고 실행 (다중 서버 돌리는 상황에서 중복 실행 방지)
      */
-    private void processPolicy(QueuePolicy queuePolicy) {
+    private void processPolicyWithLock(QueuePolicy queuePolicy) {
         UUID productId = queuePolicy.getProductId();
-        TrafficSetting setting = queuePolicy.getTrafficSetting();
 
-        // 대기열 -> 활성열로 이동 주기
-        int queueGap = setting.getQueueGap();
+        String lockKey = getLockKey(productId);
+        // 락 키를 상품별로 생성하여 병렬 처리
+        RLock lock = redissonClient.getLock(lockKey);
 
-        // Redis에 기록된 마지막 실행 시간 체크 (실행 가능 여부 검사)
-        if (canExecute(productId, queueGap)) {
-            try {
+        try {
+            // tryLock(대기시간, 점유시간, 단위)
+            // waitTime = 0: 락을 못 잡으면 즉시 포기 (다른 서버가 하고 있겠거니 생각. 대기 X, 다음 턴에서)
+            // Scale-out(다중 서버) 상황에서 서버 A가 실행 중이면, 서버 B와 C는 1초 뒤(다음 스케줄링)에 다시 시도하면 되므로 굳이 기다릴 필요X
+            // (Thread Blocking 방지)
+
+            // leaseTime = 3초: 3초 뒤엔 락 자동 반납 (서버가 죽었을 때 데드락 방지)
+            // 스케줄러 주기가 1초이므로 leaseTime은 1~3초 정도로 짧게 설정
+            boolean isLocked = lock.tryLock(0, 3, TimeUnit.SECONDS);
+
+            if (!isLocked) {
+                // 이미 다른 서버가 실행 중임 -> 패스
+                return;
+            }
+
+            // 락 획득 성공
+            TrafficSetting setting = queuePolicy.getTrafficSetting();
+            // 대기열 -> 활성열로 이동 주기
+            int queueGap = setting.getQueueGap();
+
+            // Redis에 기록된 마지막 실행 시간 체크 (실행 가능 여부 검사)
+            if (canExecute(productId, queueGap)) {
                 // 대기열 -> 활성열 이동 요청
                 queueService.activateTokens(productId, setting);
                 updateLastExecutionTime(productId);
-            } catch (Exception e) {
-                log.error("[Scheduler] 상품({}) 활성화 중 에러 발생", productId, e);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("[Scheduler] 락 획득 중 인터럽트 발생", e);
+        } catch (Exception e) {
+            log.error("[Scheduler] 상품({}) 활성화 중 에러 발생", productId, e);
+        } finally {
+            // 내가 건 락인 경우에만 해제
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
             }
         }
     }
@@ -116,17 +154,24 @@ public class QueueScheduler {
      * 조건: (현재시간 - 마지막실행시간) >= queueGap
      */
     private boolean canExecute(UUID productId, int queueGap) {
-        String lastRunKey = String.format(LAST_RUN_KEY, productId);
-        String lastRunTimeStr = redisTemplate.opsForValue().get(lastRunKey);
+        try {
+            String lastRunKey = String.format(LAST_RUN_KEY, productId);
+            String lastRunTimeStr = redisTemplate.opsForValue().get(lastRunKey);
 
-        // 첫 시작에는 true
-        if (lastRunTimeStr == null) return true;
+            // 첫 시작에는 true
+            if (lastRunTimeStr == null) return true;
 
-        long lastRunTime = Long.parseLong(lastRunTimeStr);
-        long currentTime = System.currentTimeMillis();
-        long diffSeconds = (currentTime - lastRunTime) / 1000;
+            long lastRunTime = Long.parseLong(lastRunTimeStr);
+            long currentTime = System.currentTimeMillis();
+            long diffMillis = currentTime - lastRunTime;
 
-        return diffSeconds >= queueGap;
+            // 밀리초 단위로 비교 (초 단위보다 정밀)
+            return diffMillis >= (queueGap * 1000L);
+        } catch (Exception e) {
+            log.error("[Scheduler] Redis 조회 실패 (상품: {})", productId, e);
+            // Redis 실패 시 false 반환 (다음 스케줄에서 재시도)
+            return false;
+        }
     }
 
     /**
@@ -135,5 +180,9 @@ public class QueueScheduler {
     private void updateLastExecutionTime(UUID productId) {
         String lastRunKey = String.format(LAST_RUN_KEY, productId);
         redisTemplate.opsForValue().set(lastRunKey, String.valueOf(System.currentTimeMillis()));
+    }
+
+    private String getLockKey(UUID productId) {
+        return String.format(LOCK_KEY, productId);
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -66,6 +66,7 @@ public class QueueScheduler {
             cachedPolicies.addAll(newPolicies);
             log.info("[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: {})", allActivePolicies.size());
         } catch (Exception e) {
+            // SQLException 터지면 스케줄링이 전부 중단될 수 있으므로 기존 캐시를 유지하여 서비스가 계속 운영되도록 함
             // 기존 캐시로 계속 운영 (장애 시에도 서비스 유지. 스케줄러 영구 중단 방지)
             log.error("[Scheduler:Refresher] 정책 캐시 갱신 실패 - 기존 캐시 유지", e);
         }

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -13,8 +13,16 @@ public enum QueueErrorCode implements ErrorCode {
     ROLE_NOT_EXISTS(HttpStatus.NOT_FOUND, "ROLE_NOT_EXISTS", "유효하지 않은 권한입니다."),
     QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다."),
     ACTIVE_QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "ACTIVE_QUEUE_FULL", "활성 큐 용량 초과로 현재 요청을 처리할 수 없습니다."),
-    NO_TOKEN_TO_ACTIVATE(HttpStatus.SERVICE_UNAVAILABLE, "NO_TOKEN_TO_ACTIVATE", "활성 큐로 이동시킬 토큰이 없습니다.")
+    NO_TOKEN_TO_ACTIVATE(HttpStatus.SERVICE_UNAVAILABLE, "NO_TOKEN_TO_ACTIVATE", "활성 큐로 이동시킬 토큰이 없습니다."),
+    USER_ALREADY_IN_WAITING_QUEUE(HttpStatus.CONFLICT, "USER_ALREADY_IN_WAITING_QUEUE", "이미 대기열에 등록된 사용자입니다."),
+    TOKEN_OWNER_NOT_MATCH(HttpStatus.NOT_FOUND, "TOKEN_OWNER_NOT_MATCH", "토큰 소유자가 일치하지 않습니다."),
+    QUEUE_TOKEN_EXPIRED(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_TOKEN_EXPIRED", "대기열에 존재하지 않는 만료 토큰입니다.")
+
+
+
+
     ;
+
 
     private final HttpStatus status;
     private final String name;

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -11,10 +11,7 @@ public enum QueueErrorCode implements ErrorCode {
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "FORBIDDEN_ACCESS", "접근 권한이 없습니다."),
     POLICY_ALREADY_DELETED(HttpStatus.NOT_FOUND, "POLICY_ALREADY_DELETED", "이미 삭제된 정책 정보입니다."),
     ROLE_NOT_EXISTS(HttpStatus.NOT_FOUND, "ROLE_NOT_EXISTS", "유효하지 않은 권한입니다."),
-    QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다."),
-    ACTIVE_QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "ACTIVE_QUEUE_FULL", "활성 큐 용량 초과로 현재 요청을 처리할 수 없습니다."),
-    NO_TOKEN_TO_ACTIVATE(HttpStatus.SERVICE_UNAVAILABLE, "NO_TOKEN_TO_ACTIVATE", "활성 큐로 이동시킬 토큰이 없습니다."),
-    WAITING_QUEUE_IS_EMPTY(HttpStatus.SERVICE_UNAVAILABLE, "WAITING_QUEUE_IS_EMPTY", "대기열 큐가 비어있습니다.")
+    QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다.")
 
     ;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -11,8 +11,9 @@ public enum QueueErrorCode implements ErrorCode {
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "FORBIDDEN_ACCESS", "접근 권한이 없습니다."),
     POLICY_ALREADY_DELETED(HttpStatus.NOT_FOUND, "POLICY_ALREADY_DELETED", "이미 삭제된 정책 정보입니다."),
     ROLE_NOT_EXISTS(HttpStatus.NOT_FOUND, "ROLE_NOT_EXISTS", "유효하지 않은 권한입니다."),
-    QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다.")
-
+    QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다."),
+    ACTIVE_QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "ACTIVE_QUEUE_FULL", "활성 큐 용량 초과로 현재 요청을 처리할 수 없습니다."),
+    NO_TOKEN_TO_ACTIVATE(HttpStatus.SERVICE_UNAVAILABLE, "NO_TOKEN_TO_ACTIVATE", "활성 큐로 이동시킬 토큰이 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -11,7 +11,10 @@ public enum QueueErrorCode implements ErrorCode {
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "FORBIDDEN_ACCESS", "접근 권한이 없습니다."),
     POLICY_ALREADY_DELETED(HttpStatus.NOT_FOUND, "POLICY_ALREADY_DELETED", "이미 삭제된 정책 정보입니다."),
     ROLE_NOT_EXISTS(HttpStatus.NOT_FOUND, "ROLE_NOT_EXISTS", "유효하지 않은 권한입니다."),
-    QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다.")
+    QUEUE_TOKEN_NOT_AVAILABLE(HttpStatus.NOT_FOUND, "", "잘못된 토큰 형식입니다."),
+    ACTIVE_QUEUE_FULL(HttpStatus.SERVICE_UNAVAILABLE, "ACTIVE_QUEUE_FULL", "활성 큐 용량 초과로 현재 요청을 처리할 수 없습니다."),
+    NO_TOKEN_TO_ACTIVATE(HttpStatus.SERVICE_UNAVAILABLE, "NO_TOKEN_TO_ACTIVATE", "활성 큐로 이동시킬 토큰이 없습니다."),
+    WAITING_QUEUE_IS_EMPTY(HttpStatus.SERVICE_UNAVAILABLE, "WAITING_QUEUE_IS_EMPTY", "대기열 큐가 비어있습니다.")
 
     ;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -82,4 +82,13 @@ public interface QueueRepository {
      * @param tokenId
      */
     void removeToken(UUID productId, TokenId tokenId);
+
+    /**
+     * 명시적 퇴장 : 활성열/대기열 토큰 삭제 + USER_INDEX_KEY 삭제
+     * QueueService에서 사용자가 직접 취소하거나 주문 완료 시 호출
+     * @param productId
+     * @param tokenId
+     * @param userId
+     */
+    void removeTokenWithUserIdxKey(UUID productId, TokenId tokenId, Long userId);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -75,4 +75,11 @@ public interface QueueRepository {
      * @return
      */
     Double getWaitingScore(UUID productId, TokenId tokenId);
+
+    /**
+     * 토큰 만료 삭제
+     * @param productId
+     * @param tokenId
+     */
+    void removeToken(UUID productId, TokenId tokenId);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/RedisConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/RedisConfig.java
@@ -55,7 +55,9 @@ public class RedisConfig {
 
         // 로컬 개발 환경에서는 localhost 기준
         config.useSingleServer()
-            .setAddress("redis://" + redisHost + ":" + redisPort);
+            .setAddress("redis://" + redisHost + ":" + redisPort)
+            .setConnectionMinimumIdleSize(5) // 최소 유휴 연결 수
+            .setConnectionPoolSize(20);      // 최대 연결 풀 크기
         return Redisson.create(config);
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -149,10 +149,24 @@ public class RedisQueueRepository implements QueueRepository {
 
     /**
      * 활성 토큰 수 확인 (ZSet Size 조회)
+     * 조회 직전에 이미 만료된 토큰을 삭제하여 정확한 수를 반환함 (Lazy cleanup)
      */
     @Override
     public Long countActiveTokens(UUID productId) {
-        Long count = redisTemplate.opsForZSet().zCard(getActiveKey(productId));
+        String activeKey = getActiveKey(productId);
+
+        // lazy cleanup
+        // ZSet의 Score(만료시간)가 현재 시간보다 작은(과거인) 멤버들 삭제
+        // ZREMRANGEBYSCORE key -inf current_timestamp
+        double now = System.currentTimeMillis() / 1000.0;
+        redisTemplate.opsForZSet().removeRangeByScore(
+            activeKey,
+            Double.NEGATIVE_INFINITY,
+            now
+        );
+
+        // 청소 후 남은 개수 반환
+        Long count = redisTemplate.opsForZSet().zCard(activeKey);
         return count != null ? count : 0L;
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -190,6 +190,21 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     /**
+     * TODO: Order Service 쪽에서 결제/주문 로직이나, 트랜잭션 종료 시점에 해당 API를 호출하여 토큰을 정리해야 함
+     * @param productId
+     * @param tokenId
+     */
+    @Override
+    public void removeToken(UUID productId, TokenId tokenId) {
+        // 활성열(ZSet)에서 해당 토큰 삭제
+        redisTemplate.opsForZSet()
+            .remove(
+                getActiveKey(productId),
+                tokenId.getValue().toString()
+            );
+    }
+
+    /**
      * 본인 확인 (대기열 토큰 소유권 검증)
      */
     @Override

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -42,6 +42,11 @@ public class RedisQueueRepository implements QueueRepository {
 
     /**
      * 대기열 등록 (ZSet : Sorted Set)
+     *
+     * 추가 처리 : Lazy Cleanup으로 인해 ZSet(대기열/활성열)에서는 토큰이 삭제되었는데
+     * USER_INDEX_KEY만 덩그러니 남아있는 상황이 발생하면, 해당 유저는 영원히 재진입이 불가능해짐.
+     * 따라서 진입 시도 시 USER_INDEX_KEY가 이미 있다면,
+     * "진짜 대기열/활성열에 살아있는지" 더블 체크. 없다면 좀비 키로 간주하고 삭제 후 재진입을 허용하는 방식으로 수정
      */
     @Override
     public boolean register(QueueToken token, LocalDateTime dealEndTime, Integer activeTtl) {
@@ -56,17 +61,32 @@ public class RedisQueueRepository implements QueueRepository {
 
         // redis 사용자 인덱스 키 생성
         String userIndexKey = getUserIndexKey(token.getProductId(), token.getUserId());
+        String newTokenValue = token.getId().getValue().toString();
 
         // 중복 방지 : 유저별 대기열 키 생성 (SETNX)
         // KEY: queue:user:product:{productId}:{userId} / VALUE: 토큰 UUID
         Boolean isNewUser = redisTemplate.opsForValue().setIfAbsent(
             userIndexKey,
-            token.getId().getValue().toString(),
+            newTokenValue,
             Duration.ofMinutes(secondsUntilClose) // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
         );
 
+        // 유저별 대기열 키(USER_INDEX_KEY)가 이미 존재하는 경우 -> 진짜 유효한지 검증
         if (Objects.equals(isNewUser, Boolean.FALSE)) {
-            // 이미 대기 중인 유저
+            // USER_INDEX_KEY가 바라보는 큐 토큰 (해당 유저가 가지고 있던 토큰의 ID(UUID))
+            String oldToken = redisTemplate.opsForValue().get(userIndexKey);
+
+            // 기존 토큰이 대기열이나 활성열에 실제로 존재하는지 확인
+            if (oldToken != null && !isTokenAlive(token.getProductId(), oldToken)) {
+                // 존재하지 않음 = 만료되었거나 삭제된 좀비 키(USER_INDEX_KEY)임 -> 삭제 후 재등록 허용
+                log.info("[QUEUE:REPAIR] 좀비 키(USER_INDEX_KEY) 발견. 삭제 후 재진입 처리 userId={}, oldToken={}", token.getUserId(), oldToken);
+                redisTemplate.delete(userIndexKey);
+
+                // 삭제하고 재시도 (재귀 호출)
+                return register(token, dealEndTime, activeTtl);
+            }
+
+            // 이미 대기 중인 유저 (중복 진입 거부)
             log.warn("[QUEUE:ERROR] 이미 대기 중인 사용자입니다. userId={}", token.getUserId());
             return false;
         }
@@ -80,6 +100,22 @@ public class RedisQueueRepository implements QueueRepository {
             // 대기열 등록 (ZSet)
             return registerWaitingQueue(token, userIndexKey);
         }
+    }
+
+    /**
+     * USER_INDEX_KEY가 가리키는 토큰이 진짜 ZSet(대기열 or 활성열)에 있는지 확인
+     */
+    private boolean isTokenAlive(UUID productId, String tokenValue) {
+        String waitingKey = getWaitingKey(productId);
+        String activeKey = getActiveKey(productId);
+
+        // 대기열 확인
+        Double waitingScore = redisTemplate.opsForZSet().score(waitingKey, tokenValue);
+        if (waitingScore != null) return true;
+
+        // 활성열 확인
+        Double activeScore = redisTemplate.opsForZSet().score(activeKey, tokenValue);
+        return activeScore != null;
     }
 
     @Override
@@ -187,9 +223,8 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     /**
+     * 활성열의 토큰 삭제
      * TODO: Order Service 쪽에서 결제/주문 로직이나, 트랜잭션 종료 시점에 해당 API를 호출하여 토큰을 정리해야 함
-     * @param productId
-     * @param tokenId
      */
     @Override
     public void removeToken(UUID productId, TokenId tokenId) {

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -158,7 +158,7 @@ public class RedisQueueRepository implements QueueRepository {
         // lazy cleanup
         // ZSet의 Score(만료시간)가 현재 시간보다 작은(과거인) 멤버들 삭제
         // ZREMRANGEBYSCORE key -inf current_timestamp
-        double now = System.currentTimeMillis() / 1000.0;
+        double now = System.currentTimeMillis();
         redisTemplate.opsForZSet().removeRangeByScore(
             activeKey,
             Double.NEGATIVE_INFINITY,
@@ -283,6 +283,7 @@ public class RedisQueueRepository implements QueueRepository {
 
     private double getExpireAt(Integer activeTtl) {
         long now = System.currentTimeMillis();
+        // 밀리초 단위 (예: 1730000000000 (13자리))
         return now + (activeTtl * 1000L);
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -237,6 +237,28 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     /**
+     * 명시적 퇴장 : 활성열/대기열 토큰 삭제 + USER_INDEX_KEY 삭제
+     * QueueService에서 사용자가 직접 취소하거나 주문 완료 시 호출
+     * 이 경우, USER_INDEX_KEY도 같이 삭제해야 바로 다시 해당 유저가 대기열 재진입 가능
+     */
+    @Override
+    public void removeTokenWithUserIdxKey(UUID productId, TokenId tokenId, Long userId) {
+        String tokenValue = tokenId.getValue().toString();
+
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            StringRedisConnection strConnection = (StringRedisConnection) connection;
+            // 활성열에서 삭제
+            strConnection.zRem(getActiveKey(productId), tokenValue);
+            // 대기열에서 삭제 (활성열에서 이미 삭제되어있다면 대기열에도 없겠지만 혹시 모르니 둘 다 삭제 처리)
+            strConnection.zRem(getWaitingKey(productId), tokenValue);
+            // 유저 인덱스 키 삭제 (재진입 허용 목적)
+            strConnection.del(getUserIndexKey(productId, userId));
+            return null;
+        });
+        log.info("[QUEUE:EXIT] 대기/활성열 퇴장 처리 완료: userId={}, token={}", userId, tokenId);
+    }
+
+    /**
      * 본인 확인 (대기열 토큰 소유권 검증)
      */
     @Override

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -137,10 +137,7 @@ public class RedisQueueRepository implements QueueRepository {
         long now = System.currentTimeMillis();
         if (expireTime < now) {
             // 만료되었으면 삭제
-            redisTemplate.opsForZSet().remove(
-                activeKey,
-                tokenId.getValue()
-            );
+            removeToken(productId, tokenId);
             log.info("[QUEUE:EXPIRE:ACTIVE] 활성 토큰 만료됨. token={}", tokenId);
             return false;
         }
@@ -149,7 +146,7 @@ public class RedisQueueRepository implements QueueRepository {
 
     /**
      * 활성 토큰 수 확인 (ZSet Size 조회)
-     * 조회 직전에 이미 만료된 토큰을 삭제하여 정확한 수를 반환함 (Lazy cleanup)
+     * 조회 직전에 이미 만료된 토큰을 일괄적으로 삭제하여 정확한 수를 반환함 (Lazy cleanup)
      */
     @Override
     public Long countActiveTokens(UUID productId) {

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueController.java
@@ -5,6 +5,7 @@ import com.rushcrew.common.dto.ApiResponse;
 import com.rushcrew.queue.application.command.queue.EnterQueueCommand;
 import com.rushcrew.queue.application.dto.QueueRedisResponse;
 import com.rushcrew.queue.application.port.in.QueuePort;
+import com.rushcrew.queue.application.service.QueueService;
 import com.rushcrew.queue.domain.enums.QueueStatus;
 import com.rushcrew.queue.presentation.dto.request.EnterQueueRequest;
 import com.rushcrew.queue.presentation.dto.response.QueueResponse;
@@ -12,7 +13,9 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -31,7 +34,7 @@ public class QueueController {
     private static final String USER_ROLE_HEADER = "X-User-Role";
     private static final String QUEUE_TOKEN_HEADER = "X-Queue-Token";
 
-    public QueueController(QueuePort queuePort) {
+    public QueueController(QueuePort queuePort, QueueService queueService) {
         this.queuePort = queuePort;
     }
 
@@ -63,6 +66,21 @@ public class QueueController {
         QueueRedisResponse redisResult = queuePort.getQueueRank(productId, queueToken, currUserId, role);
         QueueResponse response = toQueueResponse(redisResult);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response));
+    }
+
+    /**
+     * 대기열 취소/주문 완료 시 토큰 삭제 API
+     * 사용자가 대기 중 "취소" 버튼을 누르거나, 주문 프로세스가 끝나고 나갈 때 호출
+     */
+    @DeleteMapping("/{product-id}")
+    public ResponseEntity<ApiResponse<Void>> deleteQueueToken(
+        @PathVariable("product-id") UUID productId,
+        @RequestHeader(QUEUE_TOKEN_HEADER) String queueToken,
+        @RequestHeader(USER_ID_HEADER) Long currUserId,
+        @RequestHeader(USER_ROLE_HEADER) String role
+    ) {
+        queuePort.exitQueue(productId, queueToken, currUserId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(null));
     }
 
     // TODO: 추후 presenataion mapper 클래스로 이동 예정


### PR DESCRIPTION
## 🧾 Summary
(변경된 내용 요약)

### 1. 대기열 토큰 활성 시 예외 처리
- 활성 토큰 수 카운팅 시, 이미 만료된 토큰을 삭제한 이후의 수를 반환하도록 수정

> (사용자가 활성 상태가 되었는데 주문을 안 하고 나가버릴 경우, 만료된 토큰 정리하고, 활성열 카운트 갱신되도록 처리)

### 2. 스케줄러 동시성 제어 처리 (분산 락)
- 실행 시점 마지막 업데이트 시간 갱신 위치 (updateLastExecutionTime) 수정
- "대기열 -> 활성열 이동" 메서드 호출 이전에 마지막 업데이트 시간을 갱신하도록 수정
> 만약 로직 실행 후에 시간을 갱신하는데 로직에서 에러가 나면, 다음 1초 뒤에 또 실행되어 무한 에러 루프에 빠지거나 중복 실행될 위험이 있음.. 먼저 시간을 찍고 실행하는 것이 시스템 안정성 면에서 더 유리하기에 위와 같이 수정

- DB/Redis 장애 시 스케줄러 중단 방지 처리

### 3. 토큰 삭제 처리 리팩토링
- 남아있는 USER_INDEX_KEY 토큰 삭제 처리 (대기열 재진입 허용 목적)
> ZSet(대기열/활성열)에서는 토큰이 삭제되었는데 USER_INDEX_KEY만 덩그러니 남아있는 상황이 발생하면, 해당 유저는 영원히 재진입이 불가능해지는 상황이 된다.

>  따라서 진짜 대기열/활성열에 토큰이 존재하는지 검증하고, 없다면  USER_INDEX_KEY를 삭제하고 재진입이 가능하도록 처리 (추후 5분 기록 보드에 정리 예정)

### 4. 대기 취소/주문 완료 시 토큰 삭제 기능
- 대기열 취소(퇴장)/주문 완료 시 토큰 삭제 API
- 대기열 퇴장/주문 완료 이후 명시적으로 토큰 삭제 처리
- 대기열에서 토큰 삭제될 때, USER_INDEX_KEY도 같이 삭제되도록 처리

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
#95 
