### PR TITLE
Feat(queue): 주문 <-> 대기열 통신 연동 및 kafka 설정

### DIFF
--- a/queue-service/build.gradle
+++ b/queue-service/build.gradle
@@ -20,6 +20,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.20.0'
 
+	// Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	// Eureka 클라이언트
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/TokenRemoveEvent.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/TokenRemoveEvent.java
@@ -1,0 +1,18 @@
+package com.rushcrew.queue.application.port.in;
+
+import java.util.UUID;
+
+/**
+ * 토큰 삭제 이벤트
+ * Order Service와 Queue Service가 서로 주고받을 메시지 규격
+ * @param productId
+ * @param token
+ * @param userId
+ */
+public record TokenRemoveEvent(
+    UUID productId,
+    String token,
+    Long userId
+) {
+
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueuePolicyService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueuePolicyService.java
@@ -109,10 +109,10 @@ public class QueuePolicyService implements QueuePolicyPort {
         // 권한 유효성 검사
         queuePolicyValidator.validateMasterRole(userId, role);
         QueuePolicy queuePolicy = getQueuePolicy(policyId);
-        queuePolicy.update(queuePolicy.getTimeDealName(),
-            queuePolicy.getStatus(),
-            queuePolicy.getTimePeriod(),
-            queuePolicy.getTrafficSetting());
+        queuePolicy.update(command.timeDealName(),
+            command.status(),
+            command.timePeriod(),
+            command.trafficSetting());
         return QueuePolicyQueryResponse.from(queuePolicy);
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -56,18 +56,8 @@ public class QueueService implements QueuePort {
             throw new BusinessException(QueueErrorCode.USER_ALREADY_IN_WAITING_QUEUE);
         }
 
-        // 현재 순번 조회
-        Long waitingRank = queueRepository.getWaitingRank(command.productId(), queueToken.getId());
-        // 요청시간 LocalDateTime 타입으로 변환
-        LocalDateTime enteredAt = convertLocalDateTime(queueToken.getRequestTime());
-
-        return QueueRedisResponse.builder()
-            .token(queueToken.getId().getValue())
-            .productId(queueToken.getProductId())
-            .rank(waitingRank)
-            .status(queueToken.getStatus())
-            .enteredAt(enteredAt)
-            .build();
+        String tokenValue = queueToken.getId().getValue().toString();
+        return getQueueRank(command.productId(), tokenValue, command.userId(), command.role());
     }
 
     /**

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -44,7 +44,7 @@ public class QueueService implements QueuePort {
     public QueueRedisResponse enterQueue(EnterQueueCommand command) {
         // 대기열 정책 확인 (RDB 조회 - 상품 존재 여부 및 시간 확인)
         QueuePolicy policy = queuePolicyRepository.findByProductId(command.productId())
-            .orElseThrow(() -> new NoSuchElementException("타임딜이 운영되지 않는 상품입니다."));
+            .orElseThrow(() -> new BusinessException(QueueErrorCode.NO_TIMEDEAL_PRODUCT));
 
         QueueToken queueToken = QueueToken.create(command.productId(), command.userId());
 

--- a/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/util/QueueScheduler.java
@@ -1,247 +1,260 @@
-package com.rushcrew.queue.application.util;
+    package com.rushcrew.queue.application.util;
 
-import com.rushcrew.common.exception.BusinessException;
-import com.rushcrew.queue.application.port.in.QueuePort;
-import com.rushcrew.queue.domain.entity.QueuePolicy;
-import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
-import com.rushcrew.queue.domain.vo.TrafficSetting;
-import java.lang.reflect.Executable;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-import java.util.concurrent.CopyOnWriteArrayList;
+    import com.rushcrew.common.exception.BusinessException;
+    import com.rushcrew.queue.application.port.in.QueuePort;
+    import com.rushcrew.queue.domain.entity.QueuePolicy;
+    import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
+    import com.rushcrew.queue.domain.vo.TrafficSetting;
+    import java.lang.reflect.Executable;
+    import java.time.LocalDateTime;
+    import java.util.List;
+    import java.util.UUID;
+    import java.util.concurrent.TimeUnit;
+    import lombok.extern.slf4j.Slf4j;
+    import org.redisson.api.RLock;
+    import org.redisson.api.RedissonClient;
+    import org.springframework.data.redis.core.RedisTemplate;
+    import org.springframework.scheduling.annotation.Scheduled;
+    import org.springframework.stereotype.Component;
+    import java.util.concurrent.CopyOnWriteArrayList;
 
-@Slf4j
-@Component
-public class QueueScheduler {
-    private final QueuePolicyRepository queuePolicyRepository;
-    private final QueuePort queueService;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final RedissonClient redissonClient;
+    @Slf4j
+    @Component
+    public class QueueScheduler {
+        private final QueuePolicyRepository queuePolicyRepository;
+        private final QueuePort queueService;
+        private final RedisTemplate<String, String> redisTemplate;
+        private final RedissonClient redissonClient;
 
-    // DB 부하를 줄이기 위한 인메모리 캐시 (스레드 세이프)
-    private final List<QueuePolicy> cachedPolicies = new CopyOnWriteArrayList<>();
+        // DB 부하를 줄이기 위한 인메모리 캐시 (스레드 세이프)
+        private final List<QueuePolicy> cachedPolicies = new CopyOnWriteArrayList<>();
 
-    // 마지막 실행 시간 기록 Redis 키
-    private static final String LAST_RUN_KEY = "queue:scheduler:last_run:%s";
-    // 락 키
-    private static final String LOCK_KEY = "lock:scheduler:product:%s";
+        // 마지막 실행 시간 기록 Redis 키
+        private static final String LAST_RUN_KEY = "queue:scheduler:last_run:%s";
+        // 락 키
+        private static final String LOCK_KEY = "lock:scheduler:product:%s";
 
-    public QueueScheduler(QueuePolicyRepository queuePolicyRepository, QueuePort queueService,
-        RedisTemplate<String, String> redisTemplate, RedissonClient redissonClient) {
-        this.queuePolicyRepository = queuePolicyRepository;
-        this.queueService = queueService;
-        this.redisTemplate = redisTemplate;
-        this.redissonClient = redissonClient;
-    }
+        public QueueScheduler(QueuePolicyRepository queuePolicyRepository, QueuePort queueService,
+            RedisTemplate<String, String> redisTemplate, RedissonClient redissonClient) {
+            this.queuePolicyRepository = queuePolicyRepository;
+            this.queueService = queueService;
+            this.redisTemplate = redisTemplate;
+            this.redissonClient = redissonClient;
+        }
 
-    /**
-     * [Refresher] 정책 캐시 갱신 (주기: 1분)
-     * 역할: DB에서 "현재 진행 중"이거나 "곧 시작(1분 내)할" 정책을 미리 가져옴
-     * 목적: DB 조회 횟수를 획기적으로 줄임 (1분 1회)
-     */
-    @Scheduled(fixedRate = 60000)
-    public void refreshPolicies() {
-        try {
+        /**
+         * [Refresher] 정책 캐시 갱신 (주기: 1분)
+         * 역할: DB에서 "현재 진행 중"이거나 "곧 시작(1분 내)할" 정책을 미리 가져옴
+         * 목적: DB 조회 횟수를 획기적으로 줄임 (1분 1회)
+         */
+        @Scheduled(fixedRate = 60000)
+        public void refreshPolicies() {
+            try {
+                LocalDateTime now = LocalDateTime.now();
+                LocalDateTime oneMinuteLater = now.plusMinutes(1);
+
+                // 현재 유효한(진행 중인) 타임딜 정책 조회
+                // TODO: RDB 부하가 걱정된다면 이 목록을 Redis에 캐싱
+                List<QueuePolicy> allActivePolicies = queuePolicyRepository.findAllActivePolicies(now,
+                    oneMinuteLater);
+
+                // 새 리스트로 교체 (원자적 작업)
+                List<QueuePolicy> newPolicies = new CopyOnWriteArrayList<>(allActivePolicies);
+
+                // 캐시 교체 (CopyOnWriteArrayList는 참조 교체 시 스레드 세이프)
+                cachedPolicies.clear();
+                cachedPolicies.addAll(newPolicies);
+                log.info("[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: {})", allActivePolicies.size());
+            } catch (Exception e) {
+                // SQLException 터지면 스케줄링이 전부 중단될 수 있으므로 기존 캐시를 유지하여 서비스가 계속 운영되도록 함
+                // 기존 캐시로 계속 운영 (장애 시에도 서비스 유지. 스케줄러 영구 중단 방지)
+                log.error("[Scheduler:Refresher] 정책 캐시 갱신 실패 - 기존 캐시 유지", e);
+            }
+        }
+
+        /**
+         * 타임딜 활성화 스케줄러
+         * 동적 스케줄러 (Ticker)
+         * 1초(queueGap의 최소값) 주기로 실행하며 각 정책의 queueGap을 체크합니다.
+         * 진행 중인 타임딜을 찾아 각자의 queueGap 주기에 맞춰 활성화를 요청함
+         * DB I/O 없음 (위에 refreshPolicies에서 1분마다 캐시 갱신해줌)
+         */
+        @Scheduled(fixedDelay = 1000)
+        public void scheduleActivation() {
+            if (cachedPolicies.isEmpty()) {
+                return;
+            }
+
             LocalDateTime now = LocalDateTime.now();
-            LocalDateTime oneMinuteLater = now.plusMinutes(1);
 
-            // 현재 유효한(진행 중인) 타임딜 정책 조회
-            // TODO: RDB 부하가 걱정된다면 이 목록을 Redis에 캐싱
-            List<QueuePolicy> allActivePolicies = queuePolicyRepository.findAllActivePolicies(now,
-                oneMinuteLater);
-
-            // 새 리스트로 교체 (원자적 작업)
-            List<QueuePolicy> newPolicies = new CopyOnWriteArrayList<>(allActivePolicies);
-
-            // 캐시 교체 (CopyOnWriteArrayList는 참조 교체 시 스레드 세이프)
-            cachedPolicies.clear();
-            cachedPolicies.addAll(newPolicies);
-            log.info("[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: {})", allActivePolicies.size());
-        } catch (Exception e) {
-            // SQLException 터지면 스케줄링이 전부 중단될 수 있으므로 기존 캐시를 유지하여 서비스가 계속 운영되도록 함
-            // 기존 캐시로 계속 운영 (장애 시에도 서비스 유지. 스케줄러 영구 중단 방지)
-            log.error("[Scheduler:Refresher] 정책 캐시 갱신 실패 - 기존 캐시 유지", e);
-        }
-    }
-
-    /**
-     * 타임딜 활성화 스케줄러
-     * 동적 스케줄러 (Ticker)
-     * 1초(queueGap의 최소값) 주기로 실행하며 각 정책의 queueGap을 체크합니다.
-     * 진행 중인 타임딜을 찾아 각자의 queueGap 주기에 맞춰 활성화를 요청함
-     * DB I/O 없음 (위에 refreshPolicies에서 1분마다 캐시 갱신해줌)
-     */
-    @Scheduled(fixedDelay = 1000)
-    public void scheduleActivation() {
-        if (cachedPolicies.isEmpty()) {
-            return;
+            // 병렬 처리로 성능 개선 (상품별 독립 락이므로 안전)
+            cachedPolicies.parallelStream()
+                .filter(policy -> isWithinRunningTime(policy, now))
+                .forEach(this::processPolicyWithLock);
         }
 
-        LocalDateTime now = LocalDateTime.now();
+        /**
+         * 대기열 정책에서 대기열 진입 시간 확인 로직
+         */
+        private boolean isWithinRunningTime(QueuePolicy policy, LocalDateTime now) {
+            // "곧 시작(1분 내)할" 정책도 refreshPolicies 메서드에서 미리 가져왔으므로,
+            // 실제로 지금 시간이 시작 시간을 지났는지 메모리 상에서 체크
+            LocalDateTime startTime = policy.getTimePeriod().getStartTime();
+            LocalDateTime endTime = policy.getTimePeriod().getEndTime();
+            return (now.isEqual(startTime) || now.isAfter(startTime)) && now.isBefore(endTime);
+        }
 
-        // 병렬 처리로 성능 개선 (상품별 독립 락이므로 안전)
-        cachedPolicies.parallelStream()
-            .filter(policy -> isWithinRunningTime(policy, now))
-            .forEach(this::processPolicyWithLock);
-    }
+        /**
+         * 각 정책별로 활성화 로직 수행 (병렬 처리 가능)
+         * 각 상품별로 락을 걸고 실행 (다중 서버 돌리는 상황에서 중복 실행 방지)
+         * 락 획득 실패 시 즉시 반환 (다음 스케줄에서 재시도)
+         */
+        private void processPolicyWithLock(QueuePolicy queuePolicy) {
+            UUID productId = queuePolicy.getProductId();
 
-    /**
-     * 대기열 정책에서 대기열 진입 시간 확인 로직
-     */
-    private boolean isWithinRunningTime(QueuePolicy policy, LocalDateTime now) {
-        // "곧 시작(1분 내)할" 정책도 refreshPolicies 메서드에서 미리 가져왔으므로,
-        // 실제로 지금 시간이 시작 시간을 지났는지 메모리 상에서 체크
-        LocalDateTime startTime = policy.getTimePeriod().getStartTime();
-        LocalDateTime endTime = policy.getTimePeriod().getEndTime();
-        return (now.isEqual(startTime) || now.isAfter(startTime)) && now.isBefore(endTime);
-    }
+            String lockKey = getLockKey(productId);
+            // 락 키를 상품별로 생성하여 병렬 처리
+            RLock lock = redissonClient.getLock(lockKey);
 
-    /**
-     * 각 정책별로 활성화 로직 수행 (병렬 처리 가능)
-     * 각 상품별로 락을 걸고 실행 (다중 서버 돌리는 상황에서 중복 실행 방지)
-     * 락 획득 실패 시 즉시 반환 (다음 스케줄에서 재시도)
-     */
-    private void processPolicyWithLock(QueuePolicy queuePolicy) {
-        UUID productId = queuePolicy.getProductId();
+            try {
+                // tryLock(대기시간, 점유시간, 단위)
+                // waitTime = 0: 락을 못 잡으면 즉시 포기 (다른 서버가 하고 있겠거니 생각. 대기 X, 다음 턴에서)
+                // Scale-out(다중 서버) 상황에서 서버 A가 실행 중이면, 서버 B와 C는 1초 뒤(다음 스케줄링)에 다시 시도하면 되므로 굳이 기다릴 필요X
+                // (Thread Blocking 방지)
 
-        String lockKey = getLockKey(productId);
-        // 락 키를 상품별로 생성하여 병렬 처리
-        RLock lock = redissonClient.getLock(lockKey);
+                // leaseTime = 3초: 3초 뒤엔 락 자동 반납 (서버가 죽었을 때 데드락 방지)
+                // 스케줄러 주기가 1초이므로 leaseTime은 1~3초 정도로 짧게 설정
+                boolean isLocked = lock.tryLock(0, 3, TimeUnit.SECONDS);
 
-        try {
-            // tryLock(대기시간, 점유시간, 단위)
-            // waitTime = 0: 락을 못 잡으면 즉시 포기 (다른 서버가 하고 있겠거니 생각. 대기 X, 다음 턴에서)
-            // Scale-out(다중 서버) 상황에서 서버 A가 실행 중이면, 서버 B와 C는 1초 뒤(다음 스케줄링)에 다시 시도하면 되므로 굳이 기다릴 필요X
-            // (Thread Blocking 방지)
+                if (!isLocked) {
+                    // 이미 다른 서버가 실행 중임 -> 패스
+                    log.info("[Scheduler] 락 획득 패스 - 이미 다른 서버가 실행 중");
+                    return;
+                }
 
-            // leaseTime = 3초: 3초 뒤엔 락 자동 반납 (서버가 죽었을 때 데드락 방지)
-            // 스케줄러 주기가 1초이므로 leaseTime은 1~3초 정도로 짧게 설정
-            boolean isLocked = lock.tryLock(0, 3, TimeUnit.SECONDS);
+                log.info("[Scheduler] 락 획득 성공 - 상품 활성화 진행");
 
-            if (!isLocked) {
-                // 이미 다른 서버가 실행 중임 -> 패스
-                return;
-            }
+                // ==========================================
+                // [TEST] 동시성 테스트를 위해 강제로 2초 멈춤!
+                // 이 코드가 있어야 뒤따라온 요청들이 "어? 락이 걸려있네?" 하고 튕겨나감
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                // ==========================================
 
-            // 락 획득 성공
-            TrafficSetting setting = queuePolicy.getTrafficSetting();
-            // 대기열 -> 활성열로 이동 주기
-            int queueGap = setting.getQueueGap();
+                // 락 획득 성공
+                TrafficSetting setting = queuePolicy.getTrafficSetting();
+                // 대기열 -> 활성열로 이동 주기
+                int queueGap = setting.getQueueGap();
 
-            // Redis에 기록된 마지막 실행 시간 체크 (실행 가능 여부 검사)
-            if (!canExecute(productId, queueGap)) {
-                return;
-            }
+                // Redis에 기록된 마지막 실행 시간 체크 (실행 가능 여부 검사)
+                if (!canExecute(productId, queueGap)) {
+                    return;
+                }
 
-            // 실행 시간 먼저 갱신 (중복 실행 방지)
-            long executionTime = System.currentTimeMillis();
-            updateLastExecutionTime(productId, executionTime);
+                // 실행 시간 먼저 갱신 (중복 실행 방지)
+                long executionTime = System.currentTimeMillis();
+                updateLastExecutionTime(productId, executionTime);
 
-            // 대기열 -> 활성열 이동 요청
-            activateTokens(productId, executionTime, setting);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("[Scheduler] 락 획득 중 인터럽트 발생", e);
-        } catch (Exception e) {
-            log.error("[Scheduler] 상품({}) 활성화 중 에러 발생", productId, e);
-        } finally {
-            // 내가 건 락인 경우에만 해제
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
+                // 대기열 -> 활성열 이동 요청
+                activateTokens(productId, executionTime, setting);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("[Scheduler] 락 획득 중 인터럽트 발생", e);
+            } catch (Exception e) {
+                log.error("[Scheduler] 상품({}) 활성화 중 에러 발생", productId, e);
+            } finally {
+                // 내가 건 락인 경우에만 해제
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
             }
         }
-    }
 
-    /**
-     * 대기열 토큰 활성열 이동 처리 (토큰 활성화)
-     * 토큰 활성화 실패 시 마지막 실행 시간(lastExecutionTime) 롤백
-     * TODO: 추후 모니터링 추가 필요
-     */
-    private void activateTokens(UUID productId, long executionTime, TrafficSetting setting) {
-        try {
-            boolean success = queueService.activateTokens(productId, setting);
+        /**
+         * 대기열 토큰 활성열 이동 처리 (토큰 활성화)
+         * 토큰 활성화 실패 시 마지막 실행 시간(lastExecutionTime) 롤백
+         * TODO: 추후 모니터링 추가 필요
+         */
+        private void activateTokens(UUID productId, long executionTime, TrafficSetting setting) {
+            try {
+                boolean success = queueService.activateTokens(productId, setting);
 
-            if (!success) {
-                // activateTokens 실패 시 실행 시간 롤백
-                log.warn("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId);
-                // 예외를 다시 던지지 않음 (다음 스케줄에서 재시도하도록)
+                if (!success) {
+                    // activateTokens 실패 시 실행 시간 롤백
+                    log.warn("[Scheduler] 상품({}) 활성화 실패 - 실행 시간 롤백", productId);
+                    // 예외를 다시 던지지 않음 (다음 스케줄에서 재시도하도록)
+                    rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
+                    return;
+                }
+                log.info("[Scheduler] 상품({}) 활성화 완료", productId);
+            } catch (Exception e) {
+                // 실제 에러 (Redis 장애, DB 장애 등)
+                log.error("[Scheduler] 상품({}) 활성화 중 예외 발생 - 실행 시간 롤백", productId, e);
                 rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
-                return;
             }
-            log.info("[Scheduler] 상품({}) 활성화 완료", productId);
-        } catch (Exception e) {
-            // 실제 에러 (Redis 장애, DB 장애 등)
-            log.error("[Scheduler] 상품({}) 활성화 중 예외 발생 - 실행 시간 롤백", productId, e);
-            rollbackLastExecutionTime(productId, executionTime, setting.getQueueGap());
         }
-    }
 
-    /**
-     * activateTokens 실패 시 실행 시간 롤백
-     * queueGap 시간만큼 이전으로 되돌려 다음 스케줄에서 재시도 가능하도록 함
-     */
-    private void rollbackLastExecutionTime(UUID productId, long executionTime, Integer queueGap) {
-        try {
+        /**
+         * activateTokens 실패 시 실행 시간 롤백
+         * queueGap 시간만큼 이전으로 되돌려 다음 스케줄에서 재시도 가능하도록 함
+         */
+        private void rollbackLastExecutionTime(UUID productId, long executionTime, Integer queueGap) {
+            try {
+                String lastRunKey = getLastRunKey(productId);
+                // queueGap 시간만큼 되돌려서 다음 스케줄에서 재시도 가능하도록
+                long rollbackTime = executionTime - (queueGap * 1000L);
+                redisTemplate.opsForValue().set(
+                    lastRunKey,
+                    String.valueOf(rollbackTime)
+                );
+                log.info("[Scheduler] 상품({}) 실행 시간 롤백 완료", productId);
+            } catch (BusinessException e) {
+                log.error("[Scheduler] 상품({}) 실행 시간 롤백 실패 - 수동 개입 필요", productId, e);
+                // TODO: 추후 따로 알림 보내는 형식으로의 조치가 필요
+            }
+        }
+
+        /**
+         * 해당 상품의 스케줄러 실행 자격이 있는지 검사
+         * 조건: (현재시간 - 마지막실행시간) >= queueGap
+         */
+        private boolean canExecute(UUID productId, int queueGap) {
+            try {
+                String lastRunKey = getLastRunKey(productId);
+                String lastRunTimeStr = redisTemplate.opsForValue().get(lastRunKey);
+
+                // 첫 시작에는 true
+                if (lastRunTimeStr == null) return true;
+
+                long lastRunTime = Long.parseLong(lastRunTimeStr);
+                long currentTime = System.currentTimeMillis();
+                long diffMillis = currentTime - lastRunTime;
+
+                // 밀리초 단위로 비교 (초 단위보다 정밀)
+                return diffMillis >= (queueGap * 1000L);
+            } catch (Exception e) {
+                log.error("[Scheduler] Redis 조회 실패 (상품: {}) - 다음 스케줄링에서 재시도", productId, e);
+                // Redis 조회 실패 시 false 반환 (다음 스케줄에서 재시도)
+                return false;
+            }
+        }
+
+        /**
+         * 마지막 실행 시간 갱신
+         */
+        private void updateLastExecutionTime(UUID productId, long executionTime) {
             String lastRunKey = getLastRunKey(productId);
-            // queueGap 시간만큼 되돌려서 다음 스케줄에서 재시도 가능하도록
-            long rollbackTime = executionTime - (queueGap * 1000L);
-            redisTemplate.opsForValue().set(
-                lastRunKey,
-                String.valueOf(rollbackTime)
-            );
-            log.info("[Scheduler] 상품({}) 실행 시간 롤백 완료", productId);
-        } catch (BusinessException e) {
-            log.error("[Scheduler] 상품({}) 실행 시간 롤백 실패 - 수동 개입 필요", productId, e);
-            // TODO: 추후 따로 알림 보내는 형식으로의 조치가 필요
+            redisTemplate.opsForValue().set(lastRunKey, String.valueOf(executionTime));
+        }
+
+        private String getLastRunKey(UUID productId) {
+            return String.format(LAST_RUN_KEY, productId);
+        }
+
+        private String getLockKey(UUID productId) {
+            return String.format(LOCK_KEY, productId);
         }
     }
-
-    /**
-     * 해당 상품의 스케줄러 실행 자격이 있는지 검사
-     * 조건: (현재시간 - 마지막실행시간) >= queueGap
-     */
-    private boolean canExecute(UUID productId, int queueGap) {
-        try {
-            String lastRunKey = getLastRunKey(productId);
-            String lastRunTimeStr = redisTemplate.opsForValue().get(lastRunKey);
-
-            // 첫 시작에는 true
-            if (lastRunTimeStr == null) return true;
-
-            long lastRunTime = Long.parseLong(lastRunTimeStr);
-            long currentTime = System.currentTimeMillis();
-            long diffMillis = currentTime - lastRunTime;
-
-            // 밀리초 단위로 비교 (초 단위보다 정밀)
-            return diffMillis >= (queueGap * 1000L);
-        } catch (Exception e) {
-            log.error("[Scheduler] Redis 조회 실패 (상품: {}) - 다음 스케줄링에서 재시도", productId, e);
-            // Redis 조회 실패 시 false 반환 (다음 스케줄에서 재시도)
-            return false;
-        }
-    }
-
-    /**
-     * 마지막 실행 시간 갱신
-     */
-    private void updateLastExecutionTime(UUID productId, long executionTime) {
-        String lastRunKey = getLastRunKey(productId);
-        redisTemplate.opsForValue().set(lastRunKey, String.valueOf(executionTime));
-    }
-
-    private String getLastRunKey(UUID productId) {
-        return String.format(LAST_RUN_KEY, productId);
-    }
-
-    private String getLockKey(UUID productId) {
-        return String.format(LOCK_KEY, productId);
-    }
-}

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -16,7 +16,8 @@ public enum QueueErrorCode implements ErrorCode {
     NO_TOKEN_TO_ACTIVATE(HttpStatus.SERVICE_UNAVAILABLE, "NO_TOKEN_TO_ACTIVATE", "활성 큐로 이동시킬 토큰이 없습니다."),
     USER_ALREADY_IN_WAITING_QUEUE(HttpStatus.CONFLICT, "USER_ALREADY_IN_WAITING_QUEUE", "이미 대기열에 등록된 사용자입니다."),
     TOKEN_OWNER_NOT_MATCH(HttpStatus.NOT_FOUND, "TOKEN_OWNER_NOT_MATCH", "토큰 소유자가 일치하지 않습니다."),
-    QUEUE_TOKEN_EXPIRED(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_TOKEN_EXPIRED", "대기열에 존재하지 않는 만료 토큰입니다.")
+    QUEUE_TOKEN_EXPIRED(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_TOKEN_EXPIRED", "대기열에 존재하지 않는 만료 토큰입니다."),
+    NO_TIMEDEAL_PRODUCT(HttpStatus.NOT_FOUND, "NO_TIMEDEAL_PRODUCT", "타임딜이 운영되지 않는 상품입니다.")
 
 
 

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/enums/QueueStatus.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/enums/QueueStatus.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 
 @Getter
 public enum QueueStatus {
-    WAITING("대기"),   // 대기열 진입 (Redis Sorted Set)
-    ACTIVE("입장가능"), // 입장 가능 (Set)
-    EXPIRED("만료"); // 만료
+    WAITING("WAITING"),   // 대기열 진입 (Redis Sorted Set)
+    ACTIVE("ACTIVE"), // 입장 가능 (Set)
+    EXPIRED("EXPIRED"); // 만료
 
     private final String description;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/vo/TrafficSetting.java
@@ -47,6 +47,7 @@ public class TrafficSetting {
         if (ttl == null || ttl <= 60) {
             throw new IllegalArgumentException("TTL은 최소 60초 이상이어야 합니다.");
         }
+        this.maxCapacity = maxCapacity;
         this.limitSize = limitSize;
         this.queueGap = queueGap;
         this.ttl = ttl;

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,25 @@
+package com.rushcrew.queue.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaConfig {
+
+    public static final String ORDER_COMPLETE_TOPIC = "order-complete-token-remove";
+
+    /**
+     * 애플리케이션 로딩 시점에 'order-complete-token-remove' 토픽이 없으면 자동 생성
+     * partitions(1): 순서 보장이 중요하다면 1, 병렬 처리가 중요하면 늘림 (MVP는 1 추천)
+     * replicas(1): 로컬 단일 브로커이므로 1
+     */
+    @Bean
+    public NewTopic orderCompleteTopic() {
+        return TopicBuilder.name(ORDER_COMPLETE_TOPIC)
+            .partitions(1)
+            .replicas(1)
+            .build();
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
@@ -28,6 +29,9 @@ public class KafkaConsumerConfig {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String kafkaServer;
+
     public KafkaConsumerConfig(KafkaTemplate<String, Object> kafkaTemplate) {
         this.kafkaTemplate = kafkaTemplate;
     }
@@ -40,12 +44,56 @@ public class KafkaConsumerConfig {
     public ConsumerFactory<String, QueueEventConsumer> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         // 로컬 환경: localhost:9092 / Docker 내부 통신: kafka:29092
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "queue-service-group");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지 신뢰 (JSON 파싱 신뢰 패키지 설정)
         return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(),
             new JsonDeserializer<>(QueueEventConsumer.class, false));
+    }
+
+    /**
+     * 리스너 컨테이너 팩토리 (에러 핸들러 적용)
+     * 여기서 재시도(Retry) 및 DLQ(Dead Letter Queue) 전략 주입
+     */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, QueueEventConsumer> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, QueueEventConsumer> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // 수동 커밋 사용 시 설정 (Listener에서 Acknowledgment 사용 시 필요)
+        factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
+
+        // 에러 핸들러 설정 (재시도 + DLQ)
+        factory.setCommonErrorHandler(errorHandler());
+        return factory;
+    }
+
+    /**
+     * Kafka 에러 핸들러 처리
+     * 1. 재시도(Retry): 1초 간격으로 최대 3회 재시도 (FixedBackOff)
+     * 2. 복구 전략 - DLQ 이동: 3회 실패 시 '토픽명.DLT'로 메시지 이동 (Dead Letter Topic)
+     */
+    @Bean
+    public CommonErrorHandler errorHandler() {
+        // DLT 발행자: 실패한 메시지를 '원본토픽명.DLT'로 자동 발행
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
+            (record, ex) -> {
+                log.error("[QUEUE:Kafka:DLQ] 3회 재시도 실패, DLQ로 이동합니다. TOPIC: {}, Value: {}",
+                    record.topic(), record.value());
+                return new TopicPartition(record.topic() + ".DLT", record.partition());
+            });
+
+        // 백오프(재시도) 전략: 1000ms(1초) 간격으로 대기 후 재시도, 최대 3번
+        // (총 3번 실행 후 실패하면 Recoverer 실행)
+        FixedBackOff backOff = new FixedBackOff(1000L, 3L);
+        // 에러 핸들러 생성
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+
+        // 재시도할 필요 없는 치명적 예외는 바로 DLT로 보냄 (예: JSON 파싱 에러)
+        errorHandler.addNotRetryableExceptions(IllegalArgumentException.class);
+        return errorHandler;
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
@@ -6,8 +6,11 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,13 +18,16 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.util.backoff.FixedBackOff;
 
 @Slf4j
@@ -29,13 +35,30 @@ import org.springframework.util.backoff.FixedBackOff;
 @Configuration
 public class KafkaConsumerConfig {
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
-
     @Value("${spring.kafka.bootstrap-servers}")
     private String kafkaServer;
 
-    public KafkaConsumerConfig(KafkaTemplate<String, Object> kafkaTemplate) {
-        this.kafkaTemplate = kafkaTemplate;
+    /**
+     * KafkaTemplate 설정
+     * Json 직렬화 가능한 ProducerFactory 사용
+     */
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    /**
+     * Producer Factory 설정
+     * DLQ로 메시지를 보낼 때(Produce), 자바 객체를 JSON으로 직렬화하기 위해 필요함
+     */
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        // value 보낼 때 JsonSerializer 사용하도록 설정
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(props);
     }
 
     /**
@@ -91,7 +114,7 @@ public class KafkaConsumerConfig {
     @Bean
     public CommonErrorHandler errorHandler() {
         // DLT 발행자: 실패한 메시지를 '원본토픽명.DLT'로 자동 발행
-        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate(),
             (record, ex) -> {
                 log.error("[QUEUE:Kafka:DLQ] 3회 재시도 실패, DLQ로 이동합니다. TOPIC: {}, Value: {}",
                     record.topic(), record.value());

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
@@ -1,5 +1,6 @@
 package com.rushcrew.queue.infrastructure.config;
 
+import com.rushcrew.queue.application.port.in.TokenRemoveEvent;
 import com.rushcrew.queue.infrastructure.kafka.consumer.QueueEventConsumer;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +20,7 @@ import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.util.backoff.FixedBackOff;
 
@@ -41,16 +43,26 @@ public class KafkaConsumerConfig {
      * JSON 메시지 어떻게 역직렬화할지 정의
      */
     @Bean
-    public ConsumerFactory<String, QueueEventConsumer> consumerFactory() {
+    public ConsumerFactory<String, TokenRemoveEvent> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         // 로컬 환경: localhost:9092 / Docker 내부 통신: kafka:29092
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "queue-service-group");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지 신뢰 (JSON 파싱 신뢰 패키지 설정)
-        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(),
-            new JsonDeserializer<>(QueueEventConsumer.class, false));
+
+        // JSON 역직렬화 설정
+        JsonDeserializer<TokenRemoveEvent> deserializer = new JsonDeserializer<>(TokenRemoveEvent.class);
+        deserializer.setRemoveTypeHeaders(false);
+        deserializer.addTrustedPackages("*"); // 모든 패키지 신뢰
+        deserializer.setUseTypeMapperForKey(true);
+
+        // ErrorHandlingDeserializer: 역직렬화 실패 시 무한 루프 방지
+        return new DefaultKafkaConsumerFactory<>(
+            props,
+            new StringDeserializer(),
+            new ErrorHandlingDeserializer<>(deserializer)
+        );
     }
 
     /**
@@ -58,8 +70,8 @@ public class KafkaConsumerConfig {
      * 여기서 재시도(Retry) 및 DLQ(Dead Letter Queue) 전략 주입
      */
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, QueueEventConsumer> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, QueueEventConsumer> factory =
+    public ConcurrentKafkaListenerContainerFactory<String, TokenRemoveEvent> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, TokenRemoveEvent> factory =
             new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
 

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,51 @@
+package com.rushcrew.queue.infrastructure.config;
+
+import com.rushcrew.queue.infrastructure.kafka.consumer.QueueEventConsumer;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Slf4j
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public KafkaConsumerConfig(KafkaTemplate<String, Object> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    /**
+     * 컨슈머 팩토리 설정
+     * JSON 메시지 어떻게 역직렬화할지 정의
+     */
+    @Bean
+    public ConsumerFactory<String, QueueEventConsumer> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        // 로컬 환경: localhost:9092 / Docker 내부 통신: kafka:29092
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "queue-service-group");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 모든 패키지 신뢰 (JSON 파싱 신뢰 패키지 설정)
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(),
+            new JsonDeserializer<>(QueueEventConsumer.class, false));
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -1,0 +1,46 @@
+package com.rushcrew.queue.infrastructure.kafka.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.queue.application.port.in.TokenRemoveEvent;
+import com.rushcrew.queue.application.service.QueueService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class QueueEventConsumer {
+
+    private final QueueService queueService;
+    private final ObjectMapper objectMapper;
+
+    public QueueEventConsumer(QueueService queueService, ObjectMapper objectMapper) {
+        this.queueService = queueService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 주문 완료 시 발행되는 토큰 만료 요청 이벤트를 수신
+     * Topic: queue-token-remove-topic
+     */
+    @KafkaListener(topics = "queue-token-remove-topic", groupId = "queue-service-group")
+    public void consumeTokenRemoveEvent(String message) {
+        try {
+            log.info("[QUEUE:Kafka:Consume] 토큰 삭제 요청 수신: {}", message);
+
+            TokenRemoveEvent event = objectMapper.readValue(message, TokenRemoveEvent.class);
+
+            // 토큰 삭제 & 유저 인덱스 삭제
+            queueService.exitQueue(
+                event.productId(),
+                event.token(),
+                event.userId()
+            );
+            log.info("[QUEUE:Kafka:Success] 토큰 삭제 완료 - UserId: {}, ProductId: {}",
+                event.userId(), event.productId());
+        } catch (Exception e) {
+            log.error("[QUEUE:Kafka:Error] 토큰 만료 처리 중 오류 발생. Message: {}", message, e);
+            // 필요 시 Dead Letter Queue(DLQ)로 보내거나 재시도 로직 추가
+        }
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -26,6 +26,25 @@ public class QueueEventConsumer {
     public void consumeTokenRemoveEvent(TokenRemoveEvent event, Acknowledgment ack) {
         log.info("[QUEUE:Kafka:Consume] 토큰 삭제 요청 수신 - UserId: {}, Token: {}", event.userId(), event.token());
 
+        // [TEST] 재시도 로직 검증을 위한 강제 예외 발생 코드
+        // 처음 3번은 강제로 예외를 던져서 Retry가 동작하는지 확인
+        // 4번째 호출(Retry 소진 후 DLQ 가기 전 로직 확인용) 혹은 Config 설정에 따라 동작 확인
+        // 만약 DLQ(Dead Letter Queue) 이동까지 보고 싶다면 'if (currentCount <= 4)'로 변경
+
+//        int currentCount = retryCounter.incrementAndGet();
+//        1, 2, 3번째 시도까지는 고의로 에러를 냄 -> Kafka ErrorHandler가 잡아서 1초 뒤 재시도
+//        if (currentCount <= 3) {
+//            log.warn("[TEST] 강제 예외 발생! (시도 횟수: {}/3) - 재시도 로직이 동작해야 함", currentCount);
+//            throw new RuntimeException("테스트용 강제 예외입니다!");
+//        }
+//
+
+//        // 카운터 초기화 (다음 테스트를 위해)
+//        if (currentCount > 3) {
+//            retryCounter.set(0);
+//        }
+
+
         // 토큰 삭제 & 유저 인덱스 삭제
         // 여기서 예외 발생 시, try-catch가 없으므로 즉시 에러 핸들러로 넘어감 -> 재시도 시작
         queueService.exitQueue(

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -1,6 +1,7 @@
 package com.rushcrew.queue.infrastructure.kafka.consumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.application.port.in.TokenRemoveEvent;
 import com.rushcrew.queue.application.service.QueueService;
 import lombok.extern.slf4j.Slf4j;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class QueueEventConsumer {
 
-    private final QueueService queueService;
+    private final QueuePort queueService;
     private final ObjectMapper objectMapper;
 
     public QueueEventConsumer(QueueService queueService, ObjectMapper objectMapper) {
@@ -40,7 +41,7 @@ public class QueueEventConsumer {
                 event.userId(), event.productId());
         } catch (Exception e) {
             log.error("[QUEUE:Kafka:Error] 토큰 만료 처리 중 오류 발생. Message: {}", message, e);
-            // 필요 시 Dead Letter Queue(DLQ)로 보내거나 재시도 로직 추가
+            // 필요 시 (DLQ)로 보내거나 재시도 로직 추가
         }
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -1,11 +1,11 @@
 package com.rushcrew.queue.infrastructure.kafka.consumer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.application.port.in.TokenRemoveEvent;
 import com.rushcrew.queue.application.service.QueueService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -13,11 +13,9 @@ import org.springframework.stereotype.Component;
 public class QueueEventConsumer {
 
     private final QueuePort queueService;
-    private final ObjectMapper objectMapper;
 
-    public QueueEventConsumer(QueueService queueService, ObjectMapper objectMapper) {
+    public QueueEventConsumer(QueueService queueService) {
         this.queueService = queueService;
-        this.objectMapper = objectMapper;
     }
 
     /**
@@ -25,23 +23,23 @@ public class QueueEventConsumer {
      * Topic: order-complete-token-remove
      */
     @KafkaListener(topics = "order-complete-token-remove", groupId = "queue-service-group")
-    public void consumeTokenRemoveEvent(String message) {
-        try {
-            log.info("[QUEUE:Kafka:Consume] 토큰 삭제 요청 수신: {}", message);
+    public void consumeTokenRemoveEvent(TokenRemoveEvent event, Acknowledgment ack) {
+        log.info("[QUEUE:Kafka:Consume] 토큰 삭제 요청 수신 - UserId: {}, Token: {}", event.userId(), event.token());
 
-            TokenRemoveEvent event = objectMapper.readValue(message, TokenRemoveEvent.class);
+        // 토큰 삭제 & 유저 인덱스 삭제
+        // 여기서 예외 발생 시, try-catch가 없으므로 즉시 에러 핸들러로 넘어감 -> 재시도 시작
+        queueService.exitQueue(
+            event.productId(),
+            event.token(),
+            event.userId()
+        );
+        log.info("[QUEUE:Kafka:Success] 토큰 삭제 완료 - UserId: {}, ProductId: {}",
+            event.userId(), event.productId());
 
-            // 토큰 삭제 & 유저 인덱스 삭제
-            queueService.exitQueue(
-                event.productId(),
-                event.token(),
-                event.userId()
-            );
-            log.info("[QUEUE:Kafka:Success] 토큰 삭제 완료 - UserId: {}, ProductId: {}",
-                event.userId(), event.productId());
-        } catch (Exception e) {
-            log.error("[QUEUE:Kafka:Error] 토큰 만료 처리 중 오류 발생. Message: {}", message, e);
-            // 필요 시 (DLQ)로 보내거나 재시도 로직 추가
-        }
+        // 수동 커밋 실행 (성공 시에만)
+        // KafkaConsumerConfig에 AckMode.MANUAL_IMMEDIATE가 설정되어 있으므로 필수
+        ack.acknowledge();
+
+        log.info("[QUEUE:Kafka:Success] 토큰 삭제 완료 및 Offset 커밋 - UserId: {}", event.userId());
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -22,9 +22,9 @@ public class QueueEventConsumer {
 
     /**
      * 주문 완료 시 발행되는 토큰 만료 요청 이벤트를 수신
-     * Topic: queue-token-remove-topic
+     * Topic: order-complete-token-remove
      */
-    @KafkaListener(topics = "queue-token-remove-topic", groupId = "queue-service-group")
+    @KafkaListener(topics = "order-complete-token-remove", groupId = "queue-service-group")
     public void consumeTokenRemoveEvent(String message) {
         try {
             log.info("[QUEUE:Kafka:Consume] 토큰 삭제 요청 수신: {}", message);

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -164,7 +164,7 @@ public class RedisQueueRepository implements QueueRepository {
     public boolean isActivatedToken(UUID productId, TokenId tokenId) {
         // ZSet에서 Score(만료시간) 조회
         String activeKey = getActiveKey(productId);
-        Double expireTime = redisTemplate.opsForZSet().score(activeKey, tokenId.getValue());
+        Double expireTime = redisTemplate.opsForZSet().score(activeKey, tokenId.getValue().toString());
 
         // 활성열에 없음
         if (expireTime == null) return false;

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/scheduler/QueueScheduler.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/scheduler/QueueScheduler.java
@@ -1,11 +1,10 @@
-    package com.rushcrew.queue.application.util;
+    package com.rushcrew.queue.infrastructure.scheduler;
 
     import com.rushcrew.common.exception.BusinessException;
     import com.rushcrew.queue.application.port.in.QueuePort;
     import com.rushcrew.queue.domain.entity.QueuePolicy;
     import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
     import com.rushcrew.queue.domain.vo.TrafficSetting;
-    import java.lang.reflect.Executable;
     import java.time.LocalDateTime;
     import java.util.List;
     import java.util.UUID;

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
@@ -1,0 +1,60 @@
+package com.rushcrew.queue.presentation.controller;
+
+import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.queue.application.port.in.QueuePort;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/internal/queues")
+public class InternalQueueController {
+    private final QueuePort queueService;
+
+    // API Gateway에서 인증 후, USER ID와 ROLE을 헤더에 담아 전달
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+    private static final String QUEUE_TOKEN_HEADER = "X-Queue-Token";
+
+    public InternalQueueController(QueuePort queueService) {
+        this.queueService = queueService;
+    }
+
+    /**
+     * 토큰 유효성 검증 API (주문 진입 시 호출)
+     * 주문 요청 시 토큰 유효성 검증
+     * Order-Service 쪽에서 활성열에 등록된 토큰이 현재 ACTIVE 상태인지 유효성 검증 (내부 호출)
+     */
+    @GetMapping("/tokens/verify")
+    public ResponseEntity<ApiResponse<Boolean>> validateQueueToken(
+        @RequestParam UUID productId,
+        @RequestHeader(QUEUE_TOKEN_HEADER) String queueToken,
+        @RequestHeader(USER_ID_HEADER) Long currUserId,
+        @RequestHeader(USER_ROLE_HEADER) String role
+    ) {
+        boolean result = queueService.validateActivatedQueueToken(productId, queueToken, currUserId, role);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(result));
+    }
+
+    /**
+     * 대기열 취소/주문 완료 시 토큰 삭제 API
+     * 사용자가 대기 중 "취소" 버튼을 누르거나, 주문 프로세스가 끝나고 나갈 때 호출(Order-service가 호출)
+     */
+    @DeleteMapping("/{product-id}")
+    public ResponseEntity<ApiResponse<Void>> deleteQueueToken(
+        @PathVariable("product-id") UUID productId,
+        @RequestHeader(QUEUE_TOKEN_HEADER) String queueToken,
+        @RequestHeader(USER_ID_HEADER) Long currUserId,
+        @RequestHeader(USER_ROLE_HEADER) String role
+    ) {
+        queueService.exitQueue(productId, queueToken, currUserId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(null));
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
@@ -42,19 +42,4 @@ public class InternalQueueController {
         boolean result = queueService.validateActivatedQueueToken(productId, queueToken, currUserId, role);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(result));
     }
-
-    /**
-     * 대기열 취소/주문 완료 시 토큰 삭제 API
-     * 사용자가 대기 중 "취소" 버튼을 누르거나, 주문 프로세스가 끝나고 나갈 때 호출(Order-service가 호출)
-     */
-    @DeleteMapping("/{product-id}")
-    public ResponseEntity<ApiResponse<Void>> deleteQueueToken(
-        @PathVariable("product-id") UUID productId,
-        @RequestHeader(QUEUE_TOKEN_HEADER) String queueToken,
-        @RequestHeader(USER_ID_HEADER) Long currUserId,
-        @RequestHeader(USER_ROLE_HEADER) String role
-    ) {
-        queueService.exitQueue(productId, queueToken, currUserId);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(null));
-    }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/v1/internal/queues")
+@RequestMapping("/api/v1/internal/queues")
 public class InternalQueueController {
     private final QueuePort queueService;
 

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/InternalQueueController.java
@@ -39,7 +39,7 @@ public class InternalQueueController {
         @RequestHeader(USER_ID_HEADER) Long currUserId,
         @RequestHeader(USER_ROLE_HEADER) String role
     ) {
-        boolean result = queueService.validateActivatedQueueToken(productId, queueToken, currUserId, role);
+        boolean result = queueService.validateActivatedQueueToken(productId, queueToken);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(result));
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/SchedulerTestController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/SchedulerTestController.java
@@ -1,6 +1,6 @@
 package com.rushcrew.queue.presentation.controller;
 
-import com.rushcrew.queue.application.util.QueueScheduler;
+import com.rushcrew.queue.infrastructure.scheduler.QueueScheduler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/SchedulerTestController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/SchedulerTestController.java
@@ -1,0 +1,26 @@
+package com.rushcrew.queue.presentation.controller;
+
+import com.rushcrew.queue.application.util.QueueScheduler;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/test/scheduler")
+public class SchedulerTestController {
+
+    private final QueueScheduler queueScheduler;
+
+    public SchedulerTestController(QueueScheduler queueScheduler) {
+        this.queueScheduler = queueScheduler;
+    }
+
+    // 포스트맨에서 이 API를 호출하면 스케줄러 로직이 즉시 실행됨
+    @PostMapping("/activation")
+    public ResponseEntity<String> triggerActivation() {
+        queueScheduler.refreshPolicies();
+        queueScheduler.scheduleActivation();
+        return ResponseEntity.ok("스케줄러 수동 실행 요청됨");
+    }
+}

--- a/queue-service/src/main/resources/application.yaml
+++ b/queue-service/src/main/resources/application.yaml
@@ -52,3 +52,4 @@ eureka:
 
 server:
   port: 8011
+

--- a/queue-service/src/main/resources/application.yaml
+++ b/queue-service/src/main/resources/application.yaml
@@ -2,6 +2,15 @@ spring:
   application:
     name: queue-service
 
+  kafka:
+    bootstrap-servers: localhost:9092  # 로컬 개발 환경 기준 (Docker 내부 통신 시 kafka:29092)
+    consumer:
+      group-id: queue-service-group   # 컨슈머 그룹 ID (중요)
+      auto-offset-reset: latest       # 가장 최신 메시지부터 읽음
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      # JSON으로 받을거면 JsonDeserializer 사용 가능하지만, String으로 받아 직접 파싱하는게 디버깅에 유리함
+
   data:
     redis:
       host: localhost # Docker 환경이라면 컨테이너 이름 또는 IP

--- a/queue-service/src/main/resources/application.yaml
+++ b/queue-service/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ spring:
     consumer:
       group-id: queue-service-group   # 컨슈머 그룹 ID (중요)
       auto-offset-reset: latest       # 가장 최신 메시지부터 읽음
+      spring.json.trusted.packages: "*" # 모든 패키지의 객체를 신뢰하고 역직렬화 허용
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       # JSON으로 받을거면 JsonDeserializer 사용 가능하지만, String으로 받아 직접 파싱하는게 디버깅에 유리함


### PR DESCRIPTION
## 🧾 Summary
1. FeignClient용 내부 컨트롤러 생성
- 내/외부 API 호출 분리를 위해 InternalQueueController 생성 (추후 gateway application.yml의 route 부분에 추가 예정)
- Order 서비스 쪽에서 해당 API를 통해 토큰 유효성 검사 진행

3. Kafka 설정
- 주문 서비스에서 주문 완료 시 "order-complete-token-remove"라는 토픽으로 활성열 토큰 삭제 메시지 발행
- 대기열 서비스에서는 kafka 설정 및 Event Consumer 수신부 코드 구현

4. Kafka 재시도 및 DLQ 설정
- 주문 서비스로부터 메시지를 받아 처리하다 에러가 났을 경우의 재시도 처리 로직 구현
- 1초 간격으로 3회 재시도(backoff)
- 3회 재시도했음에도 실패하면, DLQ로 이동 ("토픽명.DLT"로 메시지 이동)

## 💡 Type of change
- [x] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
