### PR TITLE
Feat(timedeal): 재고 예약 기능 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - rushdeal_pg_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U rushdeal -d rushdeal_db"]
+      test: [ "CMD-SHELL", "pg_isready -U rushdeal -d rushdeal_db" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -42,6 +42,20 @@ services:
       - "6381:6379"
     volumes:
       - rushdeal_order_redis_data:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  rushdeal_timedeal_redis:
+    image: redis:7-alpine
+    container_name: rushdeal_timedeal_redis
+    restart: unless-stopped
+    ports:
+      - "6382:6379"
+    volumes:
+      - rushdeal_timedeal_redis_data:/data
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
@@ -91,3 +105,4 @@ volumes:
   rushdeal_pg_data:
   rushdeal_queue_redis_data:
   rushdeal_order_redis_data:
+  rushdeal_timedeal_redis_data:

--- a/timedeal-service/build.gradle
+++ b/timedeal-service/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     // 공통 모듈 (jitpack)

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/TimeDealApplication.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/TimeDealApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @ComponentScan(basePackages = {
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.ComponentScan;
     "com.rushcrew.common"
 })
 @EnableFeignClients
+@EnableRetry
 public class TimeDealApplication {
 
     public static void main(String[] args) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ConfirmStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ConfirmStockCommand.java
@@ -1,0 +1,13 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import java.util.UUID;
+
+public record ConfirmStockCommand(
+    OrderId orderId,
+    UUID stockId,
+    Quantity quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ReserveStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/ReserveStockCommand.java
@@ -1,0 +1,14 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import java.util.UUID;
+
+public record ReserveStockCommand(
+    OrderId orderId,
+    UUID stockId,
+    Quantity quantity,
+    Long userId
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/RestoreStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/RestoreStockCommand.java
@@ -1,0 +1,14 @@
+package com.rushcrew.timedeal.application.command;
+
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import java.util.UUID;
+
+public record RestoreStockCommand(
+    UUID stockId,
+    Quantity quantity,
+    OrderId orderId,
+    String reason
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockChangedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockChangedEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockChangedEvent(
+    UUID stockId,
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockCreatedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockCreatedEvent(
+    UUID stockId,
+    Long totalStock
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockDeletedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockDeletedEvent(
+    UUID stockId
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockReservedEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockReservedEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockReservedEvent(
+    UUID stockId,
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockRestoredEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/event/StockRestoredEvent.java
@@ -1,0 +1,10 @@
+package com.rushcrew.timedeal.application.event;
+
+import java.util.UUID;
+
+public record StockRestoredEvent(
+    UUID stockId,
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ConfirmStockResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ConfirmStockResult.java
@@ -1,0 +1,12 @@
+package com.rushcrew.timedeal.application.result;
+
+import java.util.UUID;
+
+public record ConfirmStockResult(
+    UUID orderId
+) {
+
+    public static ConfirmStockResult of(UUID orderId) {
+        return new ConfirmStockResult(orderId);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ReserveStockResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/ReserveStockResult.java
@@ -1,0 +1,12 @@
+package com.rushcrew.timedeal.application.result;
+
+public record ReserveStockResult(
+    Boolean success,
+    Integer availableStock,
+    String message
+) {
+
+    public static ReserveStockResult of(Long available, String message) {
+        return new ReserveStockResult(true, available.intValue(), message);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -3,6 +3,7 @@ package com.rushcrew.timedeal.application.service;
 import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
@@ -30,4 +31,6 @@ public interface StockService {
     ReserveStockResult reserveStock(ReserveStockCommand command);
 
     ConfirmStockResult confirmStock(ConfirmStockCommand command);
+
+    void restoreStock(RestoreStockCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -1,8 +1,10 @@
 package com.rushcrew.timedeal.application.service;
 
+import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
@@ -26,4 +28,6 @@ public interface StockService {
     StockResult getStock(UUID stockId);
 
     ReserveStockResult reserveStock(ReserveStockCommand command);
+
+    ConfirmStockResult confirmStock(ConfirmStockCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockService.java
@@ -1,8 +1,10 @@
 package com.rushcrew.timedeal.application.service;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
@@ -22,4 +24,6 @@ public interface StockService {
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
 
     StockResult getStock(UUID stockId);
+
+    ReserveStockResult reserveStock(ReserveStockCommand command);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -4,8 +4,13 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.application.event.StockChangedEvent;
+import com.rushcrew.timedeal.application.event.StockCreatedEvent;
+import com.rushcrew.timedeal.application.event.StockDeletedEvent;
 import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.application.event.StockRestoredEvent;
 import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
@@ -16,9 +21,9 @@ import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
-import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
+import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
@@ -42,7 +47,6 @@ public class StockServiceImpl implements StockService {
 
     private final TimeDealRepository timeDealRepository;
     private final StockRepository stockRepository;
-    private final StockCache stockCache;
     private final ApplicationEventPublisher eventPublisher;
 
     @Override
@@ -56,7 +60,8 @@ public class StockServiceImpl implements StockService {
 
         TimeDealStock newStock = TimeDealStock.create(command, timeDealProduct);
         stockRepository.save(newStock);
-        stockCache.register(newStock.getId(), command.totalStock());
+
+        eventPublisher.publishEvent(new StockCreatedEvent(newStock.getId(), command.totalStock()));
 
         return CreateStockResult.of(newStock, command.totalStock());
     }
@@ -73,7 +78,8 @@ public class StockServiceImpl implements StockService {
         validQuantity(stock, quantity);
 
         stock.changeAvailable(quantity, command.reason());
-        stockCache.changeCount(stockId, quantity);
+
+        eventPublisher.publishEvent(new StockChangedEvent(stockId, quantity));
 
         return UpdateStockCountResult.of(
             stock.getId(), stock.getTimeDealProduct().getId(),
@@ -105,7 +111,8 @@ public class StockServiceImpl implements StockService {
 
         // TODO: 추후에 사용자 정보 가지고 오면 주석처리 풀 예정
 //        stock.delete(userId);
-        stockCache.evict(stockId);
+
+        eventPublisher.publishEvent(new StockDeletedEvent(stockId));
     }
 
     @Override
@@ -142,6 +149,29 @@ public class StockServiceImpl implements StockService {
         stock.confirm(OrderId.of(orderId), command.quantity());
 
         return ConfirmStockResult.of(orderId);
+    }
+
+    @Override
+    @Transactional
+    public void restoreStock(RestoreStockCommand command) {
+        // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
+
+        UUID orderId = command.orderId().getOrderId();
+        TimeDealStock stock = getStockOrThrow(command.stockId());
+        StockLog log = getLastLogOrThrow(command.stockId(), orderId);
+        validateOrderQuantity(log, command.quantity());
+
+        if (log.getEventType() == EventType.RESERVE) {
+            stock.restoreFromReserved(OrderId.of(orderId), command.quantity(), command.reason());
+        } else if (log.getEventType() == EventType.SELL) {
+            stock.restoreFromSold(OrderId.of(orderId), command.quantity(), command.reason());
+        } else {
+            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_STATE);
+        }
+
+        eventPublisher.publishEvent(
+            new StockRestoredEvent(command.stockId(), command.quantity().getQuantity())
+        );
     }
 
     // ------------------------------------------------------------------------------------

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -4,6 +4,7 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
+import com.rushcrew.timedeal.application.event.StockReservedEvent;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
@@ -19,6 +20,7 @@ import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -32,6 +34,7 @@ public class StockServiceImpl implements StockService {
     private final TimeDealRepository timeDealRepository;
     private final StockRepository stockRepository;
     private final StockCache stockCache;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -104,7 +107,9 @@ public class StockServiceImpl implements StockService {
         TimeDealStock stock = getStockOrThrow(command.stockId());
 
         stock.reserve(command.quantity(), command.orderId());
-        stockCache.reserve(command.stockId(), command.quantity().getQuantity());
+        eventPublisher.publishEvent(
+            new StockReservedEvent(command.stockId(), command.quantity().getQuantity())
+        );
 
         return ReserveStockResult
             .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -23,7 +23,6 @@ import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
-import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
@@ -161,13 +160,8 @@ public class StockServiceImpl implements StockService {
         StockLog log = getLastLogOrThrow(command.stockId(), orderId);
         validateOrderQuantity(log, command.quantity());
 
-        if (log.getEventType() == EventType.RESERVE) {
-            stock.restoreFromReserved(OrderId.of(orderId), command.quantity(), command.reason());
-        } else if (log.getEventType() == EventType.SELL) {
-            stock.restoreFromSold(OrderId.of(orderId), command.quantity(), command.reason());
-        } else {
-            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_STATE);
-        }
+        log.getEventType().applyRestore(
+            stock, OrderId.of(orderId), command.quantity(), command.reason());
 
         eventPublisher.publishEvent(
             new StockRestoredEvent(command.stockId(), command.quantity().getQuantity())

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -23,6 +23,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,6 +104,11 @@ public class StockServiceImpl implements StockService {
 
     @Override
     @Transactional
+    @Retryable(
+        retryFor = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 5,
+        backoff = @Backoff(delay = 5, maxDelay = 20, multiplier = 2)
+    )
     public ReserveStockResult reserveStock(ReserveStockCommand command) {
         // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
 

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -1,23 +1,29 @@
 package com.rushcrew.timedeal.application.service.impl;
 
 import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -123,11 +129,37 @@ public class StockServiceImpl implements StockService {
             .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");
     }
 
+    @Override
+    @Transactional
+    public ConfirmStockResult confirmStock(ConfirmStockCommand command) {
+        // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
+
+        UUID orderId = command.orderId().getOrderId();
+        TimeDealStock stock = getStockOrThrow(command.stockId());
+        StockLog log = getLastLogOrThrow(command.stockId(), orderId);
+        validateOrderQuantity(log, command.quantity());
+
+        stock.confirm(OrderId.of(orderId), command.quantity());
+
+        return ConfirmStockResult.of(orderId);
+    }
+
     // ------------------------------------------------------------------------------------
 
     private TimeDealStock getStockOrThrow(UUID stockId) {
         return stockRepository.findNotDeletedById(stockId)
             .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_STOCK));
+    }
+
+    private StockLog getLastLogOrThrow(UUID stockId, UUID orderId) {
+        return stockRepository.findLastByStockIdAndOrderId(stockId, orderId)
+            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_ORDER));
+    }
+
+    private void validateOrderQuantity(StockLog log, Quantity quantity) {
+        if (!Objects.equals(log.getQuantity().getQuantity(), quantity.getQuantity())) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
+        }
     }
 
     private void validQuantity(TimeDealStock stock, Long quantity) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -20,10 +20,8 @@ import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
 import com.rushcrew.timedeal.domain.vo.OrderId;
-import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -137,7 +135,9 @@ public class StockServiceImpl implements StockService {
         UUID orderId = command.orderId().getOrderId();
         TimeDealStock stock = getStockOrThrow(command.stockId());
         StockLog log = getLastLogOrThrow(command.stockId(), orderId);
-        validateOrderQuantity(log, command.quantity());
+
+        // 주문 당시 기록된 수량과 현재 처리하려는 수량이 동일한지 검증
+        log.validateOrderQuantity(command.quantity());
 
         stock.confirm(OrderId.of(orderId), command.quantity());
 
@@ -154,12 +154,6 @@ public class StockServiceImpl implements StockService {
     private StockLog getLastLogOrThrow(UUID stockId, UUID orderId) {
         return stockRepository.findLastByStockIdAndOrderId(stockId, orderId)
             .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_ORDER));
-    }
-
-    private void validateOrderQuantity(StockLog log, Quantity quantity) {
-        if (!Objects.equals(log.getQuantity().getQuantity(), quantity.getQuantity())) {
-            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
-        }
     }
 
     private void validQuantity(TimeDealStock stock, Long quantity) {

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -2,8 +2,10 @@ package com.rushcrew.timedeal.application.service.impl;
 
 import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
@@ -92,6 +94,20 @@ public class StockServiceImpl implements StockService {
         // TODO: 추후에 사용자 정보 가지고 오면 주석처리 풀 예정
 //        stock.delete(userId);
         stockCache.evict(stockId);
+    }
+
+    @Override
+    @Transactional
+    public ReserveStockResult reserveStock(ReserveStockCommand command) {
+        // TODO: 요청한 사용자가 ORDER 권한을 가지고 있는지 체크
+
+        TimeDealStock stock = getStockOrThrow(command.stockId());
+
+        stock.reserve(command.quantity(), command.orderId());
+        stockCache.reserve(command.stockId(), command.quantity().getQuantity());
+
+        return ReserveStockResult
+            .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");
     }
 
     // ------------------------------------------------------------------------------------

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -83,4 +83,16 @@ public class StockLog extends BaseEntity {
             .quantity(quantity)
             .build();
     }
+
+    public static StockLog confirm(
+        TimeDealStock stock, OrderId orderId, Quantity quantity
+    ) {
+        return StockLog.builder()
+            .timeDealStock(stock)
+            .orderId(orderId)
+            .eventType(EventType.SELL)
+            .description("결제")
+            .quantity(quantity)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -73,4 +73,14 @@ public class StockLog extends BaseEntity {
             .description(description)
             .build();
     }
+
+    public static StockLog reserve(TimeDealStock stock, OrderId orderId, Quantity quantity) {
+        return StockLog.builder()
+            .timeDealStock(stock)
+            .orderId(orderId)
+            .eventType(EventType.RESERVE)
+            .description("주문")
+            .quantity(quantity)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -1,6 +1,8 @@
 package com.rushcrew.timedeal.domain.entity;
 
 import com.rushcrew.common.entity.BaseEntity;
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.vo.EventType;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
@@ -17,6 +19,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -94,5 +97,11 @@ public class StockLog extends BaseEntity {
             .description("결제")
             .quantity(quantity)
             .build();
+    }
+
+    public void validateOrderQuantity(Quantity quantity) {
+        if (!Objects.equals(this.getQuantity().getQuantity(), quantity.getQuantity())) {
+            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/StockLog.java
@@ -95,4 +95,17 @@ public class StockLog extends BaseEntity {
             .quantity(quantity)
             .build();
     }
+
+    public static StockLog restore(
+        TimeDealStock stock, OrderId orderId, Quantity quantity, EventType eventType,
+        String description
+    ) {
+        return StockLog.builder()
+            .timeDealStock(stock)
+            .orderId(orderId)
+            .eventType(eventType)
+            .description(description)
+            .quantity(quantity)
+            .build();
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
@@ -118,6 +118,17 @@ public class TimeDeal extends BaseEntity {
         this.status = TimeDealStatus.ENDED;
     }
 
+    public void updateStatusByPeriod(Instant now) {
+        Instant start = this.period.getStartAt();
+        Instant end = this.period.getEndAt();
+
+        if (now.isAfter(end)) { // 종료 후
+            this.status = TimeDealStatus.ENDED;
+        } else if (!now.isBefore(start) && !now.isAfter(end)) { // 진행중
+            this.status = TimeDealStatus.IN_PROGRESS;
+        }
+    }
+
     private void addTimeDealProduct(UUID productId, UUID optionId) {
         this.timeDealProducts.add(TimeDealProduct.create(
             this, ProductItemIds.of(productId, optionId)
@@ -138,6 +149,10 @@ public class TimeDeal extends BaseEntity {
     private void updatePeriod(Instant newStartAt, Instant newEndAt) {
         if (newStartAt == null && newEndAt == null) {
             return;
+        }
+
+        if (!this.status.equals(TimeDealStatus.SCHEDULED)) {
+            throw new BusinessException(TimeDealErrorCode.TIME_DEAL_UPDATE_NOT_ALLOWED);
         }
 
         Instant updatedStartAt = newStartAt != null ? newStartAt : this.getPeriod().getStartAt();

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDeal.java
@@ -99,6 +99,10 @@ public class TimeDeal extends BaseEntity {
         return timeDeal;
     }
 
+    public void updateStatus(TimeDealStatus timeDealStatus) {
+        this.status = timeDealStatus;
+    }
+
     public void update(UpdateTimeDealParams params) {
         updateTimeDealInfo(params.title(), params.description());
         this.price = params.discountPrice() != null ? Price.of(params.discountPrice()) : this.price;

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -159,4 +159,15 @@ public class TimeDealStock extends BaseEntity {
         );
         this.stockLogs.add(log);
     }
+
+    public void confirm(OrderId orderId, Quantity quantity) {
+        this.stockCounts = this.stockCounts.confirm(quantity);
+
+        if (this.stockCounts.getAvailable() == 0 && this.stockCounts.getReserved() == 0) {
+            this.status = TimeDealStockStatus.SOLD;
+        }
+
+        StockLog log = StockLog.confirm(this, orderId, quantity);
+        this.stockLogs.add(log);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -5,9 +5,12 @@ import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.vo.EventType;
+import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.ProductItemIds;
+import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.StockCounts;
 import com.rushcrew.timedeal.domain.vo.TimeDealProductStatus;
+import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -134,6 +137,25 @@ public class TimeDealStock extends BaseEntity {
         StockLog log = StockLog.addLog(
             this, EventType.ADMIN_CONTROL, beforeAvailable,
             "재고 삭제 전 남은 재고 처리 (" + beforeAvailable + " -> 0)"
+        );
+        this.stockLogs.add(log);
+    }
+
+    public void reserve(Quantity quantity, OrderId orderId) {
+        if (this.stockCounts.getAvailable() < quantity.getQuantity()) {
+            throw new BusinessException(TimeDealErrorCode.OUT_OF_STOCK);
+        }
+
+        this.stockCounts = this.stockCounts.reserve(quantity);
+
+        if (this.stockCounts.getAvailable() == 0) {
+            this.timeDealProduct.getTimeDeal().updateStatus(TimeDealStatus.SOLD_OUT);
+            this.status = TimeDealStockStatus.RESERVED;
+            this.timeDealProduct.updateStatus(TimeDealProductStatus.OUT_OF_STOCK);
+        }
+
+        StockLog log = StockLog.reserve(
+            this, orderId, quantity
         );
         this.stockLogs.add(log);
     }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -28,6 +28,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -169,5 +170,27 @@ public class TimeDealStock extends BaseEntity {
 
         StockLog log = StockLog.confirm(this, orderId, quantity);
         this.stockLogs.add(log);
+    }
+
+    public void restoreFromReserved(OrderId orderId, Quantity quantity, String reason) {
+        this.stockCounts = this.stockCounts.restoreFromReserved(quantity);
+        updateStatus();
+
+        StockLog log = StockLog.restore(this, orderId, quantity, EventType.RESERVE_CANCEL, reason);
+        this.stockLogs.add(log);
+    }
+
+    public void restoreFromSold(OrderId orderId, Quantity quantity, String reason) {
+        this.stockCounts = this.stockCounts.restoreFromSold(quantity);
+        updateStatus();
+
+        StockLog log = StockLog.restore(this, orderId, quantity, EventType.PAYMENT_CANCEL, reason);
+        this.stockLogs.add(log);
+    }
+
+    private void updateStatus() {
+        this.status = TimeDealStockStatus.AVAILABLE;
+        this.timeDealProduct.updateStatus(TimeDealProductStatus.IN_STOCK);
+        this.timeDealProduct.getTimeDeal().updateStatusByPeriod(Instant.now());
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -26,4 +26,12 @@ public interface StockCache {
      * @param stockId : Redis key에 사용되는 타임딜 재고 ID
      */
     void evict(UUID stockId);
+
+    /**
+     * Redis에 캐시된 재고 수량 차감
+     *
+     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
+     * @param quantity : value에서 차감할 재고 수량 (예약된 재고 수량)
+     */
+    void reserve(UUID stockId, Long quantity);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -34,4 +34,12 @@ public interface StockCache {
      * @param quantity : value에서 차감할 재고 수량 (예약된 재고 수량)
      */
     void reserve(UUID stockId, Long quantity);
+
+    /**
+     * Redis에 캐시된 재고 수량 복구(증가)
+     *
+     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
+     * @param quantity : value에서 증가할 재고 수량 (복구된 재고 수량)
+     */
+    void restore(UUID stockId, Long quantity);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/repository/StockRepository.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.domain.repository;
 
 import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
@@ -18,4 +19,6 @@ public interface StockRepository {
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable);
 
     StockResult findStockResultById(UUID stockId);
+
+    Optional<StockLog> findLastByStockIdAndOrderId(UUID stockId, UUID orderId);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/EventType.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/EventType.java
@@ -1,17 +1,50 @@
 package com.rushcrew.timedeal.domain.vo;
 
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
+
 public enum EventType {
+    RESERVE("재고 예약") {
+        @Override
+        public void applyRestore(
+            TimeDealStock stock,
+            OrderId orderId,
+            Quantity quantity,
+            String reason
+        ) {
+            stock.restoreFromReserved(orderId, quantity, reason);
+        }
+    },
+    SELL("판매 확정") {
+        @Override
+        public void applyRestore(
+            TimeDealStock stock,
+            OrderId orderId,
+            Quantity quantity,
+            String reason
+        ) {
+            stock.restoreFromSold(orderId, quantity, reason);
+        }
+    },
     INIT("초기 재고 설정"),
-    RESERVE("재고 예약"),
-    RESERVE_CANCEL("예약 취소"), // 재고 복구
-    PAYMENT_CANCEL("결제 취소"), // 재고 복구
-    SELL("판매 확정"), // 재고 차감
+    RESERVE_CANCEL("예약 취소"),
+    PAYMENT_CANCEL("결제 취소"),
     ROLLBACK("트랜잭션 롤백"),
-    ADMIN_CONTROL("관리자 수동 조정"); // 임의로 재고 증가/감소
+    ADMIN_CONTROL("관리자 수동 조정");
 
     private final String description;
 
     EventType(String description) {
         this.description = description;
+    }
+
+    public void applyRestore(
+        TimeDealStock stock,
+        OrderId orderId,
+        Quantity quantity,
+        String reason
+    ) {
+        throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_STATE);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
@@ -51,6 +51,22 @@ public class StockCounts {
         );
     }
 
+    public StockCounts restoreFromReserved(Quantity quantity) {
+        return StockCounts.of(
+            this.available + quantity.getQuantity(),
+            this.reserved - quantity.getQuantity(),
+            this.getSold()
+        );
+    }
+
+    public StockCounts restoreFromSold(Quantity quantity) {
+        return StockCounts.of(
+            this.available + quantity.getQuantity(),
+            this.getReserved(),
+            this.sold - quantity.getQuantity()
+        );
+    }
+
     private void validateNotNull(Long available, Long reserved, Long sold) {
         if (available == null || reserved == null || sold == null) {
             throw new BusinessException(TimeDealErrorCode.REQUIRED_STOCK_COUNT);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
@@ -35,6 +35,14 @@ public class StockCounts {
         return new StockCounts(available, 0L, 0L);
     }
 
+    public StockCounts reserve(Quantity quantity) {
+        return StockCounts.of(
+            this.available - quantity.getQuantity(),
+            this.reserved + quantity.getQuantity(),
+            this.getSold()
+        );
+    }
+
     private void validateNotNull(Long available, Long reserved, Long sold) {
         if (available == null || reserved == null || sold == null) {
             throw new BusinessException(TimeDealErrorCode.REQUIRED_STOCK_COUNT);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/vo/StockCounts.java
@@ -43,6 +43,14 @@ public class StockCounts {
         );
     }
 
+    public StockCounts confirm(Quantity quantity) {
+        return StockCounts.of(
+            this.getAvailable(),
+            this.reserved - quantity.getQuantity(),
+            this.sold + quantity.getQuantity()
+        );
+    }
+
     private void validateNotNull(Long available, Long reserved, Long sold) {
         if (available == null || reserved == null || sold == null) {
             throw new BusinessException(TimeDealErrorCode.REQUIRED_STOCK_COUNT);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -30,4 +30,10 @@ public class RedisStockCache implements StockCache {
     public void evict(UUID stockId) {
         redisTemplate.delete("tds:" + stockId);
     }
+
+    @Override
+    public void reserve(UUID stockId, Long quantity) {
+        String key = "tds:" + stockId;
+        redisTemplate.opsForValue().decrement(key, quantity);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -36,4 +36,10 @@ public class RedisStockCache implements StockCache {
         String key = "tds:" + stockId;
         redisTemplate.opsForValue().decrement(key, quantity);
     }
+
+    @Override
+    public void restore(UUID stockId, Long quantity) {
+        String key = "tds:" + stockId;
+        redisTemplate.opsForValue().increment(key, quantity);
+    }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/config/KafkaConsumerConfig.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,46 @@
+package com.rushcrew.timedeal.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        JsonDeserializer<Object> deserializer = new JsonDeserializer<>();
+        deserializer.addTrustedPackages("com.rushcrew.timedeal.infrastructure.kafka");
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "timedeal-stock");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        return new DefaultKafkaConsumerFactory<>(
+            props,
+            new StringDeserializer(),
+            deserializer
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
@@ -1,6 +1,10 @@
 package com.rushcrew.timedeal.infrastructure.event;
 
+import com.rushcrew.timedeal.application.event.StockChangedEvent;
+import com.rushcrew.timedeal.application.event.StockCreatedEvent;
+import com.rushcrew.timedeal.application.event.StockDeletedEvent;
 import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.application.event.StockRestoredEvent;
 import com.rushcrew.timedeal.domain.port.StockCache;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +20,39 @@ public class StockEventHandler {
     private final StockCache stockCache;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockCreated(StockCreatedEvent event) {
+        try {
+            stockCache.register(event.stockId(), event.totalStock());
+        } catch (Exception e) {
+            log.error(
+                "StockCreatedEvent 처리 중 Redis 반영 실패. stock={}, totalStock={}",
+                event.stockId(), event.totalStock(), e
+            );
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockChanged(StockChangedEvent event) {
+        try {
+            stockCache.changeCount(event.stockId(), event.quantity());
+        } catch (Exception e) {
+            log.error(
+                "StockChangedEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
+                event.stockId(), event.quantity(), e
+            );
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockDeleted(StockDeletedEvent event) {
+        try {
+            stockCache.evict(event.stockId());
+        } catch (Exception e) {
+            log.error("StockDeletedEvent 처리 중 Redis 반영 실패. stock={}", event.stockId(), e);
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockReserved(StockReservedEvent event) {
         try {
             stockCache.reserve(event.stockId(), event.quantity());
@@ -25,6 +62,17 @@ public class StockEventHandler {
                 event.stockId(), event.quantity(), e
             );
         }
+    }
 
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockRestored(StockRestoredEvent event) {
+        try {
+            stockCache.restore(event.stockId(), event.quantity());
+        } catch (Exception e) {
+            log.error(
+                "StockRestoredEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
+                event.stockId(), event.quantity(), e
+            );
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
@@ -1,0 +1,30 @@
+package com.rushcrew.timedeal.infrastructure.event;
+
+import com.rushcrew.timedeal.application.event.StockReservedEvent;
+import com.rushcrew.timedeal.domain.port.StockCache;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockEventHandler {
+
+    private final StockCache stockCache;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleStockReserved(StockReservedEvent event) {
+        try {
+            stockCache.reserve(event.stockId(), event.quantity());
+        } catch (Exception e) {
+            log.error(
+                "StockReservedEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
+                event.stockId(), event.quantity(), e
+            );
+        }
+
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
@@ -1,0 +1,29 @@
+package com.rushcrew.timedeal.infrastructure.kafka.consumer;
+
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.service.StockService;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import com.rushcrew.timedeal.infrastructure.kafka.dto.StockReserveEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockEventConsumer {
+
+    private final StockService stockService;
+
+    // 주문 생성 -> 재고 예약
+    @KafkaListener(topics = "order.created")
+    public void reserve(StockReserveEvent event) {
+        ReserveStockCommand command = new ReserveStockCommand(
+            OrderId.of(event.orderId()),
+            event.stockId(),
+            Quantity.positive(event.quantity()),
+            event.userId()
+        );
+        stockService.reserveStock(command);
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
@@ -1,9 +1,11 @@
 package com.rushcrew.timedeal.infrastructure.kafka.consumer;
 
+import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
+import com.rushcrew.timedeal.infrastructure.kafka.dto.StockConfirmEvent;
 import com.rushcrew.timedeal.infrastructure.kafka.dto.StockReserveEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -25,5 +27,16 @@ public class StockEventConsumer {
             event.userId()
         );
         stockService.reserveStock(command);
+    }
+
+    // 결제 -> 재고 확정
+    @KafkaListener(topics = "payment.completed")
+    public void confirm(StockConfirmEvent event) {
+        ConfirmStockCommand command = new ConfirmStockCommand(
+            OrderId.of(event.orderId()),
+            event.stockId(),
+            Quantity.positive(event.quantity())
+        );
+        stockService.confirmStock(command);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/consumer/StockEventConsumer.java
@@ -2,11 +2,13 @@ package com.rushcrew.timedeal.infrastructure.kafka.consumer;
 
 import com.rushcrew.timedeal.application.command.ConfirmStockCommand;
 import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.OrderId;
 import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.infrastructure.kafka.dto.StockConfirmEvent;
 import com.rushcrew.timedeal.infrastructure.kafka.dto.StockReserveEvent;
+import com.rushcrew.timedeal.infrastructure.kafka.dto.StockRestoreEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -39,4 +41,17 @@ public class StockEventConsumer {
         );
         stockService.confirmStock(command);
     }
+
+    // 주문 취소 -> 재고 복구
+    @KafkaListener(topics = "order.cancelled")
+    public void restore(StockRestoreEvent event) {
+        RestoreStockCommand command = new RestoreStockCommand(
+            event.stockId(),
+            Quantity.positive(event.quantity()),
+            OrderId.of(event.orderId()),
+            event.reason()
+        );
+        stockService.restoreStock(command);
+    }
+
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockConfirmEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockConfirmEvent.java
@@ -1,0 +1,17 @@
+package com.rushcrew.timedeal.infrastructure.kafka.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record StockConfirmEvent(
+    @NotNull
+    UUID orderId,
+
+    @NotNull
+    UUID stockId,
+
+    @NotNull
+    Long quantity
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockReserveEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockReserveEvent.java
@@ -1,0 +1,20 @@
+package com.rushcrew.timedeal.infrastructure.kafka.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record StockReserveEvent(
+    @NotNull
+    UUID orderId,
+
+    @NotNull
+    UUID stockId,
+
+    @NotNull
+    Long quantity,
+
+    @NotNull
+    Long userId
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockRestoreEvent.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/kafka/dto/StockRestoreEvent.java
@@ -1,0 +1,21 @@
+package com.rushcrew.timedeal.infrastructure.kafka.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record StockRestoreEvent(
+    @NotNull
+    UUID stockId,
+
+    @NotNull
+    Long quantity,
+
+    @NotNull
+    UUID orderId,
+
+    @NotBlank
+    String reason
+) {
+
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockJpaRepository.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import java.util.Optional;
@@ -68,5 +69,18 @@ public interface StockJpaRepository extends JpaRepository<TimeDealStock, UUID> {
         """)
     StockResult findStockResultById(
         @Param("stockId") UUID stockId
+    );
+
+    @Query("""
+                SELECT sl
+                FROM StockLog sl
+                WHERE sl.timeDealStock.id = :stockId
+                  AND sl.orderId.orderId = :orderId
+                ORDER BY sl.createdAt DESC
+                FETCH FIRST 1 ROW ONLY
+        """)
+    Optional<StockLog> findLastByStockIdAndOrderId(
+        @Param("stockId") UUID stockId,
+        @Param("orderId") UUID orderId
     );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/StockRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.infrastructure.repository;
 
 import com.rushcrew.timedeal.application.result.StockResult;
+import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
@@ -37,5 +38,10 @@ public class StockRepositoryAdapter implements StockRepository {
     @Override
     public StockResult findStockResultById(UUID stockId) {
         return stockJpaRepository.findStockResultById(stockId);
+    }
+
+    @Override
+    public Optional<StockLog> findLastByStockIdAndOrderId(UUID stockId, UUID orderId) {
+        return stockJpaRepository.findLastByStockIdAndOrderId(stockId, orderId);
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealJpaRepository.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/repository/TimeDealJpaRepository.java
@@ -55,5 +55,7 @@ public interface TimeDealJpaRepository extends JpaRepository<TimeDeal, UUID> {
                   WHERE tdp.deletedAt IS NULL
                     AND tdp.id = :productId
         """)
-    Optional<TimeDealProduct> findProductByProductId(UUID productId);
+    Optional<TimeDealProduct> findProductByProductId(
+        @Param(value = "productId") UUID productId
+    );
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -1,15 +1,19 @@
 package com.rushcrew.timedeal.presentation;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import com.rushcrew.timedeal.presentation.dto.request.ReserveStockRequest;
 import com.rushcrew.timedeal.presentation.dto.request.UpdateStockCountRequest;
 import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
+import com.rushcrew.timedeal.presentation.dto.response.ReserveStockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.StockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.UpdateStockCountResponse;
 import jakarta.validation.Valid;
@@ -82,5 +86,14 @@ public class StockController {
     ) {
         stockService.deleteStock(stockId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/reserve")
+    public ResponseEntity<ReserveStockResponse> reserveStock(
+        @RequestBody @Valid ReserveStockRequest request
+    ) {
+        ReserveStockCommand command = request.toCommand();
+        ReserveStockResult result = stockService.reserveStock(command);
+        return ResponseEntity.ok(ReserveStockResponse.from(result));
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/StockController.java
@@ -1,6 +1,7 @@
 package com.rushcrew.timedeal.presentation;
 
 import com.rushcrew.timedeal.application.command.CreateStockCommand;
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
 import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
 import com.rushcrew.timedeal.application.result.StockResult;
@@ -8,6 +9,7 @@ import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
+import com.rushcrew.timedeal.presentation.dto.request.RestoreStockRequest;
 import com.rushcrew.timedeal.presentation.dto.request.UpdateStockCountRequest;
 import com.rushcrew.timedeal.presentation.dto.response.CreateStockResponse;
 import com.rushcrew.timedeal.presentation.dto.response.StockResponse;
@@ -81,6 +83,15 @@ public class StockController {
         @PathVariable UUID stockId
     ) {
         stockService.deleteStock(stockId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/restore")
+    public ResponseEntity<Void> restoreStock(
+        @RequestBody @Valid RestoreStockRequest request
+    ) {
+        RestoreStockCommand command = request.toCommand();
+        stockService.restoreStock(command);
         return ResponseEntity.noContent().build();
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/ReserveStockRequest.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/ReserveStockRequest.java
@@ -1,0 +1,31 @@
+package com.rushcrew.timedeal.presentation.dto.request;
+
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record ReserveStockRequest(
+    @NotNull
+    UUID orderId,
+
+    @NotNull
+    UUID timeDealStockId,
+
+    @NotNull
+    Long quantity,
+
+    @NotNull
+    Long userId
+) {
+
+    public ReserveStockCommand toCommand() {
+        return new ReserveStockCommand(
+            OrderId.of(this.orderId),
+            this.timeDealStockId,
+            Quantity.positive(this.quantity),
+            this.userId
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/RestoreStockRequest.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/request/RestoreStockRequest.java
@@ -1,0 +1,34 @@
+package com.rushcrew.timedeal.presentation.dto.request;
+
+import com.rushcrew.timedeal.application.command.RestoreStockCommand;
+import com.rushcrew.timedeal.domain.vo.OrderId;
+import com.rushcrew.timedeal.domain.vo.Quantity;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record RestoreStockRequest(
+    @NotNull
+    UUID timeDealStockId,
+
+    @NotNull
+    @Min(value = 1)
+    Long quantity,
+
+    @NotNull
+    UUID orderId,
+
+    @NotBlank
+    String reason
+) {
+
+    public RestoreStockCommand toCommand() {
+        return new RestoreStockCommand(
+            this.timeDealStockId,
+            Quantity.positive(this.quantity),
+            OrderId.of(this.orderId),
+            this.reason
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/ReserveStockResponse.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/ReserveStockResponse.java
@@ -1,0 +1,18 @@
+package com.rushcrew.timedeal.presentation.dto.response;
+
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
+
+public record ReserveStockResponse(
+    boolean success,
+    Integer availableStock,
+    String message
+) {
+
+    public static ReserveStockResponse from(ReserveStockResult result) {
+        return new ReserveStockResponse(
+            result.success(),
+            result.availableStock(),
+            result.message()
+        );
+    }
+}

--- a/timedeal-service/src/main/resources/application.yaml
+++ b/timedeal-service/src/main/resources/application.yaml
@@ -23,6 +23,8 @@ spring:
   sql:
     init:
       mode: always
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
 
 server:
   port: 8030


### PR DESCRIPTION
## 🧾 Summary
- 재고 예약 기능 구현
- Kafka consumer 설정
- 캐시 업데이트 로직 이벤트 기반으로 분리
- 낙관락 충돌 시 자동 재시도 로직 추가

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [ ] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #149 
