### PR TITLE
Feat(order): 주문 로직 수정 + 캐시 워밍 스케줄러 추가

### DIFF
--- a/order-service/src/main/java/com/rushcrew/order_service/OrderServiceApplication.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/OrderServiceApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableScheduling
 @ComponentScan(basePackages = {
 	"com.rushcrew.order_service",
 	"com.rushcrew.common"

--- a/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CancelOrderService.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/command/service/CancelOrderService.java
@@ -52,16 +52,23 @@ public class CancelOrderService implements CancelOrderUseCase {
 
 		// 주문 상태 변경 (PENDING → CANCELLED)
 		order.cancelBeforePayment("사용자 요청에 의한 주문 취소");
+
+		// 각 예약된 재고에 대해 예약 취소 처리
+		for (OrderReservation reservation : order.getReservations()) {
+			if (reservation.getStatus() == ReservationStatus.RESERVED) {
+				// 예약 상태를 CANCELLED로 변경
+				reservation.cancel();
+			}
+		}
+
+		// Order와 OrderReservation 변경사항 DB에 저장 (cascade로 함께 저장됨)
 		Order savedOrder = orderCommandPort.save(order);
 
 		log.info("주문 취소 완료: orderId={}", savedOrder.getOrderId());
 
 		// 각 예약된 재고에 대해 예약 해제 이벤트 발행 (kafka 비동기 통신 - outbox 패턴)
 		for (OrderReservation reservation : savedOrder.getReservations()) {
-			if (reservation.getStatus() == ReservationStatus.RESERVED) {
-				// 예약 상태를 CANCELLED로 변경
-				reservation.cancel();
-
+			if (reservation.getStatus() == ReservationStatus.CANCELLED) {
 				// 재고 예약 취소 이벤트 발행
 				stockEventPort.publishStockReservationCancelled(
 					savedOrder.getOrderId(),

--- a/order-service/src/main/java/com/rushcrew/order_service/application/port/out/SagaInstancePort.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/port/out/SagaInstancePort.java
@@ -1,0 +1,13 @@
+package com.rushcrew.order_service.application.port.out;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+import com.rushcrew.order_service.domain.model.saga.SagaInstance;
+
+public interface SagaInstancePort {
+	SagaInstance save(SagaInstance sagaInstance);
+
+	List<SagaInstance> findByStatusAndCreatedAtBefore(SagaStatus status, Instant createdAt);
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestrator.java
@@ -13,6 +13,7 @@ import com.rushcrew.order_service.application.saga.step.CreateOrderStep;
 import com.rushcrew.order_service.application.saga.step.DeductPointStep;
 import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
 import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
+import com.rushcrew.order_service.application.port.out.SagaInstancePort;
 import com.rushcrew.order_service.domain.enums.SagaStatus;
 import com.rushcrew.order_service.domain.model.saga.SagaInstance;
 
@@ -29,11 +30,14 @@ public class OrderCreationSagaOrchestrator {
 	private final ReserveStockStep reserveStockStep;
 	private final DeductPointStep deductPointStep;
 	private final CreateOrderStep createOrderStep;
+	private final SagaInstancePort sagaInstancePort;
 
 	@Transactional
 	public CreateOrderResult execute(CreateOrderCommand command) {
 		// 1. Saga 인스턴스 생성 - sagaId 생성
 		SagaInstance sagaInstance = SagaInstance.create("ORDER_CREATION", command.userId());
+		// DB에 기록
+		saveSagaInstance(sagaInstance);
 		// 2. Saga Context 생성
 		SagaContext context = SagaContext.builder()
 			.sagaId(sagaInstance.getSagaId())
@@ -53,6 +57,7 @@ public class OrderCreationSagaOrchestrator {
 				throw new IllegalArgumentException(validateResult.getErrorMessage());
 			}
 			sagaInstance.addStep("VALIDATE_STOCK", SagaStatus.COMPLETED);
+			saveSagaInstance(sagaInstance);
 
 			// Step 2: 재고 예약
 			log.info("[Saga-{}] Step 2: ReserveStock 시작", context.getSagaId());
@@ -61,16 +66,18 @@ public class OrderCreationSagaOrchestrator {
 				throw new IllegalArgumentException(reserveResult.getErrorMessage());
 			}
 			sagaInstance.addStep("RESERVE_STOCK", SagaStatus.COMPLETED);
+			saveSagaInstance(sagaInstance);
 
 			// Step 3: 포인트 차감
 			log.info("[Saga-{}] Step 3: DeductPoint 시작", context.getSagaId());
 			SagaStepResult deductResult = deductPointStep.execute(context, sagaData);
 			if (!deductResult.isSuccess()) {
-				// 포인트 차감 실패 → 재고 복구
+				// 포인트 차감 실패 -> 재고 복구
 				reserveStockStep.compensate(context, sagaData);
 				throw new IllegalArgumentException(deductResult.getErrorMessage());
 			}
 			sagaInstance.addStep("DEDUCT_POINT", SagaStatus.COMPLETED);
+			saveSagaInstance(sagaInstance);
 
 			// Step 4: 주문 생성
 			log.info("[Saga-{}] Step 4: CreateOrder 시작", context.getSagaId());
@@ -82,9 +89,11 @@ public class OrderCreationSagaOrchestrator {
 				throw new IllegalArgumentException(createResult.getErrorMessage());
 			}
 			sagaInstance.addStep("CREATE_ORDER", SagaStatus.COMPLETED);
+			saveSagaInstance(sagaInstance);
 
 			// Saga 완료
 			sagaInstance.complete();
+			saveSagaInstance(sagaInstance);
 			log.info("[Saga-{}] 완료", context.getSagaId());
 
 			// 결과 리턴
@@ -118,9 +127,14 @@ public class OrderCreationSagaOrchestrator {
 		} catch (Exception e) {
 			// Saga 실패 처리
 			sagaInstance.fail(e.getMessage());
+			saveSagaInstance(sagaInstance);
 			log.error("[Saga-{}] 실패: {}", context.getSagaId(), e.getMessage(), e);
 			throw e;
 		}
 
+	}
+
+	private void saveSagaInstance(SagaInstance sagaInstance) {
+		sagaInstancePort.save(sagaInstance);
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/CreateOrderStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/CreateOrderStep.java
@@ -55,11 +55,11 @@ public class CreateOrderStep {
 						.timeDealStockId(String.valueOf(itemResult.timeDealStockId()))
 						.productId(String.valueOf(itemResult.productId()))
 						.productName(itemResult.productName())
-						.productDescription("") // stockDetail에서 가져와야 함
+						// .productDescription("")
 						.optionName(itemResult.optionName())
 						.timeDealId(String.valueOf(timeDeal.timeDealId()))
 						.timeDealTitle(timeDeal.title())
-						.discountRate(timeDeal.discountRate())
+						// .discountRate(timeDeal.discountRate())
 						.build();
 
 					return OrderItem.create(

--- a/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/saga/step/ReserveStockStep.java
@@ -1,6 +1,7 @@
 package com.rushcrew.order_service.application.saga.step;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -188,7 +189,7 @@ public class ReserveStockStep {
 			timeDealId,
 			userId,
 			availableStock,
-			java.time.Instant.now()
+			Instant.now()
 		);
 	}
 

--- a/order-service/src/main/java/com/rushcrew/order_service/application/validator/TimeDealStockValidator.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/application/validator/TimeDealStockValidator.java
@@ -2,22 +2,16 @@ package com.rushcrew.order_service.application.validator;
 
 import org.springframework.stereotype.Component;
 
-import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.order_service.application.port.dto.TimeDealStockDetail;
 import com.rushcrew.order_service.application.port.dto.TimeDealStockStatus;
-import com.rushcrew.order_service.global.error.OrderErrorCode;
 
 @Component
 public class TimeDealStockValidator {
 
 	public void validate(TimeDealStockDetail stockDetail) {
-		// 상품 활성 상태 확인
-		// if (!stockDetail.isActive()) {
-		// 	throw new BusinessException(OrderErrorCode.INVALID_PRODUCT);
-		// }
-		// 재고 상태 확인
-		if (stockDetail.getStatus() == TimeDealStockStatus.PAUSED) {
-			throw new IllegalArgumentException("판매 중지된 상품입니다.");
+		// 재고 상태: AVAILABLE 만 허용
+		if (stockDetail.getStatus() != TimeDealStockStatus.AVAILABLE) {
+			throw new IllegalArgumentException("재고가 판매 가능한 상태가 아닙니다.");
 		}
 	}
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/repository/OrderJpaRepository.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/repository/OrderJpaRepository.java
@@ -38,5 +38,5 @@ public interface OrderJpaRepository extends JpaRepository<Order, UUID> {
 	@Query("SELECT o FROM Order o " +
 		"WHERE o.orderedAt >= :since " +
 		"ORDER BY o.orderedAt DESC")
-	List<Order> findRecentOrders(Instant oneDayAgo);
+	List<Order> findRecentOrders(@Param("since") Instant since);
 }

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/saga/SagaInstanceAdapter.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/persistence/saga/SagaInstanceAdapter.java
@@ -1,0 +1,30 @@
+package com.rushcrew.order_service.infrastructure.persistence.saga;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.rushcrew.order_service.application.port.out.SagaInstancePort;
+import com.rushcrew.order_service.domain.enums.SagaStatus;
+import com.rushcrew.order_service.domain.model.saga.SagaInstance;
+import com.rushcrew.order_service.infrastructure.persistence.saga.repository.SagaInstanceJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SagaInstanceAdapter implements SagaInstancePort {
+
+	private final SagaInstanceJpaRepository sagaInstanceJpaRepository;
+
+	@Override
+	public SagaInstance save(SagaInstance sagaInstance) {
+		return sagaInstanceJpaRepository.save(sagaInstance);
+	}
+
+	@Override
+	public List<SagaInstance> findByStatusAndCreatedAtBefore(SagaStatus status, Instant createdAt) {
+		return sagaInstanceJpaRepository.findByStatusAndCreatedAtBefore(status, createdAt);
+	}
+}

--- a/order-service/src/main/java/com/rushcrew/order_service/infrastructure/scheduler/SagaRecoveryScheduler.java
+++ b/order-service/src/main/java/com/rushcrew/order_service/infrastructure/scheduler/SagaRecoveryScheduler.java
@@ -7,10 +7,10 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.rushcrew.order_service.application.port.out.SagaInstancePort;
 import com.rushcrew.order_service.application.saga.service.SagaRecoveryService;
 import com.rushcrew.order_service.domain.enums.SagaStatus;
 import com.rushcrew.order_service.domain.model.saga.SagaInstance;
-import com.rushcrew.order_service.infrastructure.persistence.saga.repository.SagaInstanceJpaRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,17 +20,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SagaRecoveryScheduler {
 
-	private final SagaInstanceJpaRepository sagaRepository;
+	private final SagaInstancePort sagaInstancePort;
 	private final SagaRecoveryService sagaRecoveryService;
 
 	/**
 	 * 10분마다 타임아웃된 Saga 복구
 	 */
-	@Scheduled(fixedDelay = 600000)
+	@Scheduled(fixedDelay = 600000)	// 10분마다 실행
 	public void recoverTimedOutSagas() {
+		// 1. 10분 이상 RUNNING 상태인 Saga 조회
 		Instant tenMinutesAgo = Instant.now().minus(10, ChronoUnit.MINUTES);
-
-		List<SagaInstance> timedOutSagas = sagaRepository
+		List<SagaInstance> timedOutSagas = sagaInstancePort
 			.findByStatusAndCreatedAtBefore(SagaStatus.RUNNING, tenMinutesAgo);
 
 		if (timedOutSagas.isEmpty()) {
@@ -39,11 +39,12 @@ public class SagaRecoveryScheduler {
 
 		log.warn("타임아웃된 Saga {}개 발견", timedOutSagas.size());
 
+		// 각 Saga에 대해 보상 트랜잭션 실행
 		for (SagaInstance saga : timedOutSagas) {
 			try {
 				// 보상 트랜잭션 실행
-				sagaRecoveryService.compensateSaga(saga);
-				sagaRepository.save(saga);
+				sagaRecoveryService.compensateSaga(saga);	// 복구 시도
+				sagaInstancePort.save(saga);	// 상태 저장
 
 				log.info("Saga 타임아웃 처리 완료: sagaId={}", saga.getSagaId());
 
@@ -52,7 +53,7 @@ public class SagaRecoveryScheduler {
 				// 실패해도 상태는 업데이트
 				try {
 					saga.fail("Saga 타임아웃 - 복구 실패: " + e.getMessage());
-					sagaRepository.save(saga);
+					sagaInstancePort.save(saga);
 				} catch (Exception saveEx) {
 					log.error("Saga 상태 저장 실패: sagaId={}", saga.getSagaId(), saveEx);
 				}

--- a/order-service/src/test/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestratorTest.java
+++ b/order-service/src/test/java/com/rushcrew/order_service/application/saga/orchestrator/OrderCreationSagaOrchestratorTest.java
@@ -26,6 +26,7 @@ import com.rushcrew.order_service.application.saga.step.CreateOrderStep;
 import com.rushcrew.order_service.application.saga.step.DeductPointStep;
 import com.rushcrew.order_service.application.saga.step.ReserveStockStep;
 import com.rushcrew.order_service.application.saga.step.ValidateStockStep;
+import com.rushcrew.order_service.application.port.out.SagaInstancePort;
 import com.rushcrew.order_service.domain.vo.ShippingInfo;
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OrderCreationSagaOrchestrator 테스트")
@@ -43,6 +44,9 @@ class OrderCreationSagaOrchestratorTest {
 	@Mock
 	private CreateOrderStep createOrderStep;
 
+	@Mock
+	private SagaInstancePort sagaInstancePort;
+
 	@InjectMocks
 	private OrderCreationSagaOrchestrator orchestrator;
 
@@ -51,6 +55,8 @@ class OrderCreationSagaOrchestratorTest {
 
 	@BeforeEach
 	void setUp() {
+		when(sagaInstancePort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
 		orderId = UUID.randomUUID();
 
 		ShippingInfo shippingInfo = ShippingInfo.create(


### PR DESCRIPTION
## 🧾 Summary
- 각 스텝의 Saga Instance DB에 저장
- 주문 생성 발행한 이벤트 consumer 추가
- 캐시 워밍 추가
- 주문 취소 시 예약해제 이벤트 발행 전 예약 상태를 먼저 CANCELLED로 바꾸도록 설정

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [ ] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #136 
