### PR TITLE
Improve(queue) : 대기열 스케줄링 병렬처리 트러블슈팅

### DIFF
--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/QueueConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/QueueConfig.java
@@ -1,0 +1,27 @@
+package com.rushcrew.queue.infrastructure.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class QueueConfig {
+
+    // 대기열 스케줄러 전용 스레드 풀 정의
+    @Bean(name = "queueSchedulerExecutor")
+    public Executor queueSchedulerExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        // 기본적으로 10개의 스레드를 항상 유지
+        executor.setCorePoolSize(10);
+        // 바쁠 때 최대 20개까지 확장
+        executor.setMaxPoolSize(20);
+        // 대기열 용량 (작업이 밀리면 500개까지 쌓아둠)
+        executor.setQueueCapacity(500);
+        // 스레드 이름 접두사 (디버깅용)
+        executor.setThreadNamePrefix("queue-scheduler-");
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/QueueConfig.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/config/QueueConfig.java
@@ -14,7 +14,7 @@ public class QueueConfig {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         // 기본적으로 10개의 스레드를 항상 유지
         executor.setCorePoolSize(10);
-        // 바쁠 때 최대 20개까지 확장
+        // 바쁠 때 최대 20개까지 확장 (기본 10개 스레드도 점유되었고, 대기열 용량도 꽉 찼을 경우)
         executor.setMaxPoolSize(20);
         // 대기열 용량 (작업이 밀리면 500개까지 쌓아둠)
         executor.setQueueCapacity(500);

--- a/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/infrastructure/repository/RedisQueueRepository.java
@@ -34,7 +34,7 @@ public class RedisQueueRepository implements QueueRepository {
 
     // FAST TRACK(대기열 진입 정책) 기준 인원 (100인 미만이면 대기열 토큰 생성 시 바로 활성열로 이동)
     // TODO: 추후 QueuePolicy (정책 DB)에서 관리하도록 수정 예정
-    private static final Long MAX_ACTIVE_COUNT = 100L;
+    private static final Long MAX_ACTIVE_COUNT = 0L;
 
     public RedisQueueRepository(StringRedisTemplate redisTemplate) {
         this.redisTemplate = redisTemplate;
@@ -93,6 +93,8 @@ public class RedisQueueRepository implements QueueRepository {
 
         // FAST TRACK 판단 : 활성열 인원 조회
         Long activeCount = countActiveTokens(token.getProductId());
+
+        log.warn("[QUEUE:INFO] 현재 활성열 인원 개수 count={}", activeCount);
         if (activeCount != null && activeCount < MAX_ACTIVE_COUNT) {
             // [Fast Track] 대기 없이 바로 활성 상태 진입
             return registerFastTrack(token, dealEndTime, activeTtl, userIndexKey);
@@ -328,7 +330,7 @@ public class RedisQueueRepository implements QueueRepository {
     }
 
     private String getActiveKey(UUID productId) {
-        return String.format(ACTIVE_KEY, productId);
+        return String.format(ACTIVE_KEY, productId.toString());
     }
 
     private String getUserIndexKey(UUID productId, Long userId) {

--- a/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueTestController.java
+++ b/queue-service/src/main/java/com/rushcrew/queue/presentation/controller/QueueTestController.java
@@ -1,0 +1,146 @@
+package com.rushcrew.queue.presentation.controller;
+
+import com.rushcrew.common.dto.ApiResponse;
+import com.rushcrew.queue.domain.entity.QueueToken;
+import com.rushcrew.queue.domain.vo.TokenId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/test/queues")
+public class QueueTestController {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String ACTIVE_KEY = "queue:active:product:%s";
+    private static final String USER_INDEX_KEY = "queue:user:product:%s:%s";
+
+    public QueueTestController(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    /**
+     * 테스트용: 활성열에 N개의 더미 토큰 미리 채우기
+     * 용도: Fast Track(100명 미만 즉시 활성) 우회하여 대기열 테스트 가능
+     */
+    @PostMapping("/seed-active-tokens")
+    public ResponseEntity<ApiResponse<String>> seedActiveTokens(
+        @RequestParam UUID productId,
+        @RequestParam(defaultValue = "110") int count,
+        @RequestParam(defaultValue = "300") int ttlSeconds // 5분 (300초)
+    ) {
+        String activeKey = String.format(ACTIVE_KEY, productId);
+        long now = System.currentTimeMillis();
+        long expireAt = now + (ttlSeconds * 1000L);
+
+        List<String> createdTokens = new ArrayList<>();
+
+        try {
+            // 파이프라인으로 한 번에 처리 (성능 최적화)
+            redisTemplate.executePipelined((org.springframework.data.redis.core.RedisCallback<Object>) connection -> {
+                org.springframework.data.redis.connection.StringRedisConnection strConn =
+                    (org.springframework.data.redis.connection.StringRedisConnection) connection;
+
+                for (int i = 0; i < count; i++) {
+                    // 더미 유저 ID (10000번부터 시작)
+                    Long dummyUserId = 10000L + i;
+
+                    // 더미 토큰 생성
+                    String tokenValue = UUID.randomUUID().toString();
+
+                    // 활성열에 추가
+                    strConn.zAdd(activeKey, expireAt, tokenValue);
+
+                    // USER_INDEX_KEY 설정 (중복 진입 방지용)
+                    String userIndexKey = String.format(USER_INDEX_KEY, productId, dummyUserId);
+                    strConn.setEx(userIndexKey, ttlSeconds, tokenValue);
+
+                    createdTokens.add(tokenValue);
+                }
+                return null;
+            });
+
+            log.info("[TEST:SEED] 활성열 더미 토큰 {}개 생성 완료 (productId: {})", count, productId);
+
+            return ResponseEntity.ok(
+                ApiResponse.success(
+                    String.format("✅ 활성열에 %d개 더미 토큰 생성 완료 (TTL: %d초)", count, ttlSeconds)
+                )
+            );
+
+        } catch (Exception e) {
+            log.error("[TEST:SEED:ERROR] 더미 토큰 생성 실패", e);
+            return ResponseEntity.internalServerError()
+                .body(ApiResponse.error("더미 토큰 생성 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 테스트용: 특정 상품의 대기열/활성열 전체 초기화
+     */
+    @PostMapping("/clear-queues")
+    public ResponseEntity<ApiResponse<String>> clearQueues(
+        @RequestParam UUID productId
+    ) {
+        try {
+            String waitingKey = String.format("queue:wait:product:%s", productId);
+            String activeKey = String.format(ACTIVE_KEY, productId);
+
+            // 대기열/활성열 삭제
+            redisTemplate.delete(waitingKey);
+            redisTemplate.delete(activeKey);
+
+            // USER_INDEX_KEY 패턴 삭제 (전체 유저)
+            String pattern = String.format(USER_INDEX_KEY, productId, "*");
+            redisTemplate.keys(pattern).forEach(redisTemplate::delete);
+
+            log.info("[TEST:CLEAR] 상품({}) 대기열/활성열 초기화 완료", productId);
+
+            return ResponseEntity.ok(
+                ApiResponse.success("✅ 대기열/활성열 초기화 완료")
+            );
+
+        } catch (Exception e) {
+            log.error("[TEST:CLEAR:ERROR] 큐 초기화 실패", e);
+            return ResponseEntity.internalServerError()
+                .body(ApiResponse.error("초기화 실패: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * 테스트용: 현재 대기열/활성열 상태 조회
+     */
+    @PostMapping("/queue-status")
+    public ResponseEntity<ApiResponse<QueueStatusResponse>> getQueueStatus(
+        @RequestParam UUID productId
+    ) {
+        String waitingKey = String.format("queue:wait:product:%s", productId);
+        String activeKey = String.format(ACTIVE_KEY, productId);
+
+        Long waitingCount = redisTemplate.opsForZSet().zCard(waitingKey);
+        Long activeCount = redisTemplate.opsForZSet().zCard(activeKey);
+
+        QueueStatusResponse status = new QueueStatusResponse(
+            productId,
+            waitingCount != null ? waitingCount : 0L,
+            activeCount != null ? activeCount : 0L
+        );
+
+        return ResponseEntity.ok(ApiResponse.success(status));
+    }
+
+    // DTO
+    public record QueueStatusResponse(
+        UUID productId,
+        Long waitingCount,
+        Long activeCount
+    ) {}
+}


### PR DESCRIPTION
## 🧾 Summary

### 1. 타임딜 정책에 따른 토큰 활성화 로직 수행 시 parallelStream 대신 전용 Executor 적용
- parallelStream 방식 특징 : ForkJoinPool.commonPool() (JVM 전체 공유)로 인해 모든 병렬 스트림이 스레드를 공유하게 됨.

- Executor 적용 이유 : 

> 대기열 로직뿐만 아니라, 다른 수많은 기능이 돌아감. 그리고 parallelStream과 같은 공용 풀을 사용 시 대기열 스케줄러도 같은 풀을 쓰므로, 다른 기능이 끝날 때까지 대기열 처리가 멈출 수 있음. 이에 반해 Executor를 적용한 전용 스레드 풀을 사용하게 된다면, 대기열 스케줄러는 자신 전용으로만 돌리는 스레드 10개(예시: 기본으로 정함)를 가지고 재활용해서 돌리므로 서버 장애의 전파를 막을 수 있음.


### 2. 전용 스레드 풀을 사용하는 스케줄러에서 스레드 10개가 어떻게 돌아가는지?
1. runAsync는 processPolicyWithLock이라는 작업을 queueSchedulerExecutor에게 줌. (QueueScheduler 참고)
2. 큐 적재: Executor 내부의 "작업 큐(Queue)"에 이 작업들이 쌓이게 됨. (타임딜이 50개면 50개가 쌓임)
3. 스레드 동작 : 미리 만들어진 10개의 스레드가 큐를 바라보고 있는 상황 
- 각 스레드는 큐에서 작업 하나를 꺼내서 실행 (비동기)
- 스레드 1: "A 상품 처리 시작" -> (처리 중) -> "끝" -> 다시 큐 확인
- 스레드 2: "B 상품 처리 시작" -> (처리 중) -> "끝" -> 다시 큐 확인


### 3. parallelStream과 Executor 성능 차이 비교 (로그 기반)

#### CASE 1 - parallelStream (공용 풀) - 소요시간 2008ms
```
[Scheduler:Refresher] 정책 캐시 갱신 완료. (로드된 정책 수: 2)
[Start] Thread: http-nio-8011-exec-2
[ForkJoinPool.commonPool-worker-1] 상품(550e8400-e29b-41d4-a716-446655440010) 활성화 시작 => 공용 풀(JVM 전체가 쓰는 스레드)
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440010) 활성화 실패 - 실행 시간 롤백
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440009) 활성화 실패 - 실행 시간 롤백
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440010) 실행 시간 롤백 완료
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440009) 실행 시간 롤백 완료
[End] Thread: http-nio-8011-exec-2, Duration: 2008ms"
```

#### CASE 2 - Executor (전용 풀) - 소요시간 (1857ms)
```
[Start] Thread: http-nio-8011-exec-2
[queue-scheduler-1] 상품(550e8400-e29b-41d4-a716-446655440010) 활성화 시작 => 각 상품을 각각의 스레드가 돌림
[queue-scheduler-2] 상품(550e8400-e29b-41d4-a716-446655440009) 활성화 시작 => 각 상품을 각각의 스레드가 돌림
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440010) 활성화 실패 - 실행 시간 롤백
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440009) 활성화 실패 - 실행 시간 롤백
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440010) 실행 시간 롤백 완료
[Scheduler] 상품(550e8400-e29b-41d4-a716-446655440009) 실행 시간 롤백 완료
[End] Thread: http-nio-8011-exec-2, Duration: 1857ms
```

각 소요시간은 큰 차이가 나지는 않지만, 만약 CASE 1에서 다른 무거운 작업들도 같이 돌렸을 경우, 저 소요시간은 더욱더 늘어나게 되었을 것이다. 그러나 전용 풀은 "타임딜 정책에 따른 토큰 활성화" 작업만을 위해 대기하고 있었기 때문에, 작업이 들어오자마자 즉시(Context Switching 비용 최소화) 처리를 시작할 수 있기에 더 빠른 처리 속도를 보인다. 이와 같이 서버 장애 전파 방지 및 자원 공유 최적화, 고도화된 성능을 위해 Executor를 적용하여 시스템 자원 경쟁을 피하고, 독립적인 성능을 보장하는 구조로 개선하였다.


## 💡 Type of change
- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [x] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #이슈번호
#123 
