### PR TITLE
Feat(queue): [Kafka] 재고 품절 메시지 수신 시 대기열 진입 차단 기능 구현

### DIFF
--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/QueuePort.java
@@ -26,7 +26,7 @@ public interface QueuePort {
     /**
      * 토큰 형식 검증 + 유저 토큰 활성화 여부
      */
-    boolean validateActivatedQueueToken(UUID productId, String token);
+    boolean validateActivatedQueueToken(UUID productId, String token, Long userId, String role);
 
     /**
      * 토큰 활성화

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/SoldOutEvent.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/SoldOutEvent.java
@@ -1,0 +1,16 @@
+package com.rushcrew.queue.application.port.in;
+
+import java.util.UUID;
+
+/**
+ * 재고 품절 이벤트
+ * TimeDeal Service와 Queue Service가 서로 주고받을 메시지 규격
+ * @param productId
+ * @param status
+ */
+public record SoldOutEvent(
+    UUID productId,
+    String status
+) {
+
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/application/port/in/SoldOutEvent.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/port/in/SoldOutEvent.java
@@ -1,5 +1,6 @@
 package com.rushcrew.queue.application.port.in;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -10,7 +11,8 @@ import java.util.UUID;
  */
 public record SoldOutEvent(
     UUID productId,
-    String status
+    String status,
+    LocalDateTime soldOutAt
 ) {
 
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -42,6 +42,11 @@ public class QueueService implements QueuePort {
     @Override
     @Transactional(readOnly = true)
     public QueueRedisResponse enterQueue(EnterQueueCommand command) {
+        // 재고 품절 여부 확인 (Redis 조회)
+        if (queueRepository.isSoldOut(command.productId())) {
+            throw new BusinessException(QueueErrorCode.PRODUCT_SOLD_OUT);
+        }
+
         // 대기열 정책 확인 (RDB 조회 - 상품 존재 여부 및 시간 확인)
         QueuePolicy policy = queuePolicyRepository.findByProductId(command.productId())
             .orElseThrow(() -> new BusinessException(QueueErrorCode.NO_TIMEDEAL_PRODUCT));

--- a/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/application/service/QueueService.java
@@ -180,7 +180,7 @@ public class QueueService implements QueuePort {
      * 토큰 유효성 검증 (활성화 여부)
      */
     @Override
-    public boolean validateActivatedQueueToken(UUID productId, String token) {
+    public boolean validateActivatedQueueToken(UUID productId, String token, Long userId, String role) {
         TokenId tokenId = extractValidQueueTokenId(token);
         return queueRepository.isActivatedToken(productId, tokenId);
     }

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -17,9 +17,8 @@ public enum QueueErrorCode implements ErrorCode {
     USER_ALREADY_IN_WAITING_QUEUE(HttpStatus.CONFLICT, "USER_ALREADY_IN_WAITING_QUEUE", "이미 대기열에 등록된 사용자입니다."),
     TOKEN_OWNER_NOT_MATCH(HttpStatus.NOT_FOUND, "TOKEN_OWNER_NOT_MATCH", "토큰 소유자가 일치하지 않습니다."),
     QUEUE_TOKEN_EXPIRED(HttpStatus.SERVICE_UNAVAILABLE, "QUEUE_TOKEN_EXPIRED", "대기열에 존재하지 않는 만료 토큰입니다."),
-    NO_TIMEDEAL_PRODUCT(HttpStatus.NOT_FOUND, "NO_TIMEDEAL_PRODUCT", "타임딜이 운영되지 않는 상품입니다.")
-
-
+    NO_TIMEDEAL_PRODUCT(HttpStatus.NOT_FOUND, "NO_TIMEDEAL_PRODUCT", "타임딜이 운영되지 않는 상품입니다."),
+    PRODUCT_SOLD_OUT(HttpStatus.SERVICE_UNAVAILABLE, "PRODUCT_SOLD_OUT", "해당 상품이 품절되었습니다.")
 
 
     ;

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -21,6 +21,7 @@ public enum QueueErrorCode implements ErrorCode {
     PRODUCT_SOLD_OUT(HttpStatus.SERVICE_UNAVAILABLE, "PRODUCT_SOLD_OUT", "해당 상품이 품절되었습니다.")
 
 
+
     ;
 
 

--- a/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/common/QueueErrorCode.java
@@ -21,7 +21,6 @@ public enum QueueErrorCode implements ErrorCode {
     PRODUCT_SOLD_OUT(HttpStatus.SERVICE_UNAVAILABLE, "PRODUCT_SOLD_OUT", "해당 상품이 품절되었습니다.")
 
 
-
     ;
 
 

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -96,7 +96,7 @@ public interface QueueRepository {
      * 상품 품절 처리 (Kafka 수신 시 호출)
      * @param productId
      */
-    void setSoldOut(UUID productId);
+    void setSoldOut(UUID productId, LocalDateTime dealEndTime);
 
     /**
      * 품절 여부 확인 (대기열 진입 시 호출)

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -91,4 +91,17 @@ public interface QueueRepository {
      * @param userId
      */
     void removeTokenWithUserIdxKey(UUID productId, TokenId tokenId, Long userId);
+
+    /**
+     * 상품 품절 처리 (Kafka 수신 시 호출)
+     * @param productId
+     */
+    void setSoldOut(UUID productId);
+
+    /**
+     * 품절 여부 확인 (대기열 진입 시 호출)
+     * @param productId
+     * @return
+     */
+    boolean isSoldOut(UUID productId);
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/domain/repository/QueueRepository.java
@@ -96,7 +96,7 @@ public interface QueueRepository {
      * 상품 품절 처리 (Kafka 수신 시 호출)
      * @param productId
      */
-    void setSoldOut(UUID productId, LocalDateTime dealEndTime);
+    void setSoldOut(UUID productId, String status, LocalDateTime dealEndTime);
 
     /**
      * 품절 여부 확인 (대기열 진입 시 호출)

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/KafkaConsumerConfig.java
@@ -25,6 +25,8 @@ import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.kafka.support.converter.StringJsonMessageConverter;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
@@ -48,6 +50,15 @@ public class KafkaConsumerConfig {
     }
 
     /**
+     * JSON 변환 담당 MessageConverter
+     * String으로 들어온 메시지를 리스너에 맞는 객체로 변환
+     */
+    @Bean
+    public RecordMessageConverter messageConverter() {
+        return new StringJsonMessageConverter();
+    }
+
+    /**
      * Producer Factory 설정
      * DLQ로 메시지를 보낼 때(Produce), 자바 객체를 JSON으로 직렬화하기 위해 필요함
      */
@@ -66,26 +77,15 @@ public class KafkaConsumerConfig {
      * JSON 메시지 어떻게 역직렬화할지 정의
      */
     @Bean
-    public ConsumerFactory<String, TokenRemoveEvent> consumerFactory() {
+    public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
         // 로컬 환경: localhost:9092 / Docker 내부 통신: kafka:29092
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "queue-service-group");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 
-        // JSON 역직렬화 설정
-        JsonDeserializer<TokenRemoveEvent> deserializer = new JsonDeserializer<>(TokenRemoveEvent.class);
-        deserializer.setRemoveTypeHeaders(false);
-        deserializer.addTrustedPackages("*"); // 모든 패키지 신뢰
-        deserializer.setUseTypeMapperForKey(true);
-
-        // ErrorHandlingDeserializer: 역직렬화 실패 시 무한 루프 방지
-        return new DefaultKafkaConsumerFactory<>(
-            props,
-            new StringDeserializer(),
-            new ErrorHandlingDeserializer<>(deserializer)
-        );
+        return new DefaultKafkaConsumerFactory<>(props);
     }
 
     /**
@@ -93,10 +93,13 @@ public class KafkaConsumerConfig {
      * 여기서 재시도(Retry) 및 DLQ(Dead Letter Queue) 전략 주입
      */
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, TokenRemoveEvent> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, TokenRemoveEvent> factory =
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
             new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+
+        // 컨버터 설정, 리스너가 DTO로 받을 수 있음
+        factory.setRecordMessageConverter(messageConverter());
 
         // 수동 커밋 사용 시 설정 (Listener에서 Acknowledgment 사용 시 필요)
         factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -1,8 +1,10 @@
 package com.rushcrew.queue.infrastructure.kafka.consumer;
 
 import com.rushcrew.queue.application.port.in.QueuePort;
+import com.rushcrew.queue.application.port.in.SoldOutEvent;
 import com.rushcrew.queue.application.port.in.TokenRemoveEvent;
 import com.rushcrew.queue.application.service.QueueService;
+import com.rushcrew.queue.infrastructure.repository.RedisQueueRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
@@ -13,9 +15,11 @@ import org.springframework.stereotype.Component;
 public class QueueEventConsumer {
 
     private final QueuePort queueService;
+    private final RedisQueueRepository redisQueueRepository;
 
-    public QueueEventConsumer(QueueService queueService) {
+    public QueueEventConsumer(QueueService queueService, RedisQueueRepository redisQueueRepository) {
         this.queueService = queueService;
+        this.redisQueueRepository = redisQueueRepository;
     }
 
     /**
@@ -60,5 +64,15 @@ public class QueueEventConsumer {
         ack.acknowledge();
 
         log.info("[QUEUE:Kafka:Success] 토큰 삭제 완료 및 Offset 커밋 - UserId: {}", event.userId());
+    }
+
+    @KafkaListener(topics = "product-sold-out", groupId = "queue-service-group")
+    public void handleSoldOutEvent(SoldOutEvent event) {
+        log.info("[QUEUE:Kafka:Consume] 상품 재고품절 이벤트 수신: - ProductId: {}", event.productId());
+
+        // Redis에 품절 정보 기록
+        redisQueueRepository.setSoldOut(event.productId());
+
+        // (추후 선택사항) 현재 대기열에 있는 사람들에게 웹소켓 등으로 "품절되었습니다" 알림
     }
 }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -74,7 +74,7 @@ public class QueueEventConsumer {
     }
 
     @KafkaListener(topics = "product-sold-out", groupId = "queue-service-group")
-    public void handleSoldOutEvent(SoldOutEvent event) {
+    public void handleSoldOutEvent(SoldOutEvent event, Acknowledgment ack) {
         log.info("[QUEUE:Kafka:Consume] 상품 재고품절 이벤트 수신: - ProductId: {}", event.productId());
 
         QueuePolicy queuePolicy = queuePolicyRepository.findByProductId(event.productId())
@@ -82,6 +82,9 @@ public class QueueEventConsumer {
 
         // Redis에 품절 정보 기록
         redisQueueRepository.setSoldOut(event.productId(), queuePolicy.getTimePeriod().getEndTime());
+
+        // 수동 커밋 실행 - KafkaConsumerConfig에 AckMode.MANUAL_IMMEDIATE가 설정되어 있으므로 필수
+        ack.acknowledge();
 
         // (추후 선택사항) 현재 대기열에 있는 사람들에게 웹소켓 등으로 "품절되었습니다" 알림
     }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -81,7 +81,7 @@ public class QueueEventConsumer {
             .orElseThrow(() -> new BusinessException(QueueErrorCode.NO_TIMEDEAL_PRODUCT));
 
         // Redis에 품절 정보 기록
-        redisQueueRepository.setSoldOut(event.productId(), queuePolicy.getTimePeriod().getEndTime());
+        redisQueueRepository.setSoldOut(event.productId(), event.status(), queuePolicy.getTimePeriod().getEndTime());
 
         // 수동 커밋 실행 - KafkaConsumerConfig에 AckMode.MANUAL_IMMEDIATE가 설정되어 있으므로 필수
         ack.acknowledge();

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -85,6 +85,7 @@ public class QueueEventConsumer {
 
         // 수동 커밋 실행 - KafkaConsumerConfig에 AckMode.MANUAL_IMMEDIATE가 설정되어 있으므로 필수
         ack.acknowledge();
+        log.info("[QUEUE:Kafka:Success] 상품 재고 품절 레디스 등록 및 Offset 커밋 - ProductId: {}", event.productId());
 
         // (추후 선택사항) 현재 대기열에 있는 사람들에게 웹소켓 등으로 "품절되었습니다" 알림
     }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/kafka/consumer/QueueEventConsumer.java
@@ -1,9 +1,13 @@
 package com.rushcrew.queue.infrastructure.kafka.consumer;
 
+import com.rushcrew.common.exception.BusinessException;
 import com.rushcrew.queue.application.port.in.QueuePort;
 import com.rushcrew.queue.application.port.in.SoldOutEvent;
 import com.rushcrew.queue.application.port.in.TokenRemoveEvent;
 import com.rushcrew.queue.application.service.QueueService;
+import com.rushcrew.queue.common.QueueErrorCode;
+import com.rushcrew.queue.domain.entity.QueuePolicy;
+import com.rushcrew.queue.domain.repository.QueuePolicyRepository;
 import com.rushcrew.queue.infrastructure.repository.RedisQueueRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -16,10 +20,13 @@ public class QueueEventConsumer {
 
     private final QueuePort queueService;
     private final RedisQueueRepository redisQueueRepository;
+    private final QueuePolicyRepository queuePolicyRepository;
 
-    public QueueEventConsumer(QueueService queueService, RedisQueueRepository redisQueueRepository) {
+    public QueueEventConsumer(QueueService queueService, RedisQueueRepository redisQueueRepository,
+        QueuePolicyRepository queuePolicyRepository) {
         this.queueService = queueService;
         this.redisQueueRepository = redisQueueRepository;
+        this.queuePolicyRepository = queuePolicyRepository;
     }
 
     /**
@@ -70,8 +77,11 @@ public class QueueEventConsumer {
     public void handleSoldOutEvent(SoldOutEvent event) {
         log.info("[QUEUE:Kafka:Consume] 상품 재고품절 이벤트 수신: - ProductId: {}", event.productId());
 
+        QueuePolicy queuePolicy = queuePolicyRepository.findByProductId(event.productId())
+            .orElseThrow(() -> new BusinessException(QueueErrorCode.NO_TIMEDEAL_PRODUCT));
+
         // Redis에 품절 정보 기록
-        redisQueueRepository.setSoldOut(event.productId());
+        redisQueueRepository.setSoldOut(event.productId(), queuePolicy.getTimePeriod().getEndTime());
 
         // (추후 선택사항) 현재 대기열에 있는 사람들에게 웹소켓 등으로 "품절되었습니다" 알림
     }

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -268,7 +268,7 @@ public class RedisQueueRepository implements QueueRepository {
      * @param productId
      */
     @Override
-    public void setSoldOut(UUID productId, LocalDateTime dealEndTime) {
+    public void setSoldOut(UUID productId, String status, LocalDateTime dealEndTime) {
         String productStatusKey = getProductStatusKey(productId);
 
         // TTL 계산 : (이벤트 종료 시간 - 현재 시간)
@@ -280,7 +280,7 @@ public class RedisQueueRepository implements QueueRepository {
         }
 
         // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
-        redisTemplate.opsForValue().set(productStatusKey, "SOLDOUT", Duration.ofSeconds(secondsUntilClose));
+        redisTemplate.opsForValue().set(productStatusKey, status, Duration.ofSeconds(secondsUntilClose));
         log.info("[QUEUE:SOLDOUT] 상품({}) 품절 상태로 변경", productId);
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -1,5 +1,7 @@
 package com.rushcrew.queue.infrastructure.repository;
 
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.queue.common.QueueErrorCode;
 import com.rushcrew.queue.domain.entity.QueueToken;
 import com.rushcrew.queue.domain.repository.QueueRepository;
 import com.rushcrew.queue.domain.vo.TokenId;
@@ -57,7 +59,7 @@ public class RedisQueueRepository implements QueueRepository {
         if (secondsUntilClose < 0) {
             // 이미 종료된 이벤트면 진입 불가 처리
             log.warn("[QUEUE:ERROR] 이미 종료된 이벤트입니다. productId={}", token.getProductId());
-            return false;
+            throw new BusinessException(QueueErrorCode.NO_TIMEDEAL_PRODUCT);
         }
 
         // redis 사용자 인덱스 키 생성

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -71,7 +71,7 @@ public class RedisQueueRepository implements QueueRepository {
         Boolean isNewUser = redisTemplate.opsForValue().setIfAbsent(
             userIndexKey,
             newTokenValue,
-            Duration.ofMinutes(secondsUntilClose) // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
+            Duration.ofSeconds(secondsUntilClose) // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
         );
 
         // 유저별 대기열 키(USER_INDEX_KEY)가 이미 존재하는 경우 -> 진짜 유효한지 검증
@@ -268,10 +268,14 @@ public class RedisQueueRepository implements QueueRepository {
      * @param productId
      */
     @Override
-    public void setSoldOut(UUID productId) {
+    public void setSoldOut(UUID productId, LocalDateTime dealEndTime) {
         String productStatusKey = getProductStatusKey(productId);
-        // 영구 저장이 아니라 타임딜 종료 시간까지만 유지되면 되므로 적절한 TTL 설정 권장
-        redisTemplate.opsForValue().set(productStatusKey, "SOLDOUT", Duration.ofHours(1));
+
+        // TTL 계산 : (이벤트 종료 시간 - 현재 시간)
+        long secondsUntilClose = Duration.between(LocalDateTime.now(), dealEndTime).getSeconds();
+
+        // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
+        redisTemplate.opsForValue().set(productStatusKey, "SOLDOUT", Duration.ofSeconds(secondsUntilClose));
         log.info("[QUEUE:SOLDOUT] 상품({}) 품절 상태로 변경", productId);
     }
 

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -274,6 +274,11 @@ public class RedisQueueRepository implements QueueRepository {
         // TTL 계산 : (이벤트 종료 시간 - 현재 시간)
         long secondsUntilClose = Duration.between(LocalDateTime.now(), dealEndTime).getSeconds();
 
+        // 이미 시간이 지난 경우 (음수가 나오면 에러 나거나 바로 만료 처리)
+        if (secondsUntilClose < 0) {
+            secondsUntilClose = 0;
+        }
+
         // TTL 설정: 타임딜 종료 시간에 맞춰 자동 만료
         redisTemplate.opsForValue().set(productStatusKey, "SOLDOUT", Duration.ofSeconds(secondsUntilClose));
         log.info("[QUEUE:SOLDOUT] 상품({}) 품절 상태로 변경", productId);

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -31,6 +31,7 @@ public class RedisQueueRepository implements QueueRepository {
     private static final String WAITING_KEY = "queue:wait:product:%s";
     private static final String ACTIVE_KEY = "queue:active:product:%s";
     private static final String USER_INDEX_KEY = "queue:user:product:%s:%s"; // String (중복방지용)
+    private static final String PRODUCT_STATUS_KEY = "queue:product:status:%s"; // 카프카로부터 받아옴 - Value: "AVAILABLE" or "SOLDOUT"
 
     // FAST TRACK(대기열 진입 정책) 기준 인원 (100인 미만이면 대기열 토큰 생성 시 바로 활성열로 이동)
     // TODO: 추후 QueuePolicy (정책 DB)에서 관리하도록 수정 예정
@@ -261,6 +262,29 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     /**
+     * 상품 품절 처리 (Kafka 수신 시 호출)
+     * @param productId
+     */
+    @Override
+    public void setSoldOut(UUID productId) {
+        String productStatusKey = getProductStatusKey(productId);
+        // 영구 저장이 아니라 타임딜 종료 시간까지만 유지되면 되므로 적절한 TTL 설정 권장
+        redisTemplate.opsForValue().set(productStatusKey, "SOLDOUT", Duration.ofHours(1));
+        log.info("[QUEUE:SOLDOUT] 상품({}) 품절 상태로 변경", productId);
+    }
+
+    /**
+     * 품절 여부 확인 (enterQueue 진입 시 호출)
+     */
+    @Override
+    public boolean isSoldOut(UUID productId) {
+        String key = String.format(PRODUCT_STATUS_KEY, productId);
+        String status = redisTemplate.opsForValue().get(key);
+        return "SOLDOUT".equals(status);
+    }
+
+
+    /**
      * 본인 확인 (대기열 토큰 소유권 검증)
      */
     @Override
@@ -335,6 +359,10 @@ public class RedisQueueRepository implements QueueRepository {
 
     private String getUserIndexKey(UUID productId, Long userId) {
         return String.format(USER_INDEX_KEY, productId, userId);
+    }
+
+    private String getProductStatusKey(UUID productId) {
+        return String.format(PRODUCT_STATUS_KEY, productId);
     }
 
     private double getExpireAt(Integer activeTtl) {


### PR DESCRIPTION
## 🧾 Summary

### 1. 상품 재고 품절 이벤트 리스너 추가
  - topic = "product-sold-out"
  - groupId = "queue-service-group"

### 2. Redis 상품상태 키(PRODUCT_STATUS_KEY) 추가
   - Redis에 상품 재고 품절 정보 기록 (플래그 값 기록)
   - RedisQueueRepository에 setSoldOut(Kafka 수신 시 호출용), isSoldOut(대기열 진입 시 호출용) 메서드 정의 및 구현
   - setSoldOut : 해당 상품에 대한 status값("SOLDOUT") 기록,  TTL은 타임딜 종료 시간에 맞춰 자동 만료되도록 설정
   - isSoldOut: 클라이언트로부터 대기열 진입 요청 시 PRODUCT_STATUS_KEY를 통해 해당 상품 품절 여부 확인
     - 품절이면 "해당 상품이 품절되었습니다." 에러 메시지 표시 및 대기열 진입 차단

### 3. 예외 처리
  - 이미 종료된 이벤트면 진입 불가 예외 처리 메시지 표시

### 4. 카프카 설정 리팩토링
 - 상품 재고 품절 이벤트 수신 시 수동 커밋 추가 (Manual Ack)
 - KafkaConsumerConfig JSON 역직렬화 방식 수정 (타입 캐스팅 오류로 인해 JsonDeserializer -> StringDeserializer로 수정)
 - MessageConverter 정의 및 적용 (StringDeserializer로 안전하게 문자를 받은 뒤, Spring의 MessageConverter가 객체로 변환해주는 방식)
    - 기존 코드에서 consumerFactory 부분의 Deserializer를 String으로 변경하고, MessageConverter를 등록하는 방식으로 변경됨


### 테스트 결과
<img width="429" height="573" alt="스크린샷 2025-12-16 오전 2 14 15" src="https://github.com/user-attachments/assets/1d446260-c610-4053-9eaf-6f6ceddaa074" />

### kafka-ui 테스트 (메시지 발행)
<img width="1117" height="194" alt="스크린샷 2025-12-16 오전 2 14 31" src="https://github.com/user-attachments/assets/9bd98f16-0af4-4c28-a9e8-39dd1c636c7e" />



## 💡 Type of change
- [x] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
#135 
