### PR TITLE
Refac(timedeal): 재고 예약 시 Redis 선차감

### DIFF
--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/CreateStockCommand.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/command/CreateStockCommand.java
@@ -4,7 +4,7 @@ import com.rushcrew.timedeal.presentation.dto.request.CreateStockRequest;
 import java.util.UUID;
 
 public record CreateStockCommand(
-    UUID productId,
+    UUID productId, // timeDealProductId
     Long totalStock
 ) {
 

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/CreateTimeDealResult.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/result/CreateTimeDealResult.java
@@ -1,0 +1,21 @@
+package com.rushcrew.timedeal.application.result;
+
+import com.rushcrew.timedeal.domain.entity.TimeDeal;
+import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
+import java.util.List;
+import java.util.UUID;
+
+public record CreateTimeDealResult(
+    UUID timeDealId,
+    List<UUID> timeDealProductIds
+) {
+
+    public static CreateTimeDealResult from(TimeDeal timeDeal) {
+        List<UUID> timeDealProductIds = timeDeal.getTimeDealProducts().stream()
+            .map(TimeDealProduct::getId).toList();
+        return new CreateTimeDealResult(
+            timeDeal.getId(),
+            timeDealProductIds
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/RetryStockService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/RetryStockService.java
@@ -1,0 +1,34 @@
+package com.rushcrew.timedeal.application.service;
+
+import com.rushcrew.timedeal.application.command.ReserveStockCommand;
+import com.rushcrew.timedeal.application.result.ReserveStockResult;
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class RetryStockService {
+
+    private final StockPolicy stockPolicy;
+
+    @Retryable(
+        retryFor = {ObjectOptimisticLockingFailureException.class},
+        maxAttempts = 5,
+        backoff = @Backoff(delay = 5, maxDelay = 20, multiplier = 2)
+    )
+    @Transactional
+    public ReserveStockResult reserveWithRetry(ReserveStockCommand command) {
+        TimeDealStock stock = stockPolicy.getStockOrThrow(command.stockId());
+        stock.reserve(command.quantity(), command.orderId());
+
+        return ReserveStockResult.of(
+            stock.getStockCounts().getAvailable(),
+            "재고가 예약되었습니다."
+        );
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockPolicy.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/StockPolicy.java
@@ -1,0 +1,27 @@
+package com.rushcrew.timedeal.application.service;
+
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.domain.entity.StockLog;
+import com.rushcrew.timedeal.domain.entity.TimeDealStock;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
+import com.rushcrew.timedeal.domain.repository.StockRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StockPolicy {
+
+    private final StockRepository stockRepository;
+
+    public TimeDealStock getStockOrThrow(UUID stockId) {
+        return stockRepository.findNotDeletedById(stockId)
+            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_STOCK));
+    }
+
+    public StockLog getLastLogOrThrow(UUID stockId, UUID orderId) {
+        return stockRepository.findLastByStockIdAndOrderId(stockId, orderId)
+            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_ORDER));
+    }
+}

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/TimeDealService.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/TimeDealService.java
@@ -2,6 +2,7 @@ package com.rushcrew.timedeal.application.service;
 
 import com.rushcrew.timedeal.application.command.CreateTimeDealCommand;
 import com.rushcrew.timedeal.application.command.UpdateTimeDealCommand;
+import com.rushcrew.timedeal.application.result.CreateTimeDealResult;
 import com.rushcrew.timedeal.application.result.TimeDealDetailResult;
 import com.rushcrew.timedeal.application.result.TimeDealResult;
 import com.rushcrew.timedeal.application.result.UpdateTimeDealResult;
@@ -13,7 +14,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface TimeDealService {
 
-    UUID createTimeDeal(Long userId, String role, CreateTimeDealCommand command);
+    CreateTimeDealResult createTimeDeal(Long userId, String role, CreateTimeDealCommand command);
 
     UpdateTimeDealResult updateTimeDeal(
         Long userId, String role, UUID timeDealId, UpdateTimeDealCommand command);

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/StockServiceImpl.java
@@ -11,7 +11,6 @@ import com.rushcrew.timedeal.application.command.UpdateStockCountCommand;
 import com.rushcrew.timedeal.application.event.StockChangedEvent;
 import com.rushcrew.timedeal.application.event.StockCreatedEvent;
 import com.rushcrew.timedeal.application.event.StockDeletedEvent;
-import com.rushcrew.timedeal.application.event.StockReservedEvent;
 import com.rushcrew.timedeal.application.event.StockRestoredEvent;
 import com.rushcrew.timedeal.application.result.ConfirmStockResult;
 import com.rushcrew.timedeal.application.result.CreateStockResult;
@@ -19,36 +18,39 @@ import com.rushcrew.timedeal.application.result.ReserveStockResult;
 import com.rushcrew.timedeal.application.result.StockLogResult;
 import com.rushcrew.timedeal.application.result.StockResult;
 import com.rushcrew.timedeal.application.result.UpdateStockCountResult;
+import com.rushcrew.timedeal.application.service.RetryStockService;
+import com.rushcrew.timedeal.application.service.StockPolicy;
 import com.rushcrew.timedeal.application.service.StockService;
 import com.rushcrew.timedeal.domain.entity.StockLog;
 import com.rushcrew.timedeal.domain.entity.TimeDealProduct;
 import com.rushcrew.timedeal.domain.entity.TimeDealStock;
 import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
+import com.rushcrew.timedeal.domain.port.StockCache;
 import com.rushcrew.timedeal.domain.repository.StockRepository;
 import com.rushcrew.timedeal.domain.repository.TimeDealRepository;
 import com.rushcrew.timedeal.domain.vo.OrderId;
-import com.rushcrew.timedeal.domain.vo.Quantity;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
+import jakarta.persistence.OptimisticLockException;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class StockServiceImpl implements StockService {
 
     private final TimeDealRepository timeDealRepository;
     private final StockRepository stockRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final StockCache stockCache;
+
+    private final StockPolicy stockPolicy;
+    private final RetryStockService retryStockService;
 
     @Override
     @Transactional
@@ -68,7 +70,7 @@ public class StockServiceImpl implements StockService {
     @Override
     @Transactional
     public UpdateStockCountResult changeStockCount(UUID stockId, UpdateStockCountCommand command) {
-        TimeDealStock stock = getStockOrThrow(stockId);
+        TimeDealStock stock = stockPolicy.getStockOrThrow(stockId);
         Long previousStock = stock.getStockCounts().getAvailable();
 
         Long quantity = command.quantity().getQuantity();
@@ -85,6 +87,7 @@ public class StockServiceImpl implements StockService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<StockResult> getStocks(
         String keyword, UUID productId, TimeDealStockStatus status, Pageable pageable
     ) {
@@ -93,6 +96,7 @@ public class StockServiceImpl implements StockService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public StockResult getStock(Long userId, String role, UUID stockId) {
         StockResult result = stockRepository.findStockResultById(stockId);
         if (role.equals(UserRole.SELLER.getDescription())
@@ -106,38 +110,39 @@ public class StockServiceImpl implements StockService {
     @Override
     @Transactional
     public void deleteStock(UUID stockId, Long userId) {
-        TimeDealStock stock = getStockOrThrow(stockId);
+        TimeDealStock stock = stockPolicy.getStockOrThrow(stockId);
 
         stock.delete(userId);
         eventPublisher.publishEvent(new StockDeletedEvent(stockId));
     }
 
     @Override
-    @Transactional
-    @Retryable(
-        retryFor = {ObjectOptimisticLockingFailureException.class},
-        maxAttempts = 5,
-        backoff = @Backoff(delay = 5, maxDelay = 20, multiplier = 2)
-    )
     public ReserveStockResult reserveStock(ReserveStockCommand command) {
-        TimeDealStock stock = getStockOrThrow(command.stockId());
+        UUID stockId = command.stockId();
+        Long quantity = command.quantity().getQuantity();
 
-        stock.reserve(command.quantity(), command.orderId());
-        eventPublisher.publishEvent(
-            new StockReservedEvent(command.stockId(), command.quantity().getQuantity())
-        );
+        if (!stockCache.decrease(stockId, quantity)) {
+            throw new BusinessException(TimeDealErrorCode.OUT_OF_STOCK);
+        }
 
-        return ReserveStockResult
-            .of(stock.getStockCounts().getAvailable(), "재고가 예약되었습니다.");
+        try {
+            return retryStockService.reserveWithRetry(command);
+        } catch (OptimisticLockException e) {
+            stockCache.increase(stockId, quantity);
+            throw e;
+        } catch (Exception e) {
+            stockCache.increase(stockId, quantity);
+            throw e;
+        }
     }
 
     @Override
     @Transactional
     public ConfirmStockResult confirmStock(ConfirmStockCommand command) {
         UUID orderId = command.orderId().getOrderId();
-        TimeDealStock stock = getStockOrThrow(command.stockId());
-        StockLog log = getLastLogOrThrow(command.stockId(), orderId);
-        validateOrderQuantity(log, command.quantity());
+        TimeDealStock stock = stockPolicy.getStockOrThrow(command.stockId());
+        StockLog log = stockPolicy.getLastLogOrThrow(command.stockId(), orderId);
+        log.validateOrderQuantity(command.quantity());
 
         stock.confirm(OrderId.of(orderId), command.quantity());
 
@@ -148,9 +153,9 @@ public class StockServiceImpl implements StockService {
     @Transactional
     public void restoreStock(RestoreStockCommand command) {
         UUID orderId = command.orderId().getOrderId();
-        TimeDealStock stock = getStockOrThrow(command.stockId());
-        StockLog log = getLastLogOrThrow(command.stockId(), orderId);
-        validateOrderQuantity(log, command.quantity());
+        TimeDealStock stock = stockPolicy.getStockOrThrow(command.stockId());
+        StockLog log = stockPolicy.getLastLogOrThrow(command.stockId(), orderId);
+        log.validateOrderQuantity(command.quantity());
 
         log.getEventType().applyRestore(
             stock, OrderId.of(orderId), command.quantity(), command.reason());
@@ -161,25 +166,8 @@ public class StockServiceImpl implements StockService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<StockLogResult> getStockLogs(UUID stockId, String eventType, Pageable pageable) {
         return stockRepository.findLogByIdAndFilter(stockId, eventType, pageable);
-    }
-
-    // ------------------------------------------------------------------------------------
-
-    private TimeDealStock getStockOrThrow(UUID stockId) {
-        return stockRepository.findNotDeletedById(stockId)
-            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_STOCK));
-    }
-
-    private StockLog getLastLogOrThrow(UUID stockId, UUID orderId) {
-        return stockRepository.findLastByStockIdAndOrderId(stockId, orderId)
-            .orElseThrow(() -> new BusinessException(TimeDealErrorCode.NOT_FOUND_ORDER));
-    }
-
-    private void validateOrderQuantity(StockLog log, Quantity quantity) {
-        if (!Objects.equals(log.getQuantity().getQuantity(), quantity.getQuantity())) {
-            throw new BusinessException(TimeDealErrorCode.INVALID_ORDER_INFO);
-        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/TimeDealServiceImpl.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/application/service/impl/TimeDealServiceImpl.java
@@ -7,6 +7,7 @@ import com.rushcrew.timedeal.application.command.CreateTimeDealCommand;
 import com.rushcrew.timedeal.application.command.UpdateTimeDealCommand;
 import com.rushcrew.timedeal.application.event.TimeDealScheduledEvent;
 import com.rushcrew.timedeal.application.model.ProductInfo;
+import com.rushcrew.timedeal.application.result.CreateTimeDealResult;
 import com.rushcrew.timedeal.application.result.TimeDealDetailResult;
 import com.rushcrew.timedeal.application.result.TimeDealProductResult;
 import com.rushcrew.timedeal.application.result.TimeDealResult;
@@ -46,7 +47,9 @@ public class TimeDealServiceImpl implements TimeDealService {
 
     @Override
     @Transactional
-    public UUID createTimeDeal(Long userId, String role, CreateTimeDealCommand command) {
+    public CreateTimeDealResult createTimeDeal(
+        Long userId, String role, CreateTimeDealCommand command
+    ) {
         ProductInfo productInfo = productClient.getProductItemIds(command.productId());
 
         Long sellerId = productInfo.sellerId();
@@ -73,7 +76,7 @@ public class TimeDealServiceImpl implements TimeDealService {
         eventPublisher.publishEvent(
             new TimeDealScheduledEvent(newTimeDeal.getId(), endAt, TimeDealQueueKey.END));
 
-        return newTimeDeal.getId();
+        return CreateTimeDealResult.from(newTimeDeal);
     }
 
     @Override

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/entity/TimeDealStock.java
@@ -14,6 +14,7 @@ import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import com.rushcrew.timedeal.domain.vo.TimeDealStockStatus;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -79,7 +80,7 @@ public class TimeDealStock extends BaseEntity {
     @Column(nullable = false)
     private Long version;
 
-    @OneToMany(mappedBy = "timeDealStock", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "timeDealStock", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @Builder.Default
     private List<StockLog> stockLogs = new ArrayList<>();
 

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/domain/port/StockCache.java
@@ -13,19 +13,11 @@ public interface StockCache {
     void register(UUID stockId, Long available);
 
     /**
-     * Redis에 캐시된 타임딜 재고 정보 수량 증가/감소
-     *
-     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
-     * @param quantity : 증가/감소할 재고 수량
-     */
-    void changeCount(UUID stockId, Long quantity);
-
-    /**
      * Redis에 캐시된 타임딜 재고 정보 삭제(무효화)
      *
      * @param stockId : Redis key에 사용되는 타임딜 재고 ID
      */
-    void evict(UUID stockId);
+    void delete(UUID stockId);
 
     /**
      * Redis에 캐시된 재고 수량 차감
@@ -33,13 +25,7 @@ public interface StockCache {
      * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
      * @param quantity : value에서 차감할 재고 수량 (예약된 재고 수량)
      */
-    void reserve(UUID stockId, Long quantity);
+    boolean decrease(UUID stockId, Long quantity);
 
-    /**
-     * Redis에 캐시된 재고 수량 복구(증가)
-     *
-     * @param stockId  : Redis key에 사용되는 타임딜 재고 ID
-     * @param quantity : value에서 증가할 재고 수량 (복구된 재고 수량)
-     */
-    void restore(UUID stockId, Long quantity);
+    void increase(UUID stockId, Long quantity);
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisStockCache.java
@@ -1,5 +1,7 @@
 package com.rushcrew.timedeal.infrastructure.adapter;
 
+import com.rushcrew.common.exception.BusinessException;
+import com.rushcrew.timedeal.domain.exception.TimeDealErrorCode;
 import com.rushcrew.timedeal.domain.port.StockCache;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,28 +20,34 @@ public class RedisStockCache implements StockCache {
         redisTemplate.opsForValue().set(key, String.valueOf(available));
     }
 
+    @Override
+    public void delete(UUID stockId) {
+        redisTemplate.delete("tds:" + stockId);
+    }
+
     /**
      * quantity가 양수면 증가, 음수면 감소
      */
     @Override
-    public void changeCount(UUID stockId, Long quantity) {
-        redisTemplate.opsForValue().increment("tds:" + stockId, quantity);
-    }
-
-    @Override
-    public void evict(UUID stockId) {
-        redisTemplate.delete("tds:" + stockId);
-    }
-
-    @Override
-    public void reserve(UUID stockId, Long quantity) {
-        String key = "tds:" + stockId;
-        redisTemplate.opsForValue().decrement(key, quantity);
-    }
-
-    @Override
-    public void restore(UUID stockId, Long quantity) {
+    public void increase(UUID stockId, Long quantity) {
         String key = "tds:" + stockId;
         redisTemplate.opsForValue().increment(key, quantity);
+    }
+
+    @Override
+    public boolean decrease(UUID stockId, Long quantity) {
+        String key = "tds:" + stockId;
+        Long available = redisTemplate.opsForValue().decrement(key, quantity);
+
+        if(available == null) {
+            throw new BusinessException(TimeDealErrorCode.NOT_FOUND_STOCK);
+        }
+
+        if(available < 0) {
+            redisTemplate.opsForValue().increment(key, quantity);
+            return false;
+        }
+
+        return true;
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisTimeDealCache.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/adapter/RedisTimeDealCache.java
@@ -32,6 +32,6 @@ public class RedisTimeDealCache implements TimeDealCache {
 
     @Override
     public void removeTimedOut(TimeDealQueueKey key, List<String> timeDealIds) {
-        redisTemplate.opsForZSet().remove(key.getKey(), timeDealIds);
+        redisTemplate.opsForZSet().remove(key.getKey(), timeDealIds.toArray());
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/event/StockEventHandler.java
@@ -34,7 +34,7 @@ public class StockEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockChanged(StockChangedEvent event) {
         try {
-            stockCache.changeCount(event.stockId(), event.quantity());
+            stockCache.increase(event.stockId(), event.quantity());
         } catch (Exception e) {
             log.error(
                 "StockChangedEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
@@ -46,7 +46,7 @@ public class StockEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockDeleted(StockDeletedEvent event) {
         try {
-            stockCache.evict(event.stockId());
+            stockCache.delete(event.stockId());
         } catch (Exception e) {
             log.error("StockDeletedEvent 처리 중 Redis 반영 실패. stock={}", event.stockId(), e);
         }
@@ -55,7 +55,7 @@ public class StockEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockReserved(StockReservedEvent event) {
         try {
-            stockCache.reserve(event.stockId(), event.quantity());
+            stockCache.decrease(event.stockId(), event.quantity());
         } catch (Exception e) {
             log.error(
                 "StockReservedEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",
@@ -67,7 +67,7 @@ public class StockEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleStockRestored(StockRestoredEvent event) {
         try {
-            stockCache.restore(event.stockId(), event.quantity());
+            stockCache.increase(event.stockId(), event.quantity());
         } catch (Exception e) {
             log.error(
                 "StockRestoredEvent 처리 중 Redis 반영 실패. stock={}, quantity={}",

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/scheduler/TimeDealScheduler.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/infrastructure/scheduler/TimeDealScheduler.java
@@ -23,7 +23,9 @@ public class TimeDealScheduler {
         }
 
         List<String> updatedIds = timeDealService.startTimeDeals(startedTimeDealIds);
-        timeDealCache.removeTimedOut(TimeDealQueueKey.START, updatedIds);
+        if(!updatedIds.isEmpty()) {
+            timeDealCache.removeTimedOut(TimeDealQueueKey.START, updatedIds);
+        }
     }
 
     @Scheduled(fixedDelay = 1000)
@@ -34,6 +36,8 @@ public class TimeDealScheduler {
         }
 
         List<String> updatedIds = timeDealService.endTimeDeals(endedTimeDealIds);
-        timeDealCache.removeTimedOut(TimeDealQueueKey.END, updatedIds);
+        if(!updatedIds.isEmpty()) {
+            timeDealCache.removeTimedOut(TimeDealQueueKey.END, updatedIds);
+        }
     }
 }

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/TimeDealController.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/TimeDealController.java
@@ -2,6 +2,7 @@ package com.rushcrew.timedeal.presentation;
 
 import com.rushcrew.timedeal.application.command.CreateTimeDealCommand;
 import com.rushcrew.timedeal.application.command.UpdateTimeDealCommand;
+import com.rushcrew.timedeal.application.result.CreateTimeDealResult;
 import com.rushcrew.timedeal.application.result.TimeDealDetailResult;
 import com.rushcrew.timedeal.application.result.TimeDealResult;
 import com.rushcrew.timedeal.application.result.UpdateTimeDealResult;
@@ -10,6 +11,7 @@ import com.rushcrew.timedeal.domain.vo.TimeDealStatus;
 import com.rushcrew.timedeal.global.security.model.UserDetailsImpl;
 import com.rushcrew.timedeal.presentation.dto.request.CreateTimeDealRequest;
 import com.rushcrew.timedeal.presentation.dto.request.UpdateTimeDealRequest;
+import com.rushcrew.timedeal.presentation.dto.response.CreateTimeDealResponse;
 import com.rushcrew.timedeal.presentation.dto.response.TimeDealDetailResponse;
 import com.rushcrew.timedeal.presentation.dto.response.TimeDealResponse;
 import com.rushcrew.timedeal.presentation.dto.response.UpdateTimeDealResponse;
@@ -42,14 +44,14 @@ public class TimeDealController {
 
     @PostMapping
     @PreAuthorize("hasAnyRole('MASTER', 'SELLER')")
-    public ResponseEntity<UUID> createTimeDeal(
+    public ResponseEntity<CreateTimeDealResponse> createTimeDeal(
         @Valid @RequestBody CreateTimeDealRequest request,
         @AuthenticationPrincipal UserDetailsImpl principal
     ) {
         CreateTimeDealCommand command = request.toCommand();
-        UUID timeDealId =
+        CreateTimeDealResult result =
             timeDealService.createTimeDeal(principal.userId(), principal.role(), command);
-        return ResponseEntity.status(HttpStatus.CREATED).body(timeDealId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(CreateTimeDealResponse.from(result));
     }
 
     @PatchMapping("/{timeDealId}")

--- a/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/CreateTimeDealResponse.java
+++ b/timedeal-service/src/main/java/com/rushcrew/timedeal/presentation/dto/response/CreateTimeDealResponse.java
@@ -1,0 +1,18 @@
+package com.rushcrew.timedeal.presentation.dto.response;
+
+import com.rushcrew.timedeal.application.result.CreateTimeDealResult;
+import java.util.List;
+import java.util.UUID;
+
+public record CreateTimeDealResponse(
+    UUID timeDealId,
+    List<UUID> timeDealProductIds
+) {
+
+    public static CreateTimeDealResponse from(CreateTimeDealResult result) {
+        return new CreateTimeDealResponse(
+            result.timeDealId(),
+            result.timeDealProductIds()
+        );
+    }
+}


### PR DESCRIPTION
## 🧾 Summary
- 재고 예약 시 불필요한 DB 접근 없도록 리팩토링
- 재시도 로직 클래스 분리
- ZSet remove 파라미터 타입 오류로 인한 에러 수정

## 💡 Type of change
- [ ] Feature
- [x] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Hotfix

## 🧪 Test Checklist
- [ ] Local build success
- [ ] Unit test passed

## 📌 Related Issues
Closes #207 
