### PR TITLE
Feat(timedeal): 재고 생성 API 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - rushdeal_pg_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U rushdeal -d rushdeal_db"]
+      test: [ "CMD-SHELL", "pg_isready -U rushdeal -d rushdeal_db" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -42,6 +42,20 @@ services:
       - "6381:6379"
     volumes:
       - rushdeal_order_redis_data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  rushdeal_timedeal_redis:
+    image: redis:7-alpine
+    container_name: rushdeal_timedeal_redis
+    restart: unless-stopped
+    ports:
+      - "6382:6379"
+    volumes:
+      - rushdeal_timedeal_redis_data:/data
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
@@ -91,3 +105,4 @@ volumes:
   rushdeal_pg_data:
   rushdeal_queue_redis_data:
   rushdeal_order_redis_data:
+  rushdeal_timedeal_redis_data:

--- a/timedeal-service/build.gradle
+++ b/timedeal-service/build.gradle
@@ -3,6 +3,7 @@ description = 'Timedeal Service for rush-deal Project'
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'

--- a/timedeal-service/build.gradle
+++ b/timedeal-service/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     // 공통 모듈 (jitpack)

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/TimeDealApplication.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/TimeDealApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.ComponentScan;
     "com.rushcrew.common"
 })
 @EnableFeignClients
+@EnableRetry
 public class TimeDealApplication {
 
     public static void main(String[] args) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ConfirmStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ConfirmStockCommand.java
@@ -1,0 +1,13 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import java.util.UUID;
+
+public record ConfirmStockCommand(
+    OrderId orderId,
+    UUID stockId,
+    Quantity quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/CreateStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/CreateStockCommand.java
@@ -1,0 +1,17 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import java.util.UUID;
+
+public record CreateStockCommand(
+    UUID productId,
+    Long totalStock
+) {
+
+    public static CreateStockCommand from(CreateStockRequest request) {
+        return new CreateStockCommand(
+            request.productId(),
+            request.totalStock()
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ReserveStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ReserveStockCommand.java
@@ -1,0 +1,14 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import java.util.UUID;
+
+public record ReserveStockCommand(
+    OrderId orderId,
+    UUID stockId,
+    Quantity quantity,
+    Long userId
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/RestoreStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/RestoreStockCommand.java
@@ -1,0 +1,14 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import java.util.UUID;
+
+public record RestoreStockCommand(
+    UUID stockId,
+    Quantity quantity,
+    OrderId orderId,
+    String reason
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/UpdateStockCountCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/UpdateStockCountCommand.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.Quantity;
+
+public record UpdateStockCountCommand(
+    Quantity quantity,
+    String reason
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockChangedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockChangedEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockChangedEvent(
+    UUID stockId,
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockCreatedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockCreatedEvent(
+    UUID stockId,
+    Long totalStock
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockDeletedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockDeletedEvent(
+    UUID stockId
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockReservedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockReservedEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockReservedEvent(
+    UUID stockId,
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockRestoredEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockRestoredEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockRestoredEvent(
+    UUID stockId,
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ConfirmStockResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ConfirmStockResult.java
@@ -1,0 +1,12 @@
+package com.rushcrew.timedeal.application.result;
+
+import java.util.UUID;
+
+public record ConfirmStockResult(
+    UUID orderId
+) {
+
+    public static ConfirmStockResult of(UUID orderId) {
+        return new ConfirmStockResult(orderId);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/CreateStockResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/CreateStockResult.java
@@ -1,0 +1,31 @@
+package com.rushcrew.timedeal.application.result;
+
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateStockResult(
+    UUID stockId,
+    UUID productId,
+    Long availableStock,
+    Long reservedStock,
+    Long soldStock,
+    Long totalStock,
+    TimeDealStockStatus status,
+    LocalDateTime createdAt
+) {
+
+    public static CreateStockResult of(TimeDealStock stock, Long totalStock) {
+        return new CreateStockResult(
+            stock.getId(),
+            stock.getTimeDealProduct().getId(),
+            stock.getStockCounts().getAvailable(),
+            stock.getStockCounts().getReserved(),
+            stock.getStockCounts().getSold(),
+            totalStock,
+            stock.getStatus(),
+            stock.getCreatedAt()
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ReserveStockResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ReserveStockResult.java
@@ -1,0 +1,12 @@
+package com.rushcrew.timedeal.application.result;
+
+public record ReserveStockResult(
+    Boolean success,
+    Integer availableStock,
+    String message
+) {
+
+    public static ReserveStockResult of(Long available, String message) {
+        return new ReserveStockResult(true, available.intValue(), message);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/StockResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/StockResult.java
@@ -1,0 +1,17 @@
+package com.rushcrew.timedeal.application.result;
+
+import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StockResult(
+    UUID stockId,
+    UUID productId,
+    Long availableStock,
+    Long reservedStock,
+    Long soldStock,
+    TimeDealProductStatus status,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/UpdateStockCountResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/UpdateStockCountResult.java
@@ -1,0 +1,28 @@
+package com.rushcrew.timedeal.application.result;
+
+import java.util.UUID;
+
+public record UpdateStockCountResult(
+    UUID stockId,
+    UUID productId,
+    Long previousStock,
+    Long currentStock,
+    Long changedQuantity
+) {
+
+    public static UpdateStockCountResult of(
+        UUID stockId,
+        UUID productId,
+        Long previousStock,
+        Long currentStock,
+        Long changedQuantity
+    ) {
+        return new UpdateStockCountResult(
+            stockId,
+            productId,
+            previousStock,
+            currentStock,
+            changedQuantity
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -1,10 +1,14 @@
 package com.rushcrew.timedeal.application.service;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
+import java.util.UUID;
 
 public interface StockService {
 
     CreateStockResult createStock(CreateStockCommand command);
 
+    UpdateStockCountResult changeStockCount(UUID stockId, UpdateStockCountCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -20,4 +20,6 @@ public interface StockService {
 
     Page<StockResult> getStocks(
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
+
+    StockResult getStock(UUID stockId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -3,6 +3,7 @@ package com.rushcrew.timedeal.application.service;
 import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
@@ -30,4 +31,6 @@ public interface StockService {
     ReserveStockResult reserveStock(ReserveStockCommand command);
 
     ConfirmStockResult confirmStock(ConfirmStockCommand command);
+
+    void restoreStock(RestoreStockCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.service;
+
+import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.result.CreateStockResult;
+
+public interface StockService {
+
+    CreateStockResult createStock(CreateStockCommand command);
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -1,8 +1,10 @@
 package com.rushcrew.timedeal.application.service;
 
+import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
@@ -26,4 +28,6 @@ public interface StockService {
     StockResult getStock(UUID stockId);
 
     ReserveStockResult reserveStock(ReserveStockCommand command);
+
+    ConfirmStockResult confirmStock(ConfirmStockCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -3,8 +3,12 @@ package com.rushcrew.timedeal.application.service;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface StockService {
 
@@ -13,4 +17,7 @@ public interface StockService {
     UpdateStockCountResult changeStockCount(UUID stockId, UpdateStockCountCommand command);
 
     void deleteStock(UUID stockId);
+
+    Page<StockResult> getStocks(
+        String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -11,4 +11,6 @@ public interface StockService {
     CreateStockResult createStock(CreateStockCommand command);
 
     UpdateStockCountResult changeStockCount(UUID stockId, UpdateStockCountCommand command);
+
+    void deleteStock(UUID stockId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -1,8 +1,10 @@
 package com.rushcrew.timedeal.application.service;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
@@ -22,4 +24,6 @@ public interface StockService {
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
 
     StockResult getStock(UUID stockId);
+
+    ReserveStockResult reserveStock(ReserveStockCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -4,8 +4,13 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.application.event.StockChangedEvent;
+import com.rushcrew.timedeal.application.event.StockCreatedEvent;
+import com.rushcrew.timedeal.application.event.StockDeletedEvent;
 import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.application.event.StockRestoredEvent;
 import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
@@ -16,9 +21,9 @@ import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
-import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
+import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
@@ -42,7 +47,6 @@ public class StockServiceImpl implements StockService {
 
     private final TimeDealRepository timeDealRepository;
     private final StockRepository stockRepository;
-    private final StockCache stockCache;
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
@@ -56,7 +60,8 @@ public class StockServiceImpl implements StockService {
 
         TimeDealStock newStock = TimeDealStock.create(command, timeDealProduct);
         stockRepository.save(newStock);
-        stockCache.register(newStock.getId(), command.totalStock());
+
+        eventPublisher.publishEvent(new StockCreatedEvent(newStock.getId(), command.totalStock()));
 
         return CreateStockResult.of(newStock, command.totalStock());
     }
@@ -73,7 +78,8 @@ public class StockServiceImpl implements StockService {
         validQuantity(stock, quantity);
 
         stock.changeAvailable(quantity, command.reason());
-        stockCache.changeCount(stockId, quantity);
+
+        eventPublisher.publishEvent(new StockChangedEvent(stockId, quantity));
 
         return UpdateStockCountResult.of(
             stock.getId(), stock.getTimeDealProduct().getId(),
@@ -105,7 +111,8 @@ public class StockServiceImpl implements StockService {
 
         // TODO: 추후에 사용자 정보 가지고 오면 주석처리 풀 예정
 //        stock.delete(userId);
-        stockCache.evict(stockId);
+
+        eventPublisher.publishEvent(new StockDeletedEvent(stockId));
     }
 
     @Override
@@ -142,6 +149,29 @@ public class StockServiceImpl implements StockService {
         stock.confirm(OrderId.of(orderId), command.quantity());
 
         return ConfirmStockResult.of(orderId);
+    }
+
+    @Override
+    @Transactional
+    public void restoreStock(RestoreStockCommand command) {
+        // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
+
+        UUID orderId = command.orderId().getOrderId();
+        TimeDealStock stock = getStockOrThrow(command.stockId());
+        StockLog log = getLastLogOrThrow(command.stockId(), orderId);
+        validateOrderQuantity(log, command.quantity());
+
+        if (log.getEventType() == EventType.RESERVE) {
+            stock.restoreFromReserved(OrderId.of(orderId), command.quantity(), command.reason());
+        } else if (log.getEventType() == EventType.SELL) {
+            stock.restoreFromSold(OrderId.of(orderId), command.quantity(), command.reason());
+        } else {
+            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_STATE);
+        }
+
+        eventPublisher.publishEvent(
+            new StockRestoredEvent(command.stockId(), command.quantity().getQuantity())
+        );
     }
 
     // ------------------------------------------------------------------------------------

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -1,0 +1,41 @@
+package com.rushcrew.timedeal.application.service.impl;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
+import com.rushcrew.timedeal.domain.port.StockCache;
+import com.rushcrew.timedeal.domain.repository.StockRepository;
+import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockServiceImpl implements StockService {
+
+    private final TimeDealRepository timeDealRepository;
+    private final StockRepository stockRepository;
+    private final StockCache stockCache;
+
+    @Override
+    @Transactional
+    public CreateStockResult createStock(CreateStockCommand command) {
+        // TODO: 요청한 사용자가 MASTER 권한 가지고 있는지 체크
+
+        TimeDealProduct timeDealProduct =
+            timeDealRepository.findProductByProductId(command.productId())
+                .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_PRODUCT));
+
+        TimeDealStock newStock = TimeDealStock.create(command, timeDealProduct);
+        stockRepository.save(newStock);
+        stockCache.register(newStock.getId(), command.totalStock());
+
+        return CreateStockResult.of(newStock, command.totalStock());
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -63,6 +63,18 @@ public class StockServiceImpl implements StockService {
         );
     }
 
+    @Override
+    @Transactional
+    public void deleteStock(UUID stockId) {
+        // TODO: 요청한 사용자가 MASTER 권한 가지고 있는지 체크
+
+        TimeDealStock stock = getStockOrThrow(stockId);
+
+        // TODO: 추후에 사용자 정보 가지고 오면 주석처리 풀 예정
+//        stock.delete(userId);
+        stockCache.evict(stockId);
+    }
+
     // ------------------------------------------------------------------------------------
 
     private TimeDealStock getStockOrThrow(UUID stockId) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -2,7 +2,9 @@ package com.rushcrew.timedeal.application.service.impl;
 
 import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
@@ -10,6 +12,8 @@ import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
+import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,5 +41,45 @@ public class StockServiceImpl implements StockService {
         stockCache.register(newStock.getId(), command.totalStock());
 
         return CreateStockResult.of(newStock, command.totalStock());
+    }
+
+    @Override
+    @Transactional
+    public UpdateStockCountResult changeStockCount(UUID stockId, UpdateStockCountCommand command) {
+        // TODO: 요청한 사용자가 MASTER 권한 가지고 있는지 체크
+
+        TimeDealStock stock = getStockOrThrow(stockId);
+        Long previousStock = stock.getStockCounts().getAvailable();
+
+        Long quantity = command.quantity().getQuantity();
+        validQuantity(stock, quantity);
+
+        stock.changeAvailable(quantity, command.reason());
+        stockCache.changeCount(stockId, quantity);
+
+        return UpdateStockCountResult.of(
+            stock.getId(), stock.getTimeDealProduct().getId(),
+            previousStock, stock.getStockCounts().getAvailable(), quantity
+        );
+    }
+
+    // ------------------------------------------------------------------------------------
+
+    private TimeDealStock getStockOrThrow(UUID stockId) {
+        return stockRepository.findNotDeletedById(stockId)
+            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_STOCK));
+    }
+
+    private void validQuantity(TimeDealStock stock, Long quantity) {
+        // 변화할 재고 수량이 음수일 때, 품절인지 아닌지 체크
+        if (quantity < 0 &&
+            TimeDealProductStatus.OUT_OF_STOCK.equals(stock.getTimeDealProduct().getStatus())) {
+            throw new BusinessException(TimeDealErrorCode.CAN_NOT_DECREASE_STOCK);
+        }
+
+        // 남은 재고 수량이 감소할 수량보다 적은지 체크
+        if (stock.getStockCounts().getAvailable() + quantity < 0) {
+            throw new BusinessException(TimeDealErrorCode.CAN_NOT_DECREASE_BELOW_ZERO);
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -4,6 +4,7 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
@@ -13,8 +14,11 @@ import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,6 +65,15 @@ public class StockServiceImpl implements StockService {
             stock.getId(), stock.getTimeDealProduct().getId(),
             previousStock, stock.getStockCounts().getAvailable(), quantity
         );
+    }
+
+    @Override
+    public Page<StockResult> getStocks(
+        String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable
+    ) {
+        // TODO: 요청한 사용자가 MASTER 권한 가지고 있는지 체크
+        String pattern = (keyword == null || keyword.isBlank()) ? null : "%" + keyword + "%";
+        return stockRepository.findStockResults(pattern, productId, status, pageable);
     }
 
     @Override

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -4,6 +4,7 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.application.event.StockReservedEvent;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
@@ -19,6 +20,7 @@ import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -32,6 +34,7 @@ public class StockServiceImpl implements StockService {
     private final TimeDealRepository timeDealRepository;
     private final StockRepository stockRepository;
     private final StockCache stockCache;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -104,7 +107,9 @@ public class StockServiceImpl implements StockService {
         TimeDealStock stock = getStockOrThrow(command.stockId());
 
         stock.reserve(command.quantity(), command.orderId());
-        stockCache.reserve(command.stockId(), command.quantity().getQuantity());
+        eventPublisher.publishEvent(
+            new StockReservedEvent(command.stockId(), command.quantity().getQuantity())
+        );
 
         return ReserveStockResult
             .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -23,7 +23,6 @@ import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
-import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
@@ -161,13 +160,8 @@ public class StockServiceImpl implements StockService {
         StockLog log = getLastLogOrThrow(command.stockId(), orderId);
         validateOrderQuantity(log, command.quantity());
 
-        if (log.getEventType() == EventType.RESERVE) {
-            stock.restoreFromReserved(OrderId.of(orderId), command.quantity(), command.reason());
-        } else if (log.getEventType() == EventType.SELL) {
-            stock.restoreFromSold(OrderId.of(orderId), command.quantity(), command.reason());
-        } else {
-            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_STATE);
-        }
+        log.getEventType().applyRestore(
+            stock, OrderId.of(orderId), command.quantity(), command.reason());
 
         eventPublisher.publishEvent(
             new StockRestoredEvent(command.stockId(), command.quantity().getQuantity())

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -23,6 +23,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,6 +104,11 @@ public class StockServiceImpl implements StockService {
 
     @Override
     @Transactional
+    @Retryable(
+        retryFor = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 5,
+        backoff = @Backoff(delay = 5, maxDelay = 20, multiplier = 2)
+    )
     public ReserveStockResult reserveStock(ReserveStockCommand command) {
         // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
 

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -1,23 +1,29 @@
 package com.rushcrew.timedeal.application.service.impl;
 
 import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -123,11 +129,37 @@ public class StockServiceImpl implements StockService {
             .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");
     }
 
+    @Override
+    @Transactional
+    public ConfirmStockResult confirmStock(ConfirmStockCommand command) {
+        // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
+
+        UUID orderId = command.orderId().getOrderId();
+        TimeDealStock stock = getStockOrThrow(command.stockId());
+        StockLog log = getLastLogOrThrow(command.stockId(), orderId);
+        validateOrderQuantity(log, command.quantity());
+
+        stock.confirm(OrderId.of(orderId), command.quantity());
+
+        return ConfirmStockResult.of(orderId);
+    }
+
     // ------------------------------------------------------------------------------------
 
     private TimeDealStock getStockOrThrow(UUID stockId) {
         return stockRepository.findNotDeletedById(stockId)
             .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_STOCK));
+    }
+
+    private StockLog getLastLogOrThrow(UUID stockId, UUID orderId) {
+        return stockRepository.findLastByStockIdAndOrderId(stockId, orderId)
+            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_ORDER));
+    }
+
+    private void validateOrderQuantity(StockLog log, Quantity quantity) {
+        if (!Objects.equals(log.getQuantity().getQuantity(), quantity.getQuantity())) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
+        }
     }
 
     private void validQuantity(TimeDealStock stock, Long quantity) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -77,6 +77,12 @@ public class StockServiceImpl implements StockService {
     }
 
     @Override
+    public StockResult getStock(UUID stockId) {
+        // TODO: 요청한 사용자가 MASTER or SELLER 권한 가지고 있는지 체크
+        return stockRepository.findStockResultById(stockId);
+    }
+
+    @Override
     @Transactional
     public void deleteStock(UUID stockId) {
         // TODO: 요청한 사용자가 MASTER 권한 가지고 있는지 체크

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -20,10 +20,8 @@ import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
 import com.rushcrew.timedeal.domain.vo.OrderId;
-import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -137,7 +135,9 @@ public class StockServiceImpl implements StockService {
         UUID orderId = command.orderId().getOrderId();
         TimeDealStock stock = getStockOrThrow(command.stockId());
         StockLog log = getLastLogOrThrow(command.stockId(), orderId);
-        validateOrderQuantity(log, command.quantity());
+
+        // 주문 당시 기록된 수량과 현재 처리하려는 수량이 동일한지 검증
+        log.validateOrderQuantity(command.quantity());
 
         stock.confirm(OrderId.of(orderId), command.quantity());
 
@@ -154,12 +154,6 @@ public class StockServiceImpl implements StockService {
     private StockLog getLastLogOrThrow(UUID stockId, UUID orderId) {
         return stockRepository.findLastByStockIdAndOrderId(stockId, orderId)
             .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_ORDER));
-    }
-
-    private void validateOrderQuantity(StockLog log, Quantity quantity) {
-        if (!Objects.equals(log.getQuantity().getQuantity(), quantity.getQuantity())) {
-            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
-        }
     }
 
     private void validQuantity(TimeDealStock stock, Long quantity) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -2,8 +2,10 @@ package com.rushcrew.timedeal.application.service.impl;
 
 import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
@@ -92,6 +94,20 @@ public class StockServiceImpl implements StockService {
         // TODO: 추후에 사용자 정보 가지고 오면 주석처리 풀 예정
 //        stock.delete(userId);
         stockCache.evict(stockId);
+    }
+
+    @Override
+    @Transactional
+    public ReserveStockResult reserveStock(ReserveStockCommand command) {
+        // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
+
+        TimeDealStock stock = getStockOrThrow(command.stockId());
+
+        stock.reserve(command.quantity(), command.orderId());
+        stockCache.reserve(command.stockId(), command.quantity().getQuantity());
+
+        return ReserveStockResult
+            .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");
     }
 
     // ------------------------------------------------------------------------------------

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -54,4 +54,12 @@ public class StockLog extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String description;
+
+    public static StockLog init(TimeDealStock timeDealStock, Long quantity) {
+        return StockLog.builder()
+            .timeDealStock(timeDealStock)
+            .eventType(EventType.INIT)
+            .quantity(Quantity.of(quantity))
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -83,4 +83,16 @@ public class StockLog extends BaseEntity {
             .quantity(quantity)
             .build();
     }
+
+    public static StockLog confirm(
+        TimeDealStock stock, OrderId orderId, Quantity quantity
+    ) {
+        return StockLog.builder()
+            .timeDealStock(stock)
+            .orderId(orderId)
+            .eventType(EventType.SELL)
+            .description("결제")
+            .quantity(quantity)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -62,4 +62,15 @@ public class StockLog extends BaseEntity {
             .quantity(Quantity.of(quantity))
             .build();
     }
+
+    public static StockLog addLog(
+        TimeDealStock timeDealStock, EventType eventType, Long quantity, String description
+    ) {
+        return com.rushcrew.timedeal.domain.entity.StockLog.builder()
+            .timeDealStock(timeDealStock)
+            .eventType(eventType)
+            .quantity(Quantity.of(quantity))
+            .description(description)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -73,4 +73,14 @@ public class StockLog extends BaseEntity {
             .description(description)
             .build();
     }
+
+    public static StockLog reserve(TimeDealStock stock, OrderId orderId, Quantity quantity) {
+        return StockLog.builder()
+            .timeDealStock(stock)
+            .orderId(orderId)
+            .eventType(EventType.RESERVE)
+            .description("주문")
+            .quantity(quantity)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -1,6 +1,8 @@
 package com.rushcrew.timedeal.domain.entity;
 
 import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
@@ -17,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -94,5 +97,11 @@ public class StockLog extends BaseEntity {
             .description("결제")
             .quantity(quantity)
             .build();
+    }
+
+    public void validateOrderQuantity(Quantity quantity) {
+        if (!Objects.equals(this.getQuantity().getQuantity(), quantity.getQuantity())) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -66,7 +66,7 @@ public class StockLog extends BaseEntity {
     public static StockLog addLog(
         TimeDealStock timeDealStock, EventType eventType, Long quantity, String description
     ) {
-        return com.rushcrew.timedeal.domain.entity.StockLog.builder()
+        return StockLog.builder()
             .timeDealStock(timeDealStock)
             .eventType(eventType)
             .quantity(Quantity.of(quantity))

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -95,4 +95,17 @@ public class StockLog extends BaseEntity {
             .quantity(quantity)
             .build();
     }
+
+    public static StockLog restore(
+        TimeDealStock stock, OrderId orderId, Quantity quantity, EventType eventType,
+        String description
+    ) {
+        return StockLog.builder()
+            .timeDealStock(stock)
+            .orderId(orderId)
+            .eventType(eventType)
+            .description(description)
+            .quantity(quantity)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
@@ -118,6 +118,17 @@ public class TimeDeal extends BaseEntity {
         this.status = TimeDealStatus.ENDED;
     }
 
+    public void updateStatusByPeriod(Instant now) {
+        Instant start = this.period.getStartAt();
+        Instant end = this.period.getEndAt();
+
+        if (now.isAfter(end)) { // 종료 후
+            this.status = TimeDealStatus.ENDED;
+        } else if (!now.isBefore(start) && !now.isAfter(end)) { // 진행중
+            this.status = TimeDealStatus.IN_PROGRESS;
+        }
+    }
+
     private void addTimeDealProduct(UUID productId, UUID optionId) {
         this.timeDealProducts.add(TimeDealProduct.create(
             this, ProductItemIds.of(productId, optionId)
@@ -138,6 +149,10 @@ public class TimeDeal extends BaseEntity {
     private void updatePeriod(Instant newStartAt, Instant newEndAt) {
         if (newStartAt == null && newEndAt == null) {
             return;
+        }
+
+        if (!this.status.equals(TimeDealStatus.SCHEDULED)) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_UPDATE_NOT_ALLOWED);
         }
 
         Instant updatedStartAt = newStartAt != null ? newStartAt : this.getPeriod().getStartAt();

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
@@ -99,6 +99,10 @@ public class TimeDeal extends BaseEntity {
         return timeDeal;
     }
 
+    public void updateStatus(TimeDealStatus timeDealStatus) {
+        this.status = timeDealStatus;
+    }
+
     public void update(UpdateTimeDealParams params) {
         updateTimeDealInfo(params.title(), params.description());
         this.price = params.discountPrice() != null ? Price.of(params.discountPrice()) : this.price;

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealProduct.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealProduct.java
@@ -61,4 +61,8 @@ public class TimeDealProduct extends BaseEntity {
             .status(TimeDealProductStatus.OUT_OF_STOCK)
             .build();
     }
+
+    public void updateStatus(TimeDealProductStatus timeDealProductStatus) {
+        this.status = timeDealProductStatus;
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -159,4 +159,15 @@ public class TimeDealStock extends BaseEntity {
         );
         this.stockLogs.add(log);
     }
+
+    public void confirm(OrderId orderId, Quantity quantity) {
+        this.stockCounts = this.stockCounts.confirm(quantity);
+
+        if (this.stockCounts.getAvailable() == 0 && this.stockCounts.getReserved() == 0) {
+            this.status = TimeDealStockStatus.SOLD;
+        }
+
+        StockLog log = StockLog.confirm(this, orderId, quantity);
+        this.stockLogs.add(log);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -1,7 +1,9 @@
 package com.rushcrew.timedeal.domain.entity;
 
 import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.ProductItemIds;
 import com.rushcrew.timedeal.domain.vo.StockCounts;
@@ -113,6 +115,26 @@ public class TimeDealStock extends BaseEntity {
         }
 
         StockLog log = StockLog.addLog(this, EventType.ADMIN_CONTROL, quantity, reason);
+        this.stockLogs.add(log);
+    }
+
+    public void delete(Long userId) {
+        if (this.stockCounts.getReserved() > 0) {
+            throw new BusinessException(TimeDealErrorCode.CAN_NOT_DELETE_STOCK);
+        }
+
+        Long beforeAvailable = this.stockCounts.getAvailable();
+
+        this.status = TimeDealStockStatus.PAUSED;
+        this.stockCounts =
+            StockCounts.of(0L, this.stockCounts.getReserved(), this.stockCounts.getSold());
+        this.softDelete(userId);
+        this.getTimeDealProduct().updateStatus(TimeDealProductStatus.OUT_OF_STOCK);
+
+        StockLog log = StockLog.addLog(
+            this, EventType.ADMIN_CONTROL, beforeAvailable,
+            "재고 삭제 전 남은 재고 처리 (" + beforeAvailable + " -> 0)"
+        );
         this.stockLogs.add(log);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -1,8 +1,10 @@
 package com.rushcrew.timedeal.domain.entity;
 
 import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.domain.vo.ProductItemIds;
 import com.rushcrew.timedeal.domain.vo.StockCounts;
+import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -74,4 +76,23 @@ public class TimeDealStock extends BaseEntity {
     @OneToMany(mappedBy = "timeDealStock", fetch = FetchType.LAZY)
     @Builder.Default
     private List<StockLog> stockLogs = new ArrayList<>();
+
+    public static TimeDealStock create(CreateStockCommand command,
+        TimeDealProduct timeDealProduct) {
+        TimeDealStock stock = TimeDealStock.builder()
+            .timeDealProduct(timeDealProduct)
+            .timeDealId(timeDealProduct.getTimeDeal().getId())
+            .itemIds(
+                ProductItemIds.of(command.productId(), timeDealProduct.getItemIds().getOptionId()))
+            .stockCounts(StockCounts.init(command.totalStock()))
+            .status(TimeDealStockStatus.AVAILABLE)
+            .build();
+
+        timeDealProduct.updateStatus(TimeDealProductStatus.IN_STOCK);
+
+        StockLog log = StockLog.init(stock, command.totalStock());
+        stock.stockLogs.add(log);
+
+        return stock;
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -5,9 +5,12 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.vo.EventType;
+import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.ProductItemIds;
+import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.StockCounts;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
+import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -134,6 +137,25 @@ public class TimeDealStock extends BaseEntity {
         StockLog log = StockLog.addLog(
             this, EventType.ADMIN_CONTROL, beforeAvailable,
             "재고 삭제 전 남은 재고 처리 (" + beforeAvailable + " -> 0)"
+        );
+        this.stockLogs.add(log);
+    }
+
+    public void reserve(Quantity quantity, OrderId orderId) {
+        if (this.stockCounts.getAvailable() < quantity.getQuantity()) {
+            throw new BusinessException(TimeDealErrorCode.OUT_OF_STOCK);
+        }
+
+        this.stockCounts = this.stockCounts.reserve(quantity);
+
+        if (this.stockCounts.getAvailable() == 0) {
+            this.timeDealProduct.getTimeDeal().updateStatus(TimeDealStatus.SOLD_OUT);
+            this.status = TimeDealStockStatus.RESERVED;
+            this.timeDealProduct.updateStatus(TimeDealProductStatus.OUT_OF_STOCK);
+        }
+
+        StockLog log = StockLog.reserve(
+            this, orderId, quantity
         );
         this.stockLogs.add(log);
     }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -28,6 +28,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -169,5 +170,27 @@ public class TimeDealStock extends BaseEntity {
 
         StockLog log = StockLog.confirm(this, orderId, quantity);
         this.stockLogs.add(log);
+    }
+
+    public void restoreFromReserved(OrderId orderId, Quantity quantity, String reason) {
+        this.stockCounts = this.stockCounts.restoreFromReserved(quantity);
+        updateStatus();
+
+        StockLog log = StockLog.restore(this, orderId, quantity, EventType.RESERVE_CANCEL, reason);
+        this.stockLogs.add(log);
+    }
+
+    public void restoreFromSold(OrderId orderId, Quantity quantity, String reason) {
+        this.stockCounts = this.stockCounts.restoreFromSold(quantity);
+        updateStatus();
+
+        StockLog log = StockLog.restore(this, orderId, quantity, EventType.PAYMENT_CANCEL, reason);
+        this.stockLogs.add(log);
+    }
+
+    private void updateStatus() {
+        this.status = TimeDealStockStatus.AVAILABLE;
+        this.timeDealProduct.updateStatus(TimeDealProductStatus.IN_STOCK);
+        this.timeDealProduct.getTimeDeal().updateStatusByPeriod(Instant.now());
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -2,6 +2,7 @@ package com.rushcrew.timedeal.domain.entity;
 
 import com.rushcrew.common.entity.BaseEntity;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.ProductItemIds;
 import com.rushcrew.timedeal.domain.vo.StockCounts;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
@@ -94,5 +95,24 @@ public class TimeDealStock extends BaseEntity {
         stock.stockLogs.add(log);
 
         return stock;
+    }
+
+    public void changeAvailable(Long quantity, String reason) {
+        long newAvailable = this.stockCounts.getAvailable() + quantity;
+
+        this.stockCounts = StockCounts.of(
+            newAvailable,
+            this.stockCounts.getReserved(),
+            this.stockCounts.getSold()
+        );
+
+        if (newAvailable > 0) {
+            this.timeDealProduct.updateStatus(TimeDealProductStatus.IN_STOCK);
+        } else {
+            this.timeDealProduct.updateStatus(TimeDealProductStatus.OUT_OF_STOCK);
+        }
+
+        StockLog log = StockLog.addLog(this, EventType.ADMIN_CONTROL, quantity, reason);
+        this.stockLogs.add(log);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/exception/TimeDealErrorCode.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/exception/TimeDealErrorCode.java
@@ -23,6 +23,16 @@ public enum TimeDealErrorCode implements ErrorCode {
     MUST_BE_CHEAPER(HttpStatus.BAD_REQUEST, "TD-012", "타임딜 할인가격은 기존 가격보다 낮아야 합니다."),
     NOT_FOUND_TIME_DEAL(HttpStatus.NOT_FOUND, "TD-013", "존재하지 않는 타임딜입니다."),
     ALREADY_ENDED(HttpStatus.CONFLICT, "TD-014", "이미 종료된 타임딜입니다."),
+    TIME_DEAL_UPDATE_NOT_ALLOWED(HttpStatus.CONFLICT, "TD-015",
+        "타임딜 정보 수정은 SCHEDULED 상태에서만 가능합니다."),
+    NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "TD-016", "존재하지 않는 타임딜 재고입니다."),
+    CAN_NOT_DECREASE_STOCK(HttpStatus.BAD_REQUEST, "TD-017", "품절 상태의 재고는 감소시킬 수 없습니다."),
+    CAN_NOT_DECREASE_BELOW_ZERO(HttpStatus.BAD_REQUEST, "TD-018", "남은 재고보다 더 많이 감소시킬 수 없습니다."),
+    CAN_NOT_DELETE_STOCK(HttpStatus.BAD_REQUEST, "TD-019", "예약된 재고가 있어 삭제할 수 없습니다."),
+    OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "TD-020", "재고가 부족합니다."),
+    NOT_FOUND_LOG(HttpStatus.NOT_FOUND, "TD-021", "존재하지 않는 재고 로그입니다."),
+    INVALID_ORDER_INFO(HttpStatus.BAD_REQUEST, "TD-022", "주문 정보와 일치하지 않습니다."),
+    INVALID_ORDER_STATE(HttpStatus.BAD_REQUEST, "TD-023", "복구 불가능한 주문 상태입니다."),
 
     ;
 

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -12,4 +12,11 @@ public interface StockCache {
      */
     void register(UUID stockId, Long available);
 
+    /**
+     * Redis에 캐시된 타임딜 재고 정보 수량 증가/감소
+     *
+     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
+     * @param quantity : 증가/감소할 재고 수량
+     */
+    void changeCount(UUID stockId, Long quantity);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -1,0 +1,15 @@
+package com.rushcrew.timedeal.domain.port;
+
+import java.util.UUID;
+
+public interface StockCache {
+
+    /**
+     * Redis에 타임딜 재고 id, 구매가능한 quantity 캐시
+     *
+     * @param stockId   : Redis key에 사용되는 타임딜 재고 ID
+     * @param available : 구매 가능한 재고 수량
+     */
+    void register(UUID stockId, Long available);
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -26,4 +26,12 @@ public interface StockCache {
      * @param stockId : Redis key에 사용되는 타임딜 재고 ID
      */
     void evict(UUID stockId);
+
+    /**
+     * Redis에 캐시된 재고 수량 차감
+     *
+     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
+     * @param quantity : value에서 차감할 재고 수량 (예약된 재고 수량)
+     */
+    void reserve(UUID stockId, Long quantity);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -34,4 +34,12 @@ public interface StockCache {
      * @param quantity : value에서 차감할 재고 수량 (예약된 재고 수량)
      */
     void reserve(UUID stockId, Long quantity);
+
+    /**
+     * Redis에 캐시된 재고 수량 복구(증가)
+     *
+     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
+     * @param quantity : value에서 증가할 재고 수량 (복구된 재고 수량)
+     */
+    void restore(UUID stockId, Long quantity);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -19,4 +19,11 @@ public interface StockCache {
      * @param quantity : 증가/감소할 재고 수량
      */
     void changeCount(UUID stockId, Long quantity);
+
+    /**
+     * Redis에 캐시된 타임딜 재고 정보 삭제(무효화)
+     *
+     * @param stockId : Redis key에 사용되는 타임딜 재고 ID
+     */
+    void evict(UUID stockId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.domain.repository;
 
 import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
@@ -18,4 +19,6 @@ public interface StockRepository {
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
 
     StockResult findStockResultById(UUID stockId);
+
+    Optional<StockLog> findLastByStockIdAndOrderId(UUID stockId, UUID orderId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
@@ -17,4 +17,5 @@ public interface StockRepository {
     Page<StockResult> findStockResults(
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
 
+    StockResult findStockResultById(UUID stockId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
@@ -1,0 +1,8 @@
+package com.rushcrew.timedeal.domain.repository;
+
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+
+public interface StockRepository {
+
+    void save(TimeDealStock newStock);
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
@@ -1,8 +1,12 @@
 package com.rushcrew.timedeal.domain.repository;
 
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface StockRepository {
 
     void save(TimeDealStock newStock);
+
+    Optional<TimeDealStock> findNotDeletedById(UUID stockId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
@@ -1,12 +1,20 @@
 package com.rushcrew.timedeal.domain.repository;
 
+import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface StockRepository {
 
     void save(TimeDealStock newStock);
 
     Optional<TimeDealStock> findNotDeletedById(UUID stockId);
+
+    Page<StockResult> findStockResults(
+        String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
+
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/TimeDealRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/TimeDealRepository.java
@@ -2,6 +2,7 @@ package com.rushcrew.timedeal.domain.repository;
 
 import com.rushcrew.timedeal.application.result.TimeDealResult;
 import com.rushcrew.timedeal.domain.entity.TimeDeal;
+import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface TimeDealRepository {
     Page<TimeDealResult> findNotEndedByStatus(TimeDealStatus status, Pageable pageable);
 
     Optional<TimeDeal> findByIdAndStatusNot(UUID timeDealId, TimeDealStatus timeDealStatus);
+
+    Optional<TimeDealProduct> findProductByProductId(UUID productId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/EventType.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/EventType.java
@@ -1,17 +1,50 @@
 package com.rushcrew.timedeal.domain.vo;
 
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
+
 public enum EventType {
+    RESERVE("재고 예약") {
+        @Override
+        public void applyRestore(
+            TimeDealStock stock,
+            OrderId orderId,
+            Quantity quantity,
+            String reason
+        ) {
+            stock.restoreFromReserved(orderId, quantity, reason);
+        }
+    },
+    SELL("판매 확정") {
+        @Override
+        public void applyRestore(
+            TimeDealStock stock,
+            OrderId orderId,
+            Quantity quantity,
+            String reason
+        ) {
+            stock.restoreFromSold(orderId, quantity, reason);
+        }
+    },
     INIT("초기 재고 설정"),
-    RESERVE("재고 예약"),
-    RESERVE_CANCEL("예약 취소"), // 재고 복구
-    PAYMENT_CANCEL("결제 취소"), // 재고 복구
-    SELL("판매 확정"), // 재고 차감
+    RESERVE_CANCEL("예약 취소"),
+    PAYMENT_CANCEL("결제 취소"),
     ROLLBACK("트랜잭션 롤백"),
-    ADMIN_CONTROL("관리자 수동 조정"); // 임의로 재고 증가/감소
+    ADMIN_CONTROL("관리자 수동 조정");
 
     private final String description;
 
     EventType(String description) {
         this.description = description;
+    }
+
+    public void applyRestore(
+        TimeDealStock stock,
+        OrderId orderId,
+        Quantity quantity,
+        String reason
+    ) {
+        throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_STATE);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/Quantity.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/Quantity.java
@@ -17,13 +17,21 @@ public class Quantity {
     private Long quantity;
 
     private Quantity(Long quantity) {
-        if (quantity <= 0) {
+        if (quantity == 0) {
             throw new BusinessException(TimeDealErrorCode.INVALID_QUANTITY_RANGE);
         }
         this.quantity = quantity;
     }
 
     public static Quantity of(Long quantity) {
+        return new Quantity(quantity);
+    }
+
+    public static Quantity nonZero(Long quantity) {
+        return new Quantity(quantity);
+    }
+
+    public static Quantity positive(Long quantity) {
         return new Quantity(quantity);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
@@ -51,6 +51,22 @@ public class StockCounts {
         );
     }
 
+    public StockCounts restoreFromReserved(Quantity quantity) {
+        return StockCounts.of(
+            this.available + quantity.getQuantity(),
+            this.reserved - quantity.getQuantity(),
+            this.getSold()
+        );
+    }
+
+    public StockCounts restoreFromSold(Quantity quantity) {
+        return StockCounts.of(
+            this.available + quantity.getQuantity(),
+            this.getReserved(),
+            this.sold - quantity.getQuantity()
+        );
+    }
+
     private void validateNotNull(Long available, Long reserved, Long sold) {
         if (available == null || reserved == null || sold == null) {
             throw new BusinessException(TimeDealErrorCode.REQUIRED_STOCK_COUNT);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
@@ -35,6 +35,14 @@ public class StockCounts {
         return new StockCounts(available, 0L, 0L);
     }
 
+    public StockCounts reserve(Quantity quantity) {
+        return StockCounts.of(
+            this.available - quantity.getQuantity(),
+            this.reserved + quantity.getQuantity(),
+            this.getSold()
+        );
+    }
+
     private void validateNotNull(Long available, Long reserved, Long sold) {
         if (available == null || reserved == null || sold == null) {
             throw new BusinessException(TimeDealErrorCode.REQUIRED_STOCK_COUNT);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
@@ -43,6 +43,14 @@ public class StockCounts {
         );
     }
 
+    public StockCounts confirm(Quantity quantity) {
+        return StockCounts.of(
+            this.getAvailable(),
+            this.reserved - quantity.getQuantity(),
+            this.sold + quantity.getQuantity()
+        );
+    }
+
     private void validateNotNull(Long available, Long reserved, Long sold) {
         if (available == null || reserved == null || sold == null) {
             throw new BusinessException(TimeDealErrorCode.REQUIRED_STOCK_COUNT);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -1,0 +1,20 @@
+package com.rushcrew.timedeal.infrastructure.adapter;
+
+import com.rushcrew.timedeal.domain.port.StockCache;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisStockCache implements StockCache {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void register(UUID stockId, Long available) {
+        String key = "tds:" + stockId;
+        redisTemplate.opsForValue().set(key, String.valueOf(available));
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -17,4 +17,12 @@ public class RedisStockCache implements StockCache {
         String key = "tds:" + stockId;
         redisTemplate.opsForValue().set(key, String.valueOf(available));
     }
+
+    /**
+     * quantity가 양수면 증가, 음수면 감소
+     */
+    @Override
+    public void changeCount(UUID stockId, Long quantity) {
+        redisTemplate.opsForValue().increment("tds:" + stockId, quantity);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -30,4 +30,10 @@ public class RedisStockCache implements StockCache {
     public void evict(UUID stockId) {
         redisTemplate.delete("tds:" + stockId);
     }
+
+    @Override
+    public void reserve(UUID stockId, Long quantity) {
+        String key = "tds:" + stockId;
+        redisTemplate.opsForValue().decrement(key, quantity);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -25,4 +25,9 @@ public class RedisStockCache implements StockCache {
     public void changeCount(UUID stockId, Long quantity) {
         redisTemplate.opsForValue().increment("tds:" + stockId, quantity);
     }
+
+    @Override
+    public void evict(UUID stockId) {
+        redisTemplate.delete("tds:" + stockId);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -36,4 +36,10 @@ public class RedisStockCache implements StockCache {
         String key = "tds:" + stockId;
         redisTemplate.opsForValue().decrement(key, quantity);
     }
+
+    @Override
+    public void restore(UUID stockId, Long quantity) {
+        String key = "tds:" + stockId;
+        redisTemplate.opsForValue().increment(key, quantity);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/config/KafkaConsumerConfig.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,46 @@
+package com.rushcrew.timedeal.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        JsonDeserializer<Object> deserializer = new JsonDeserializer<>();
+        deserializer.addTrustedPackages("com.rushcrew.timedeal.infrastructure.kafka");
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "timedeal-stock");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        return new DefaultKafkaConsumerFactory<>(
+            props,
+            new StringDeserializer(),
+            deserializer
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
@@ -1,6 +1,10 @@
 package com.rushcrew.timedeal.infrastructure.event;
 
+import com.rushcrew.timedeal.application.event.StockChangedEvent;
+import com.rushcrew.timedeal.application.event.StockCreatedEvent;
+import com.rushcrew.timedeal.application.event.StockDeletedEvent;
 import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.application.event.StockRestoredEvent;
 import com.rushcrew.timedeal.domain.port.StockCache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +20,39 @@ public class StockEventHandler {
     private final StockCache stockCache;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockCreated(StockCreatedEvent event) {
+        try {
+            stockCache.register(event.stockId(), event.totalStock());
+        } catch (Exception e) {
+            log.error(
+                "StockCreatedEvent 처리 중 Redis 반영 실패. stock={}, totalStock={}",
+                event.stockId(), event.totalStock(), e
+            );
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockChanged(StockChangedEvent event) {
+        try {
+            stockCache.changeCount(event.stockId(), event.quantity());
+        } catch (Exception e) {
+            log.error(
+                "StockChangedEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
+                event.stockId(), event.quantity(), e
+            );
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockDeleted(StockDeletedEvent event) {
+        try {
+            stockCache.evict(event.stockId());
+        } catch (Exception e) {
+            log.error("StockDeletedEvent 처리 중 Redis 반영 실패. stock={}", event.stockId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockReserved(StockReservedEvent event) {
         try {
             stockCache.reserve(event.stockId(), event.quantity());
@@ -25,6 +62,17 @@ public class StockEventHandler {
                 event.stockId(), event.quantity(), e
             );
         }
+    }
 
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockRestored(StockRestoredEvent event) {
+        try {
+            stockCache.restore(event.stockId(), event.quantity());
+        } catch (Exception e) {
+            log.error(
+                "StockRestoredEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
+                event.stockId(), event.quantity(), e
+            );
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
@@ -1,0 +1,30 @@
+package com.rushcrew.timedeal.infrastructure.event;
+
+import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.domain.port.StockCache;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockEventHandler {
+
+    private final StockCache stockCache;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockReserved(StockReservedEvent event) {
+        try {
+            stockCache.reserve(event.stockId(), event.quantity());
+        } catch (Exception e) {
+            log.error(
+                "StockReservedEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
+                event.stockId(), event.quantity(), e
+            );
+        }
+
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
@@ -1,0 +1,29 @@
+package com.rushcrew.timedeal.infrastructure.kafka.consumer;
+
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import com.rushcrew.timedeal.infrastructure.kafka.dto.StockReserveEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockEventConsumer {
+
+    private final StockService stockService;
+
+    // 주문 생성 -> 재고 예약
+    @KafkaListener(topics = "order.created")
+    public void reserve(StockReserveEvent event) {
+        ReserveStockCommand command = new ReserveStockCommand(
+            OrderId.of(event.orderId()),
+            event.stockId(),
+            Quantity.positive(event.quantity()),
+            event.userId()
+        );
+        stockService.reserveStock(command);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
@@ -1,9 +1,11 @@
 package com.rushcrew.timedeal.infrastructure.kafka.consumer;
 
+import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
+import com.rushcrew.timedeal.infrastructure.kafka.dto.StockConfirmEvent;
 import com.rushcrew.timedeal.infrastructure.kafka.dto.StockReserveEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -25,5 +27,16 @@ public class StockEventConsumer {
             event.userId()
         );
         stockService.reserveStock(command);
+    }
+
+    // 결제 -> 재고 확정
+    @KafkaListener(topics = "payment.completed")
+    public void confirm(StockConfirmEvent event) {
+        ConfirmStockCommand command = new ConfirmStockCommand(
+            OrderId.of(event.orderId()),
+            event.stockId(),
+            Quantity.positive(event.quantity())
+        );
+        stockService.confirmStock(command);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
@@ -2,11 +2,13 @@ package com.rushcrew.timedeal.infrastructure.kafka.consumer;
 
 import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.infrastructure.kafka.dto.StockConfirmEvent;
 import com.rushcrew.timedeal.infrastructure.kafka.dto.StockReserveEvent;
+import com.rushcrew.timedeal.infrastructure.kafka.dto.StockRestoreEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -39,4 +41,17 @@ public class StockEventConsumer {
         );
         stockService.confirmStock(command);
     }
+
+    // 주문 취소 -> 재고 복구
+    @KafkaListener(topics = "order.cancelled")
+    public void restore(StockRestoreEvent event) {
+        RestoreStockCommand command = new RestoreStockCommand(
+            event.stockId(),
+            Quantity.positive(event.quantity()),
+            OrderId.of(event.orderId()),
+            event.reason()
+        );
+        stockService.restoreStock(command);
+    }
+
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockConfirmEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockConfirmEvent.java
@@ -1,0 +1,17 @@
+package com.rushcrew.timedeal.infrastructure.kafka.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record StockConfirmEvent(
+    @NotNull
+    UUID orderId,
+
+    @NotNull
+    UUID stockId,
+
+    @NotNull
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockReserveEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockReserveEvent.java
@@ -1,0 +1,20 @@
+package com.rushcrew.timedeal.infrastructure.kafka.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record StockReserveEvent(
+    @NotNull
+    UUID orderId,
+
+    @NotNull
+    UUID stockId,
+
+    @NotNull
+    Long quantity,
+
+    @NotNull
+    Long userId
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockRestoreEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockRestoreEvent.java
@@ -1,0 +1,21 @@
+package com.rushcrew.timedeal.infrastructure.kafka.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record StockRestoreEvent(
+    @NotNull
+    UUID stockId,
+
+    @NotNull
+    Long quantity,
+
+    @NotNull
+    UUID orderId,
+
+    @NotBlank
+    String reason
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
@@ -68,5 +69,18 @@ public interface StockJpaRepository extends JpaRepository<TimeDealStock, UUID> {
         """)
     StockResult findStockResultById(
         @Param("stockId") UUID stockId
+    );
+
+    @Query("""
+                SELECT sl
+                FROM StockLog sl
+                WHERE sl.timeDealStock.id = :stockId
+                  AND sl.orderId.orderId = :orderId
+                ORDER BY sl.createdAt DESC
+                FETCH FIRST 1 ROW ONLY
+        """)
+    Optional<StockLog> findLastByStockIdAndOrderId(
+        @Param("stockId") UUID stockId,
+        @Param("orderId") UUID orderId
     );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
@@ -49,4 +49,24 @@ public interface StockJpaRepository extends JpaRepository<TimeDealStock, UUID> {
         @Param("status") TimeDealStockStatus status,
         Pageable pageable
     );
+
+
+    @Query("""
+                  SELECT new com.rushcrew.timedeal.application.result.StockResult(
+                                  tds.id,
+                                  tdp.id,
+                                  tds.stockCounts.available,
+                                  tds.stockCounts.reserved,
+                                  tds.stockCounts.sold,
+                                  tdp.status,
+                                  tds.updatedAt
+                             )
+                  FROM TimeDealStock tds
+                  JOIN tds.timeDealProduct tdp
+                  WHERE tds.id = :stockId
+                    AND tds.deletedAt IS NULL
+        """)
+    StockResult findStockResultById(
+        @Param("stockId") UUID stockId
+    );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
@@ -1,11 +1,23 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StockJpaRepository extends JpaRepository<TimeDealStock, UUID> {
 
+    @Query("""
+                  SELECT tds
+                  FROM TimeDealStock tds
+                  WHERE tds.id = :stockId
+                    AND tds.deletedAt IS NULL
+        """)
+    Optional<TimeDealStock> findNotDeletedById(
+        @Param("stockId") UUID stockId
+    );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
@@ -1,8 +1,12 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
+import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,5 +23,30 @@ public interface StockJpaRepository extends JpaRepository<TimeDealStock, UUID> {
         """)
     Optional<TimeDealStock> findNotDeletedById(
         @Param("stockId") UUID stockId
+    );
+
+    @Query("""
+                  SELECT new com.rushcrew.timedeal.application.result.StockResult(
+                                  tds.id,
+                                  tdp.id,
+                                  tds.stockCounts.available,
+                                  tds.stockCounts.reserved,
+                                  tds.stockCounts.sold,
+                                  tdp.status,
+                                  tds.updatedAt
+                             )
+                  FROM TimeDealStock tds
+                  JOIN tds.timeDealProduct tdp
+                  JOIN tdp.timeDeal td
+                  WHERE (:keyword IS NULL OR CAST(td.timeDealInfo.title AS STRING) LIKE :keyword)
+                    AND (:productId IS NULL OR tdp.id = :productId)
+                    AND (:status IS NULL OR tds.status = :status)
+                    AND tds.deletedAt IS NULL
+        """)
+    Page<StockResult> findStockResults(
+        @Param("keyword") String keyword,
+        @Param("productId") UUID productId,
+        @Param("status") TimeDealStockStatus status,
+        Pageable pageable
     );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
@@ -1,0 +1,11 @@
+package com.rushcrew.timedeal.infrastructure.repository;
+
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StockJpaRepository extends JpaRepository<TimeDealStock, UUID> {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
@@ -2,6 +2,8 @@ package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,5 +16,10 @@ public class StockRepositoryAdapter implements StockRepository {
     @Override
     public void save(TimeDealStock newStock) {
         stockJpaRepository.save(newStock);
+    }
+
+    @Override
+    public Optional<TimeDealStock> findNotDeletedById(UUID stockId) {
+        return stockJpaRepository.findNotDeletedById(stockId);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
@@ -37,5 +38,10 @@ public class StockRepositoryAdapter implements StockRepository {
     @Override
     public StockResult findStockResultById(UUID stockId) {
         return stockJpaRepository.findStockResultById(stockId);
+    }
+
+    @Override
+    public Optional<StockLog> findLastByStockIdAndOrderId(UUID stockId, UUID orderId) {
+        return stockJpaRepository.findLastByStockIdAndOrderId(stockId, orderId);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
@@ -1,10 +1,14 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
+import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,5 +25,12 @@ public class StockRepositoryAdapter implements StockRepository {
     @Override
     public Optional<TimeDealStock> findNotDeletedById(UUID stockId) {
         return stockJpaRepository.findNotDeletedById(stockId);
+    }
+
+    @Override
+    public Page<StockResult> findStockResults(
+        String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable
+    ) {
+        return stockJpaRepository.findStockResults(keyword, productId, status, pageable);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
@@ -1,0 +1,18 @@
+package com.rushcrew.timedeal.infrastructure.repository;
+
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockRepositoryAdapter implements StockRepository {
+
+    private final StockJpaRepository stockJpaRepository;
+
+    @Override
+    public void save(TimeDealStock newStock) {
+        stockJpaRepository.save(newStock);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
@@ -33,4 +33,9 @@ public class StockRepositoryAdapter implements StockRepository {
     ) {
         return stockJpaRepository.findStockResults(keyword, productId, status, pageable);
     }
+
+    @Override
+    public StockResult findStockResultById(UUID stockId) {
+        return stockJpaRepository.findStockResultById(stockId);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealJpaRepository.java
@@ -2,6 +2,7 @@ package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.application.result.TimeDealResult;
 import com.rushcrew.timedeal.domain.entity.TimeDeal;
+import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import java.util.Optional;
 import java.util.UUID;
@@ -40,11 +41,19 @@ public interface TimeDealJpaRepository extends JpaRepository<TimeDeal, UUID> {
                    SELECT td
                     FROM TimeDeal td
                    WHERE td.id = :timeDealId
-                    AND td.status = :timeDealStatus
+                    AND td.status <> :timeDealStatus
                     AND td.deletedAt IS NULL
         """)
     Optional<TimeDeal> findByIdAndStatusNot(
         @Param(value = "timeDealId") UUID timeDealId,
         @Param(value = "timeDealStatus") TimeDealStatus timeDealStatus
     );
+
+    @Query("""
+                  SELECT tdp
+                  FROM TimeDealProduct tdp
+                  WHERE tdp.deletedAt IS NULL
+                    AND tdp.id = :productId
+        """)
+    Optional<TimeDealProduct> findProductByProductId(UUID productId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealJpaRepository.java
@@ -55,5 +55,7 @@ public interface TimeDealJpaRepository extends JpaRepository<TimeDeal, UUID> {
                   WHERE tdp.deletedAt IS NULL
                     AND tdp.id = :productId
         """)
-    Optional<TimeDealProduct> findProductByProductId(UUID productId);
+    Optional<TimeDealProduct> findProductByProductId(
+        @Param(value = "productId") UUID productId
+    );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealRepositoryAdapter.java
@@ -2,6 +2,7 @@ package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.application.result.TimeDealResult;
 import com.rushcrew.timedeal.domain.entity.TimeDeal;
+import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
 import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import java.util.Optional;
@@ -37,5 +38,10 @@ public class TimeDealRepositoryAdapter implements TimeDealRepository {
         UUID timeDealId, TimeDealStatus timeDealStatus
     ) {
         return timeDealJpaRepository.findByIdAndStatusNot(timeDealId, timeDealStatus);
+    }
+
+    @Override
+    public Optional<TimeDealProduct> findProductByProductId(UUID productId) {
+        return timeDealJpaRepository.findProductByProductId(productId);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,5 +45,13 @@ public class StockController {
         UpdateStockCountCommand command = request.toCommand();
         UpdateStockCountResult result = stockService.changeStockCount(stockId, command);
         return ResponseEntity.ok(UpdateStockCountResponse.from(result));
+    }
+
+    @DeleteMapping("/{stockId}")
+    public ResponseEntity<Void> deleteStock(
+        @PathVariable UUID stockId
+    ) {
+        stockService.deleteStock(stockId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -3,22 +3,31 @@ package com.rushcrew.timedeal.presentation;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
 import com.rushcrew.timedeal.presentation.dto.request.UpdateStockCountRequest;
 import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
+import com.rushcrew.timedeal.presentation.dto.response.StockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.UpdateStockCountResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,6 +54,18 @@ public class StockController {
         UpdateStockCountCommand command = request.toCommand();
         UpdateStockCountResult result = stockService.changeStockCount(stockId, command);
         return ResponseEntity.ok(UpdateStockCountResponse.from(result));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<StockResponse>> getStocks(
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) UUID productId,
+        @RequestParam(required = false) TimeDealStockStatus status,
+        @SortDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable
+    ) {
+        Page<StockResult> result = stockService.getStocks(keyword, productId, status, pageable);
+        Page<StockResponse> response = result.map(StockResponse::from);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{stockId}")

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -68,6 +68,14 @@ public class StockController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/{stockId}")
+    public ResponseEntity<StockResponse> getStock(
+        @PathVariable UUID stockId
+    ) {
+        StockResult result = stockService.getStock(stockId);
+        return ResponseEntity.ok(StockResponse.from(result));
+    }
+
     @DeleteMapping("/{stockId}")
     public ResponseEntity<Void> deleteStock(
         @PathVariable UUID stockId

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -1,0 +1,32 @@
+package com.rushcrew.timedeal.presentation;
+
+import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/stocks")
+@RequiredArgsConstructor
+public class StockController {
+
+    private final StockService stockService;
+
+    @PostMapping
+    public ResponseEntity<CreateStockResponse> createStock(
+        @RequestBody @Valid CreateStockRequest request
+    ) {
+        CreateStockCommand command = request.toCommand();
+        CreateStockResult result = stockService.createStock(command);
+        return ResponseEntity.status(HttpStatus.CREATED).body(CreateStockResponse.from(result));
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -1,14 +1,20 @@
 package com.rushcrew.timedeal.presentation;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import com.rushcrew.timedeal.presentation.dto.request.UpdateStockCountRequest;
 import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
+import com.rushcrew.timedeal.presentation.dto.response.UpdateStockCountResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,5 +34,15 @@ public class StockController {
         CreateStockCommand command = request.toCommand();
         CreateStockResult result = stockService.createStock(command);
         return ResponseEntity.status(HttpStatus.CREATED).body(CreateStockResponse.from(result));
+    }
+
+    @PostMapping("/{stockId}/change")
+    public ResponseEntity<UpdateStockCountResponse> changeStockCount(
+        @PathVariable UUID stockId,
+        @RequestBody @Valid UpdateStockCountRequest request
+    ) {
+        UpdateStockCountCommand command = request.toCommand();
+        UpdateStockCountResult result = stockService.changeStockCount(stockId, command);
+        return ResponseEntity.ok(UpdateStockCountResponse.from(result));
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -1,15 +1,19 @@
 package com.rushcrew.timedeal.presentation;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import com.rushcrew.timedeal.presentation.dto.request.ReserveStockRequest;
 import com.rushcrew.timedeal.presentation.dto.request.UpdateStockCountRequest;
 import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
+import com.rushcrew.timedeal.presentation.dto.response.ReserveStockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.StockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.UpdateStockCountResponse;
 import jakarta.validation.Valid;
@@ -82,5 +86,14 @@ public class StockController {
     ) {
         stockService.deleteStock(stockId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reserve")
+    public ResponseEntity<ReserveStockResponse> reserveStock(
+        @RequestBody @Valid ReserveStockRequest request
+    ) {
+        ReserveStockCommand command = request.toCommand();
+        ReserveStockResult result = stockService.reserveStock(command);
+        return ResponseEntity.ok(ReserveStockResponse.from(result));
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.presentation;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
@@ -8,6 +9,7 @@ import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import com.rushcrew.timedeal.presentation.dto.request.RestoreStockRequest;
 import com.rushcrew.timedeal.presentation.dto.request.UpdateStockCountRequest;
 import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.StockResponse;
@@ -81,6 +83,15 @@ public class StockController {
         @PathVariable UUID stockId
     ) {
         stockService.deleteStock(stockId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/restore")
+    public ResponseEntity<Void> restoreStock(
+        @RequestBody @Valid RestoreStockRequest request
+    ) {
+        RestoreStockCommand command = request.toCommand();
+        stockService.restoreStock(command);
         return ResponseEntity.noContent().build();
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/CreateStockRequest.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/CreateStockRequest.java
@@ -1,0 +1,14 @@
+package com.rushcrew.timedeal.presentation.dto.request;
+
+import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import java.util.UUID;
+
+public record CreateStockRequest(
+    UUID productId,
+    Long totalStock
+) {
+
+    public CreateStockCommand toCommand() {
+        return new CreateStockCommand(this.productId, this.totalStock);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/ReserveStockRequest.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/ReserveStockRequest.java
@@ -1,0 +1,31 @@
+package com.rushcrew.timedeal.presentation.dto.request;
+
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ReserveStockRequest(
+    @NotNull
+    UUID orderId,
+
+    @NotNull
+    UUID timeDealStockId,
+
+    @NotNull
+    Long quantity,
+
+    @NotNull
+    Long userId
+) {
+
+    public ReserveStockCommand toCommand() {
+        return new ReserveStockCommand(
+            OrderId.of(this.orderId),
+            this.timeDealStockId,
+            Quantity.positive(this.quantity),
+            this.userId
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/RestoreStockRequest.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/RestoreStockRequest.java
@@ -1,0 +1,34 @@
+package com.rushcrew.timedeal.presentation.dto.request;
+
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record RestoreStockRequest(
+    @NotNull
+    UUID timeDealStockId,
+
+    @NotNull
+    @Min(value = 1)
+    Long quantity,
+
+    @NotNull
+    UUID orderId,
+
+    @NotBlank
+    String reason
+) {
+
+    public RestoreStockCommand toCommand() {
+        return new RestoreStockCommand(
+            this.timeDealStockId,
+            Quantity.positive(this.quantity),
+            OrderId.of(this.orderId),
+            this.reason
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/UpdateStockCountRequest.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/UpdateStockCountRequest.java
@@ -1,0 +1,23 @@
+package com.rushcrew.timedeal.presentation.dto.request;
+
+import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateStockCountRequest(
+
+    @NotNull
+    Long quantity,
+
+    @NotBlank
+    String reason
+) {
+
+    public UpdateStockCountCommand toCommand() {
+        return new UpdateStockCountCommand(
+            Quantity.of(this.quantity),
+            this.reason
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/CreateStockResponse.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/CreateStockResponse.java
@@ -1,0 +1,31 @@
+package com.rushcrew.timedeal.presentation.dto.response;
+
+import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CreateStockResponse(
+    UUID stockId,
+    UUID productId,
+    Long availableStock,
+    Long reservedStock,
+    Long soldStock,
+    Long totalStock,
+    TimeDealStockStatus status,
+    LocalDateTime createdAt
+) {
+
+    public static CreateStockResponse from(CreateStockResult result) {
+        return new CreateStockResponse(
+            result.stockId(),
+            result.productId(),
+            result.availableStock(),
+            result.reservedStock(),
+            result.soldStock(),
+            result.totalStock(),
+            result.status(),
+            result.createdAt()
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/ReserveStockResponse.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/ReserveStockResponse.java
@@ -1,0 +1,18 @@
+package com.rushcrew.timedeal.presentation.dto.response;
+
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
+
+public record ReserveStockResponse(
+    boolean success,
+    Integer availableStock,
+    String message
+) {
+
+    public static ReserveStockResponse from(ReserveStockResult result) {
+        return new ReserveStockResponse(
+            result.success(),
+            result.availableStock(),
+            result.message()
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/StockResponse.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/StockResponse.java
@@ -1,0 +1,29 @@
+package com.rushcrew.timedeal.presentation.dto.response;
+
+import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StockResponse(
+    UUID stockId,
+    UUID productId,
+    Long availableStock,
+    Long reservedStock,
+    Long soldStock,
+    TimeDealProductStatus status,
+    LocalDateTime updatedAt
+) {
+
+    public static StockResponse from(StockResult result) {
+        return new StockResponse(
+            result.stockId(),
+            result.productId(),
+            result.availableStock(),
+            result.reservedStock(),
+            result.soldStock(),
+            result.status(),
+            result.updatedAt()
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/UpdateStockCountResponse.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/UpdateStockCountResponse.java
@@ -1,0 +1,22 @@
+package com.rushcrew.timedeal.presentation.dto.response;
+
+import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
+import java.util.UUID;
+
+public record UpdateStockCountResponse(
+    UUID stockId,
+    UUID productId,
+    Long currentStock,
+    Long changedQuantity
+) {
+
+    public static UpdateStockCountResponse from(UpdateStockCountResult result) {
+        return new UpdateStockCountResponse(
+            result.stockId(),
+            result.productId(),
+            result.currentStock(),
+            result.changedQuantity()
+        );
+
+    }
+}

--- a/timedeal-service/src/main/resources/application.yaml
+++ b/timedeal-service/src/main/resources/application.yaml
@@ -3,6 +3,10 @@ spring:
     name: timedeal-service
   config:
     import: "optional:file:.env"
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${TIME_DEAL_DB}
     username: ${POSTGRES_USER}

--- a/timedeal-service/src/main/resources/application.yaml
+++ b/timedeal-service/src/main/resources/application.yaml
@@ -23,6 +23,8 @@ spring:
   sql:
     init:
       mode: always
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
 
 server:
   port: 8030


### PR DESCRIPTION
## 🧾 Summary
- 재고 캐시 기능 추가(redis 의존성 및 설정 추가)
- 재고 생성 API 구현

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [ ] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #142 
